### PR TITLE
fix(convert): stream tippecanoe \r progress; release 1.10.0-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.10.0-beta.1",
+      "version": "1.10.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/container-runtime.ts
+++ b/src/utils/container-runtime.ts
@@ -158,20 +158,28 @@ function splitLines(callback: ((line: string) => void) | undefined): PassThrough
     stream.resume();
     return stream;
   }
+  // Treat any of \r\n, \n, or bare \r as a line boundary. Tools like tippecanoe
+  // repaint a progress line in place using bare \r — without that split, every
+  // update concatenates into a single never-ending "line" and stream consumers
+  // see only the first segment.
   let buffer = '';
   stream.on('data', (chunk: Buffer) => {
     buffer += chunk.toString('utf8');
-    const lines = buffer.split(/\r?\n/);
+    const lines = buffer.split(/\r\n|\r|\n/);
     buffer = lines.pop() ?? '';
     for (const line of lines) {
-      if (line.length) {
-        callback(line);
+      const trimmed = line.trim();
+      if (trimmed.length) {
+        callback(trimmed);
       }
     }
   });
   stream.on('end', () => {
     if (buffer.length) {
-      callback(buffer);
+      const trimmed = buffer.trim();
+      if (trimmed.length) {
+        callback(trimmed);
+      }
       buffer = '';
     }
   });


### PR DESCRIPTION
## Summary

Field-test follow-up to 1.10.0-beta.1 (PR #25). Stack:

- **`64d3f51` fix(convert): split stream output on bare \r so tippecanoe progress streams** — the badge stayed pinned at "Generating tiles: 0%" for the entire conversion even though the log panel kept ticking. Tippecanoe repaints its progress line using bare `\r` rather than `\n`. The wrapper's `splitLines` was matching `/\r?\n/`, so every progress update concatenated into a single ever-growing "line" that the consumer never finished — the percentage regex matched the first `0%` segment and got latched. Switched the splitter to `/\r\n|\r|\n/` and trim each segment. Verified against real tippecanoe: where the old splitter produced 1 callback per pull, the new one emits 30+ progress callbacks.

- **`f9baee5` chore(release): 1.10.0-beta.2** — version bump on top.

The two earlier field-test fixes (regex loosened to match integer percentages, conversion containers given names + `io.signalk.charts-provider.*` labels) already landed on main as `5263731` since they were pushed before this branch existed.

## Tested

- `npm run format:check && npm run build && npm test` — 53/53 pass.
- Real tippecanoe smoke: pulled the actual GDAL + tippecanoe images, ran a synthetic 1-feature conversion through `runContainer`, asserted ≥30 distinct percentage callbacks reached the consumer (was 1 before this commit).
- Live S-57 conversion in containerized Signal K (issue #7 setup): badge now ticks `Generating tiles: 0%` → `…` → `99%` in real time and matches the log panel.

## Why two betas in quick succession

`v1.10.0-beta.1` shipped the dockerode runtime swap; field testing immediately exposed the latched-progress bug above. Cutting `beta.2` rather than rushing to a stable `1.10.0` until the field has had more time with this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved line parsing to properly handle carriage-return characters in progress updates, preventing display concatenation issues.

* **Chores**
  * Updated package version to 1.10.0-beta.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->