### PR TITLE
added multi upload/convert for S57 charts, and parallel conversions

### DIFF
--- a/public/js/chart-convert.js
+++ b/public/js/chart-convert.js
@@ -52,8 +52,8 @@ async function initConvertTab() {
               <path d="M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM14 13v4h-4v-4H7l5-5 5 5h-3z"/>
             </svg>
           </div>
-          <div class="convert-upload-text">Drop S-57 ENC ZIP here or click to select</div>
-          <input type="file" id="s57FileInput" accept=".zip" style="display:none" onchange="handleConvertFile(this, 's57')">
+          <div class="convert-upload-text">Drop S-57 ENC ZIP files here or click to select</div>
+          <input type="file" id="s57FileInput" accept=".zip" multiple style="display:none" onchange="handleConvertFile(this, 's57')">
         </div>
         <div class="convert-upload-options">
           <label>Zoom levels:</label>
@@ -127,16 +127,22 @@ function setupDropZone(zoneId, inputId) {
       return;
     }
     const files = e.dataTransfer.files;
-    if (files.length > 0 && files[0].name.endsWith('.zip')) {
-      const type = zoneId === 's57DropZone' ? 's57' : 'rnc';
-      uploadConvertFile(files[0], type);
+    const type = zoneId === 's57DropZone' ? 's57' : 'rnc';
+    if (zoneId === 's57DropZone') {
+      // Allow multiple files for S-57
+      const zips = Array.from(files).filter((f) => f.name.endsWith('.zip'));
+      zips.forEach((f) => uploadConvertFile(f, type));
+    } else {
+      if (files.length > 0 && files[0].name.endsWith('.zip')) {
+        uploadConvertFile(files[0], type);
+      }
     }
   };
 }
 
 window.handleConvertFile = function (input, type) {
   if (input.files.length > 0) {
-    uploadConvertFile(input.files[0], type);
+    Array.from(input.files).forEach((file) => uploadConvertFile(file, type));
     input.value = ''; // reset so same file can be selected again
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import https from 'https';
+import os from 'os';
 import type { Plugin, Path } from '@signalk/server-api';
 import { findCharts } from './charts-loader';
 import { scanChartsRecursively, scanAllFolders } from './utils/file-scanner';
@@ -1316,7 +1317,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             return;
           }
 
-          const MAX_CONCURRENT = 2;
+          const MAX_CONCURRENT = os.cpus().length;
           if (getConvertingCount() >= MAX_CONCURRENT) {
             cleanupDir(tmpDir);
             res.status(429).json({
@@ -1436,7 +1437,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           fs.mkdirSync(targetDir, { recursive: true });
         }
 
-        const MAX_CONCURRENT_CONVERSIONS = 2;
+        const MAX_CONCURRENT_CONVERSIONS = Math.max(1, Math.floor(os.cpus().length / 2));
         if (
           ['s57-zip', 'rnc-zip', 'gshhg', 'pilot-tar', 'shp-basemap'].includes(
             classification.format


### PR DESCRIPTION
I am converting a lot of ENCs, so I modified the plugin to allow ctrl-click or shift-click uploads of multiple files in the conversion dialog. I also increased the maximum number of concurrent conversions to be the number of vCPUs. I didn't change anything in the raster chart conversion because I don't have any raster charts so I cannot test that, but the same modifications should work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S-57 file uploads now support selecting and dragging multiple `.zip` files simultaneously.

* **Chores**
  * Optimized conversion throttling to dynamically scale based on available system resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->