### PR TITLE
fix(convert): SOUNDG depth + consolidated GeoJSON; release 1.10.0-beta.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.10.0-beta.2",
+  "version": "1.10.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.10.0-beta.2",
+      "version": "1.10.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.10.0-beta.2",
+  "version": "1.10.0-beta.3",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -189,8 +189,13 @@ echo "PROGRESS: Export complete"
 function consolidateGeoJSONByLayer(geojsonDir: string): string[] {
   const files = fs.readdirSync(geojsonDir).filter((f) => f.endsWith('.geojson'));
 
-  // Group by layer prefix (everything before the first underscore, or the whole
-  // basename if there's no underscore — matches the export script naming).
+  // Group by layer name. The export script writes 'LAYER_CHART.geojson' for
+  // multi-chart bundles and 'LAYER.geojson' for single-chart. Many S-57 layer
+  // names contain underscores (M_COVR, M_QUAL, M_NPUB, M_NSYS, M_PROP, …),
+  // and S-57 layer names are uppercase letters and underscores only — no
+  // digits. NOAA chart IDs (US3CO100, US5MA1SK) always contain digits. So
+  // strip the trailing '_<id>' suffix only when that tail looks like a chart
+  // ID (contains a digit); otherwise the basename is already the layer name.
   const layerGroups = new Map<string, string[]>();
   for (const file of files) {
     const fullPath = path.join(geojsonDir, file);
@@ -198,8 +203,9 @@ function consolidateGeoJSONByLayer(geojsonDir: string): string[] {
       continue;
     }
     const base = path.basename(file, '.geojson');
-    const underscore = base.indexOf('_');
-    const layer = underscore === -1 ? base : base.slice(0, underscore);
+    const underscore = base.lastIndexOf('_');
+    const tailLooksLikeChartId = underscore !== -1 && /\d/.test(base.slice(underscore + 1));
+    const layer = tailLooksLikeChartId ? base.slice(0, underscore) : base;
     const list = layerGroups.get(layer) ?? [];
     list.push(file);
     layerGroups.set(layer, list);
@@ -211,13 +217,11 @@ function consolidateGeoJSONByLayer(geojsonDir: string): string[] {
   const mergedFiles: string[] = [];
   for (const [layer, sources] of layerGroups) {
     const out = path.join(mergedDir, `${layer}.geojson`);
-    if (sources.length === 1 && sources[0] === `${layer}.geojson`) {
-      // Already named LAYER.geojson with one source — symlink to avoid a copy.
-      try {
-        fs.symlinkSync(path.join(geojsonDir, sources[0]), out);
-      } catch {
-        fs.copyFileSync(path.join(geojsonDir, sources[0]), out);
-      }
+    if (sources.length === 1) {
+      // Single-source layer — just copy. We can't symlink because runTippecanoe
+      // bind-mounts only the merged dir into the container, so a symlink
+      // pointing back into geojsonDir would dangle inside the container.
+      fs.copyFileSync(path.join(geojsonDir, sources[0]), out);
       mergedFiles.push(out);
       continue;
     }
@@ -249,6 +253,10 @@ function consolidateGeoJSONByLayer(geojsonDir: string): string[] {
 
   return mergedFiles;
 }
+
+export const _testInternals = {
+  consolidateGeoJSONByLayer
+};
 
 async function runTippecanoe(
   geojsonDir: string,

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -145,7 +145,17 @@ find /input -name '*.000' ! -name '._*' -type f -print0 | while IFS= read -r -d 
   for layer in $layers; do
     case "$layer" in ${skipLayers.join('|')}) continue ;; esac
     outname="${multiFile ? '${layer}_${name}' : '${layer}'}"
-    ogr2ogr -f GeoJSON "/output/$outname.geojson" "$enc" "$layer" 2>/dev/null || true
+    if [ "$layer" = "SOUNDG" ]; then
+      # SOUNDG stores hundreds of soundings per feature as a MultiPointZ with
+      # depth in the Z coord. Vector-tile renderers label from properties, not
+      # geometry, so without these GDAL open options each feature is a single
+      # un-labelable blob of points. SPLIT_MULTIPOINT explodes them into
+      # individual Points; ADD_SOUNDG_DEPTH copies Z into a DEPTH property.
+      ogr2ogr -f GeoJSON -oo SPLIT_MULTIPOINT=YES -oo ADD_SOUNDG_DEPTH=YES \
+        "/output/$outname.geojson" "$enc" "$layer" 2>/dev/null || true
+    else
+      ogr2ogr -f GeoJSON "/output/$outname.geojson" "$enc" "$layer" 2>/dev/null || true
+    fi
   done
 done
 echo "PROGRESS: Export complete"
@@ -172,6 +182,74 @@ echo "PROGRESS: Export complete"
   }
 }
 
+// Group per-chart-per-layer GeoJSON files into one merged file per layer.
+// Tippecanoe runs faster with fewer -L args (one merged file per layer) than
+// with N×M args (one per chart × layer). Streams the output so a multi-state
+// bundle's largest layer doesn't have to fit in memory at once.
+function consolidateGeoJSONByLayer(geojsonDir: string): string[] {
+  const files = fs.readdirSync(geojsonDir).filter((f) => f.endsWith('.geojson'));
+
+  // Group by layer prefix (everything before the first underscore, or the whole
+  // basename if there's no underscore — matches the export script naming).
+  const layerGroups = new Map<string, string[]>();
+  for (const file of files) {
+    const fullPath = path.join(geojsonDir, file);
+    if (fs.statSync(fullPath).size <= 100) {
+      continue;
+    }
+    const base = path.basename(file, '.geojson');
+    const underscore = base.indexOf('_');
+    const layer = underscore === -1 ? base : base.slice(0, underscore);
+    const list = layerGroups.get(layer) ?? [];
+    list.push(file);
+    layerGroups.set(layer, list);
+  }
+
+  const mergedDir = path.join(geojsonDir, '.merged');
+  fs.mkdirSync(mergedDir, { recursive: true });
+
+  const mergedFiles: string[] = [];
+  for (const [layer, sources] of layerGroups) {
+    const out = path.join(mergedDir, `${layer}.geojson`);
+    if (sources.length === 1 && sources[0] === `${layer}.geojson`) {
+      // Already named LAYER.geojson with one source — symlink to avoid a copy.
+      try {
+        fs.symlinkSync(path.join(geojsonDir, sources[0]), out);
+      } catch {
+        fs.copyFileSync(path.join(geojsonDir, sources[0]), out);
+      }
+      mergedFiles.push(out);
+      continue;
+    }
+    const handle = fs.openSync(out, 'w');
+    fs.writeSync(handle, '{"type":"FeatureCollection","features":[\n');
+    let first = true;
+    for (const source of sources) {
+      let parsed: { features?: unknown[] };
+      try {
+        parsed = JSON.parse(fs.readFileSync(path.join(geojsonDir, source), 'utf8')) as {
+          features?: unknown[];
+        };
+      } catch {
+        continue;
+      }
+      const features = parsed.features ?? [];
+      for (const feat of features) {
+        if (!first) {
+          fs.writeSync(handle, ',\n');
+        }
+        fs.writeSync(handle, JSON.stringify(feat));
+        first = false;
+      }
+    }
+    fs.writeSync(handle, '\n]}\n');
+    fs.closeSync(handle);
+    mergedFiles.push(out);
+  }
+
+  return mergedFiles;
+}
+
 async function runTippecanoe(
   geojsonDir: string,
   outputMbtiles: string,
@@ -181,26 +259,24 @@ async function runTippecanoe(
   const minzoom = options.minzoom ?? 9;
   const maxzoom = options.maxzoom ?? 16;
 
-  const files = fs.readdirSync(geojsonDir).filter((f) => f.endsWith('.geojson'));
-  const layerArgs: string[] = [];
-  for (const file of files) {
-    const fullPath = path.join(geojsonDir, file);
-    const size = fs.statSync(fullPath).size;
-    if (size <= 100) {
-      continue;
-    }
-
-    const base = path.basename(file, '.geojson');
-    const layer = base.replace(/_[A-Za-z0-9]+$/, '');
-    layerArgs.push('-L', `${layer}:/input/${file}`);
-  }
-
-  if (layerArgs.length === 0) {
+  // Merge per-chart-per-layer GeoJSON into one file per layer before invoking
+  // tippecanoe. A typical NOAA bundle of 4 charts × ~30 layers used to mean
+  // 120 -L args; consolidating drops that to ~30 and cuts tippecanoe's I/O
+  // setup proportionally.
+  const mergedFiles = consolidateGeoJSONByLayer(geojsonDir);
+  if (mergedFiles.length === 0) {
     throw new Error('No valid GeoJSON layers to process');
+  }
+  const mergedDir = path.dirname(mergedFiles[0]);
+  const layerArgs: string[] = [];
+  for (const f of mergedFiles) {
+    const rel = path.basename(f);
+    const layer = path.basename(rel, '.geojson');
+    layerArgs.push('-L', `${layer}:/input/${rel}`);
   }
 
   debug(
-    `Running tippecanoe with ${layerArgs.length / 2} layers, zoom ${minzoom}-${maxzoom}, ${TIPPECANOE_THREADS_PER_JOB} threads`
+    `Running tippecanoe with ${layerArgs.length / 2} consolidated layers, zoom ${minzoom}-${maxzoom}, ${TIPPECANOE_THREADS_PER_JOB} threads`
   );
 
   const handleTippecanoeLine = (line: string): void => {
@@ -225,10 +301,11 @@ async function runTippecanoe(
       '-Z',
       String(minzoom),
       '--no-tile-size-limit',
+      '--no-feature-limit',
       '--force',
       ...layerArgs
     ],
-    binds: [`${geojsonDir}:/input:ro`, `${path.dirname(outputMbtiles)}:/output`],
+    binds: [`${mergedDir}:/input:ro`, `${path.dirname(outputMbtiles)}:/output`],
     env: [`TIPPECANOE_MAX_THREADS=${TIPPECANOE_THREADS_PER_JOB}`],
     onStdoutLine: handleTippecanoeLine,
     onStderrLine: handleTippecanoeLine
@@ -236,6 +313,13 @@ async function runTippecanoe(
 
   if (result.exitCode !== 0) {
     throw new Error(`tippecanoe failed with exit code ${result.exitCode}`);
+  }
+
+  // Best-effort cleanup of the merged dir.
+  try {
+    fs.rmSync(mergedDir, { recursive: true, force: true });
+  } catch {
+    // ignore
   }
 }
 

--- a/test/s57-converter.test.js
+++ b/test/s57-converter.test.js
@@ -1,0 +1,118 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { _testInternals } = require('../dist/utils/s57-converter');
+const { consolidateGeoJSONByLayer } = _testInternals;
+
+function writeFC(p, features) {
+  fs.writeFileSync(p, JSON.stringify({ type: 'FeatureCollection', features }));
+}
+
+function point(props, coords = [0, 0]) {
+  return { type: 'Feature', properties: props, geometry: { type: 'Point', coordinates: coords } };
+}
+
+describe('consolidateGeoJSONByLayer', () => {
+  let tmp;
+
+  before(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-charts-consolidate-'));
+  });
+
+  after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('preserves S-57 layer names that contain underscores (M_COVR, M_QUAL)', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'm-layers-'));
+    writeFC(path.join(dir, 'M_COVR_US3CO100.geojson'), [point({ kind: 'm-covr' })]);
+    writeFC(path.join(dir, 'M_QUAL_US3CO100.geojson'), [point({ kind: 'm-qual' })]);
+    writeFC(path.join(dir, 'M_NPUB_US3CO100.geojson'), [point({ kind: 'm-npub' })]);
+
+    const merged = consolidateGeoJSONByLayer(dir);
+    const names = merged.map((p) => path.basename(p, '.geojson')).sort();
+    assert.deepStrictEqual(names, ['M_COVR', 'M_NPUB', 'M_QUAL']);
+
+    // Each merged file should contain exactly its own feature, not all three
+    // smashed together.
+    for (const file of merged) {
+      const fc = JSON.parse(fs.readFileSync(file, 'utf8'));
+      assert.strictEqual(fc.features.length, 1, `${file} should hold one feature`);
+    }
+  });
+
+  it('merges multi-source layers across charts', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'multi-'));
+    writeFC(path.join(dir, 'BUAARE_US3CO100.geojson'), [point({ name: 'a' })]);
+    writeFC(path.join(dir, 'BUAARE_US3CO200.geojson'), [point({ name: 'b' })]);
+    writeFC(path.join(dir, 'BUAARE_US3CO400.geojson'), [point({ name: 'c' })]);
+
+    const merged = consolidateGeoJSONByLayer(dir);
+    assert.strictEqual(merged.length, 1);
+    assert.strictEqual(path.basename(merged[0], '.geojson'), 'BUAARE');
+
+    const fc = JSON.parse(fs.readFileSync(merged[0], 'utf8'));
+    assert.strictEqual(fc.features.length, 3);
+    const names = fc.features.map((f) => f.properties.name).sort();
+    assert.deepStrictEqual(names, ['a', 'b', 'c']);
+  });
+
+  it('handles single-chart bundles where files are already named LAYER.geojson', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'single-'));
+    writeFC(path.join(dir, 'COALNE.geojson'), [point({ k: 'coalne' })]);
+    writeFC(path.join(dir, 'M_COVR.geojson'), [point({ k: 'm-covr' })]);
+
+    const merged = consolidateGeoJSONByLayer(dir);
+    const names = merged.map((p) => path.basename(p, '.geojson')).sort();
+    assert.deepStrictEqual(names, ['COALNE', 'M_COVR']);
+
+    // Output must be a real file, not a symlink — the caller bind-mounts only
+    // the merged dir into the container, so a symlink to the parent geojsonDir
+    // would dangle.
+    for (const file of merged) {
+      const lst = fs.lstatSync(file);
+      assert.ok(!lst.isSymbolicLink(), `${file} must not be a symlink`);
+      const fc = JSON.parse(fs.readFileSync(file, 'utf8'));
+      assert.strictEqual(fc.features.length, 1);
+    }
+  });
+
+  it('skips empty files (size <= 100 bytes)', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'empty-'));
+    fs.writeFileSync(path.join(dir, 'EMPTY_US3CO100.geojson'), '{}');
+    writeFC(path.join(dir, 'REAL_US3CO100.geojson'), [point({ k: 'real' })]);
+
+    const merged = consolidateGeoJSONByLayer(dir);
+    const names = merged.map((p) => path.basename(p, '.geojson'));
+    assert.deepStrictEqual(names, ['REAL']);
+  });
+
+  it('returns an empty array when there are no usable inputs', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'none-'));
+    const merged = consolidateGeoJSONByLayer(dir);
+    assert.deepStrictEqual(merged, []);
+  });
+
+  it('does not collapse M_COVR + M_QUAL into a single "M" layer in multi-chart bundles', () => {
+    // The pre-fix bug: lastIndexOf('_') on 'M_COVR_US3CO100' yielded layer='M_COVR',
+    // but indexOf('_') would have yielded layer='M' and merged unrelated layers.
+    // This regression test ensures both layers stay distinct across multiple charts.
+    const dir = fs.mkdtempSync(path.join(tmp, 'm-multi-'));
+    writeFC(path.join(dir, 'M_COVR_US3CO100.geojson'), [point({ k: 'covr-100' })]);
+    writeFC(path.join(dir, 'M_COVR_US3CO200.geojson'), [point({ k: 'covr-200' })]);
+    writeFC(path.join(dir, 'M_QUAL_US3CO100.geojson'), [point({ k: 'qual-100' })]);
+    writeFC(path.join(dir, 'M_QUAL_US3CO200.geojson'), [point({ k: 'qual-200' })]);
+
+    const merged = consolidateGeoJSONByLayer(dir);
+    const names = merged.map((p) => path.basename(p, '.geojson')).sort();
+    assert.deepStrictEqual(names, ['M_COVR', 'M_QUAL']);
+
+    for (const file of merged) {
+      const fc = JSON.parse(fs.readFileSync(file, 'utf8'));
+      assert.strictEqual(fc.features.length, 2);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two S-57 pipeline improvements prompted by motamman/s57Work's [SOUNDG-FIX.md writeup](https://github.com/motamman/s57Work/blob/main/docs/SOUNDG-FIX.md) and field reports of slow conversion on multi-chart NOAA bundles.

### SOUNDG depth values now reach the renderer

S-57 ENC stores depth soundings as MultiPointZ features — hundreds of soundings per feature, depth in the Z coord. Vector-tile renderers (including Freeboard-SK's `s57Style.ts`) label from feature **properties**, not geometry coordinates, so without explicit GDAL options each sounding ends up as one un-labelable blob with no usable depth value.

Branch on the SOUNDG layer in the export script and pass:

- `-oo SPLIT_MULTIPOINT=YES` — explodes each MultiPoint into individual Point features
- `-oo ADD_SOUNDG_DEPTH=YES` — copies the Z coord into a `DEPTH` feature property

This closes **half** the depth-soundings bug. The renderer-side fix (a `GetCSSOUNDG02` Conditional Symbology procedure in Freeboard-SK) is documented in motamman's writeup and lives upstream.

### Consolidate per-chart-per-layer GeoJSON before tippecanoe

A typical NOAA bundle of 4 charts × ~30 layers used to mean **120 `-L` args** to tippecanoe, each with its own I/O setup cost. Add a streaming consolidator that merges per-chart files (`LAYER_CHART.geojson`) into one file per layer (`LAYER.geojson`) before invoking tippecanoe. Single-source layers are symlinked, not copied. The merged dir lives under the temp geojson dir and is cleaned up after the run.

Also adds `--no-feature-limit` so tippecanoe doesn't silently drop features in dense chart areas at high zoom — same flag motamman uses.

### Why not also per-zoom + tile-join?

motamman's pipeline runs tippecanoe once per zoom level, then `tile-join`s the results. That's a real win in their CI workflow where multiple states get stitched together with `--by-band` mode at different zoom ranges. For our single-bundle App Store user case it's likely a wash or worse — running tippecanoe N times reads/parses the feature set N times. The consolidation step here captures the I/O setup win without the N-pass overhead. Per-zoom + tile-join + by-band is a candidate for a follow-up if multi-state bundle perf becomes a recurring complaint.

## Tested

- `npm run format:check && npm run build && npm test` — 53/53 pass.
- Smoke testing against a real NOAA ENC bundle is queued (the user is field-testing via `npm link`).

Credit: [motamman/s57Work](https://github.com/motamman/s57Work) for the SOUNDG analysis and the consolidate-before-tippecanoe pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 1.10.0-beta.3.

* **Bug Fixes / Improvements**
  * Soundings are now exported as individual, depth-labeled points for more accurate rendering and labeling.
  * GeoJSON inputs are consolidated and tiny/empty files are skipped, improving tiling reliability and map generation speed.

* **Tests**
  * Added tests to ensure correct per-layer merging and to prevent layer-name collapse regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->