### PR TITLE
chore(deps): ignore @types/node major bumps in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # @types/node major versions track the Node.js major. Keep this pinned
+      # to the lowest supported runtime (Node 22 per package.json engines)
+      # so types reflect what's actually available on every supported version.
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
## Summary

Closes the loop on #17. \`@types/node\` major versions track the Node.js major release line, so they should be pinned to the floor of supported runtimes (Node 22 per \`package.json\` engines), not the latest. Otherwise the types advertise APIs that don't exist on every supported version.

This commit tells Dependabot to skip \`semver-major\` bumps for \`@types/node\` so we don't get a noisy PR every time a new Node major lands upstream.

## Tested

Config-only change. Dependabot config is validated when GitHub picks it up; no app behavior affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update configuration to enhance version management stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->