### PR TITLE
fix(convert): correctness and resource fixes for multi-file ENC conversion

### DIFF
--- a/.github/workflows/signalk-ci.yml
+++ b/.github/workflows/signalk-ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    uses: dirkwa/signalk-server/.github/workflows/plugin-ci.yml@feat-ci-for-plugins
+    uses: SignalK/signalk-server/.github/workflows/plugin-ci.yml@master
     with:
       enable-armv7: false
       enable-signalk-integration: true

--- a/public/js/chart-convert.js
+++ b/public/js/chart-convert.js
@@ -129,9 +129,12 @@ function setupDropZone(zoneId, inputId) {
     const files = e.dataTransfer.files;
     const type = zoneId === 's57DropZone' ? 's57' : 'rnc';
     if (zoneId === 's57DropZone') {
-      // Allow multiple files for S-57
       const zips = Array.from(files).filter((f) => f.name.endsWith('.zip'));
-      zips.forEach((f) => uploadConvertFile(f, type));
+      (async () => {
+        for (const f of zips) {
+          await uploadConvertFile(f, type);
+        }
+      })();
     } else {
       if (files.length > 0 && files[0].name.endsWith('.zip')) {
         uploadConvertFile(files[0], type);
@@ -140,10 +143,13 @@ function setupDropZone(zoneId, inputId) {
   };
 }
 
-window.handleConvertFile = function (input, type) {
+window.handleConvertFile = async function (input, type) {
   if (input.files.length > 0) {
-    Array.from(input.files).forEach((file) => uploadConvertFile(file, type));
-    input.value = ''; // reset so same file can be selected again
+    const files = Array.from(input.files);
+    input.value = '';
+    for (const file of files) {
+      await uploadConvertFile(file, type);
+    }
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ import type {
 
 const PLUGIN_ID = 'signalk-charts-provider-simple';
 const chartTilesPath = `/plugins/${PLUGIN_ID}`;
+const MAX_CONCURRENT_CONVERSIONS = Math.max(1, Math.floor(os.cpus().length / 2));
 
 const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
   let chartProviders: Record<string, ChartProvider> = {};
@@ -1317,12 +1318,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             return;
           }
 
-          const MAX_CONCURRENT = os.cpus().length;
-          if (getConvertingCount() >= MAX_CONCURRENT) {
+          if (getConvertingCount() >= MAX_CONCURRENT_CONVERSIONS) {
             cleanupDir(tmpDir);
             res.status(429).json({
               success: false,
-              error: `Too many conversions running (max ${MAX_CONCURRENT}). Please wait.`
+              error: `Too many conversions running (max ${MAX_CONCURRENT_CONVERSIONS}). Please wait for a conversion to finish.`
             });
             return;
           }
@@ -1437,7 +1437,6 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           fs.mkdirSync(targetDir, { recursive: true });
         }
 
-        const MAX_CONCURRENT_CONVERSIONS = Math.max(1, Math.floor(os.cpus().length / 2));
         if (
           ['s57-zip', 'rnc-zip', 'gshhg', 'pilot-tar', 'shp-basemap'].includes(
             classification.format

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import fs from 'fs';
 import https from 'https';
-import os from 'os';
 import type { Plugin, Path } from '@signalk/server-api';
 import { findCharts } from './charts-loader';
 import { scanChartsRecursively, scanAllFolders } from './utils/file-scanner';
@@ -40,6 +39,7 @@ import {
   setConversionFailed as setRncFailed
 } from './utils/rnc-converter';
 import { processGshhg, processShpBasemap } from './utils/s57-converter';
+import { MAX_CONCURRENT_CONVERSIONS } from './utils/concurrency';
 import type {
   ExtendedServerAPI,
   PluginConfig,
@@ -53,7 +53,6 @@ import type {
 
 const PLUGIN_ID = 'signalk-charts-provider-simple';
 const chartTilesPath = `/plugins/${PLUGIN_ID}`;
-const MAX_CONCURRENT_CONVERSIONS = Math.max(1, Math.floor(os.cpus().length / 2));
 
 const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
   let chartProviders: Record<string, ChartProvider> = {};

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,10 @@
+import os from 'os';
+
+const cpuCount = Math.max(1, os.cpus().length);
+
+export const MAX_CONCURRENT_CONVERSIONS = Math.max(1, Math.floor(cpuCount / 2));
+
+export const TIPPECANOE_THREADS_PER_JOB = Math.max(
+  1,
+  Math.floor(cpuCount / MAX_CONCURRENT_CONVERSIONS)
+);

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -1,6 +1,7 @@
 import { execFile, spawn } from 'child_process';
 import https from 'https';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import unzipper from 'unzipper';
 import type {
@@ -262,9 +263,12 @@ function runTippecanoe(
   }
 
   return new Promise((resolve, reject) => {
+    const tippecanoeThreads = Math.max(1, Math.floor(os.cpus().length / 2));
     const args = [
       'run',
       '--rm',
+      '-e',
+      `TIPPECANOE_MAX_THREADS=${tippecanoeThreads}`,
       '-v',
       `${geojsonDir}:/input:ro,Z`,
       '-v',
@@ -282,7 +286,9 @@ function runTippecanoe(
       ...layerArgs
     ];
 
-    debug(`Running tippecanoe with ${layerArgs.length / 2} layers, zoom ${minzoom}-${maxzoom}`);
+    debug(
+      `Running tippecanoe with ${layerArgs.length / 2} layers, zoom ${minzoom}-${maxzoom}, ${tippecanoeThreads} threads`
+    );
 
     const child = spawn('podman', args, {
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -1,9 +1,9 @@
 import { execFile, spawn } from 'child_process';
 import https from 'https';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import unzipper from 'unzipper';
+import { TIPPECANOE_THREADS_PER_JOB } from './concurrency';
 import type {
   ConversionProgress,
   ConversionProgressMap,
@@ -263,12 +263,11 @@ function runTippecanoe(
   }
 
   return new Promise((resolve, reject) => {
-    const tippecanoeThreads = Math.max(1, Math.floor(os.cpus().length / 2));
     const args = [
       'run',
       '--rm',
       '-e',
-      `TIPPECANOE_MAX_THREADS=${tippecanoeThreads}`,
+      `TIPPECANOE_MAX_THREADS=${TIPPECANOE_THREADS_PER_JOB}`,
       '-v',
       `${geojsonDir}:/input:ro,Z`,
       '-v',
@@ -287,7 +286,7 @@ function runTippecanoe(
     ];
 
     debug(
-      `Running tippecanoe with ${layerArgs.length / 2} layers, zoom ${minzoom}-${maxzoom}, ${tippecanoeThreads} threads`
+      `Running tippecanoe with ${layerArgs.length / 2} layers, zoom ${minzoom}-${maxzoom}, ${TIPPECANOE_THREADS_PER_JOB} threads`
     );
 
     const child = spawn('podman', args, {


### PR DESCRIPTION
## Summary

Follow-up to #6 (multi-file ENC upload + CPU-scaled conversion concurrency). Three fixes plus a small CI cleanup:

- **Serialize client-side multi-file uploads** — drop/select handlers used to fan out one upload per file in parallel; the server's 429 path then surfaced excess uploads as terminal `failed` jobs with no retry. Sequential `await`s gate only the upload POST, not the conversion, so server-side concurrency still applies.
- **Unify concurrency cap** — `/convert-upload` and `/catalog/download` previously used different limits (`os.cpus().length` vs `cpus/2`) while sharing the same `getConvertingCount()` counter. Both now use a module-level `MAX_CONCURRENT_CONVERSIONS = max(1, cpus/2)`.
- **Cap tippecanoe threads** — without `TIPPECANOE_MAX_THREADS`, each tippecanoe process used all cores. With multiple conversions running in parallel, this caused N² thread contention. The container is now invoked with `TIPPECANOE_MAX_THREADS=max(1, cpus/2)` so aggregate worker count never exceeds available cores.
- **CI**: rename `test-plugin-ci.yml` → `signalk-ci.yml` and point at upstream `SignalK/signalk-server@master`.

## Tested

- `npm run format && npm run build && npm test` — all 49 tests pass after each commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * S-57 ZIP uploads now run sequentially to avoid concurrent upload conflicts.

* **Improvements**
  * Conversion concurrency now scales with available CPU capacity for more efficient processing.
  * Queue-related error messaging clarified when conversions must wait due to load.
  * Tile/format conversion thread usage optimized to better utilize system resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->