### PR TITLE
feat(convert): band-aware tippecanoe maxzoom; release 1.10.0-beta.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.10.0-beta.4",
+  "version": "1.10.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.10.0-beta.4",
+      "version": "1.10.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.10.0-beta.4",
+  "version": "1.10.0-beta.5",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/s57-band.ts
+++ b/src/utils/s57-band.ts
@@ -1,0 +1,60 @@
+/**
+ * IHO S-57 ENC usage band parsed from the chart's base filename, per the
+ * IHO Annex E filename convention `<CC><band><area>` followed by all
+ * official national hydrographic offices (NOAA, UKHO, BSH, CHS, AHO, …).
+ *
+ * Returns 1..6 when the filename conforms, or `null` otherwise (IENC inland
+ * charts and ad-hoc files don't follow this convention; callers fall back
+ * to the user-requested maxzoom in that case).
+ */
+export function detectEncBand(filename: string): number | null {
+  const base = filename.replace(/\.[^.]+$/, '');
+  const m = base.match(/^[A-Z]{2}(\d)/);
+  if (!m) {
+    return null;
+  }
+  const band = parseInt(m[1], 10);
+  return band >= 1 && band <= 6 ? band : null;
+}
+
+/**
+ * Sensible tippecanoe maxzoom for each IHO band. Mirrors the documented
+ * native chart scales: emitting tiles past these zoom levels produces
+ * output that has no underlying feature precision to back it up. Renderers
+ * (Freeboard-SK, MapLibre, OpenLayers) handle higher zooms by overzooming
+ * the captured top-zoom tile, which is correct for chart data.
+ */
+export const BAND_MAX_ZOOM: Record<number, number> = {
+  1: 8, // Overview  ~1:3,500,000
+  2: 10, // General   ~1:700,000
+  3: 12, // Coastal   ~1:90,000
+  4: 14, // Approach  ~1:22,000
+  5: 16, // Harbour   ~1:8,000
+  6: 18 // Berthing  ~1:3,000   (rare — only major commercial ports)
+};
+
+/**
+ * Resolve the effective tippecanoe maxzoom for a bundle of ENC files.
+ * Highest band in the bundle wins; user-requested maxzoom is the ceiling
+ * (we never raise it past what the user asked for). Returns `null` if no
+ * file in the bundle conforms to IHO Annex E — caller should fall back
+ * to the user-requested value unchanged.
+ */
+export function bandClampedMaxzoom(
+  encFiles: readonly string[],
+  userRequestedMaxzoom: number
+): { effective: number; highestBand: number | null; bands: number[] } {
+  const bands = encFiles
+    .map((f) => detectEncBand(f.split('/').pop() ?? f))
+    .filter((b): b is number => b !== null);
+
+  if (bands.length === 0) {
+    return { effective: userRequestedMaxzoom, highestBand: null, bands: [] };
+  }
+
+  const highestBand = Math.max(...bands);
+  const bandCeiling = BAND_MAX_ZOOM[highestBand];
+  const effective =
+    bandCeiling !== undefined ? Math.min(userRequestedMaxzoom, bandCeiling) : userRequestedMaxzoom;
+  return { effective, highestBand, bands };
+}

--- a/src/utils/s57-band.ts
+++ b/src/utils/s57-band.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 /**
  * IHO S-57 ENC usage band parsed from the chart's base filename, per the
  * IHO Annex E filename convention `<CC><band><area>` followed by all
@@ -45,7 +47,7 @@ export function bandClampedMaxzoom(
   userRequestedMaxzoom: number
 ): { effective: number; highestBand: number | null; bands: number[] } {
   const bands = encFiles
-    .map((f) => detectEncBand(f.split('/').pop() ?? f))
+    .map((f) => detectEncBand(path.basename(f)))
     .filter((b): b is number => b !== null);
 
   if (bands.length === 0) {

--- a/src/utils/s57-band.ts
+++ b/src/utils/s57-band.ts
@@ -38,23 +38,34 @@ export const BAND_MAX_ZOOM: Record<number, number> = {
 /**
  * Resolve the effective tippecanoe maxzoom for a bundle of ENC files.
  * Highest band in the bundle wins; user-requested maxzoom is the ceiling
- * (we never raise it past what the user asked for). Returns `null` if no
- * file in the bundle conforms to IHO Annex E — caller should fall back
- * to the user-requested value unchanged.
+ * (we never raise it past what the user asked for).
+ *
+ * Always returns an object:
+ *   - `effective`: the maxzoom the caller should pass to tippecanoe.
+ *   - `highestBand`: the highest band detected, or `null` when no file in
+ *     the bundle conforms to IHO Annex E (IENC, hand-named, custom
+ *     producers). Caller can use this to log a fallback path.
+ *   - `bands`: unique sorted list of bands detected across the bundle,
+ *     for diagnostics. Empty when nothing matches.
+ *
+ * On `highestBand === null`, `effective` equals `userRequestedMaxzoom`
+ * unchanged — i.e. behaviour matches the pre-band-clamp pipeline.
  */
 export function bandClampedMaxzoom(
   encFiles: readonly string[],
   userRequestedMaxzoom: number
 ): { effective: number; highestBand: number | null; bands: number[] } {
-  const bands = encFiles
-    .map((f) => detectEncBand(path.basename(f)))
-    .filter((b): b is number => b !== null);
+  const bands = [
+    ...new Set(
+      encFiles.map((f) => detectEncBand(path.basename(f))).filter((b): b is number => b !== null)
+    )
+  ].sort((a, b) => a - b);
 
   if (bands.length === 0) {
     return { effective: userRequestedMaxzoom, highestBand: null, bands: [] };
   }
 
-  const highestBand = Math.max(...bands);
+  const highestBand = bands[bands.length - 1];
   const bandCeiling = BAND_MAX_ZOOM[highestBand];
   const effective =
     bandCeiling !== undefined ? Math.min(userRequestedMaxzoom, bandCeiling) : userRequestedMaxzoom;

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -9,6 +9,7 @@ import {
   pullImage as runtimePullImage,
   runContainer
 } from './container-runtime';
+import { bandClampedMaxzoom } from './s57-band';
 import type {
   ConversionProgress,
   ConversionProgressMap,
@@ -308,7 +309,8 @@ function consolidateGeoJSONByLayer(geojsonDir: string): string[] {
 
 export const _testInternals = {
   consolidateGeoJSONByLayer,
-  buildExportScript
+  buildExportScript,
+  bandClampedMaxzoom
 };
 
 async function runTippecanoe(
@@ -460,9 +462,29 @@ export async function processS57Zip(
     statusFn('converting', 'Generating vector tiles...');
     setProgress(chartNumber, 'converting', 'Generating vector tiles with tippecanoe...');
 
+    // Clamp tippecanoe's maxzoom to the IHO band ceiling. Most tippecanoe time
+    // is spent at the highest zooms; if the source charts only have band-3
+    // (coastal) precision, asking for z16 emits 4 zoom levels of tiles that
+    // can't be backed by real feature precision.
+    const userMaxzoom = options.maxzoom ?? 16;
+    const encBasenames = encFiles.map((f) => path.basename(f));
+    const clamp = bandClampedMaxzoom(encBasenames, userMaxzoom);
+    if (clamp.highestBand !== null && clamp.effective < userMaxzoom) {
+      const msg =
+        `Detected IHO bands [${clamp.bands.join(', ')}] (highest = ${clamp.highestBand}) ` +
+        `→ tippecanoe maxzoom clamped to z${clamp.effective} (was z${userMaxzoom})`;
+      debug(msg);
+      appendLog(chartNumber, msg);
+    } else if (clamp.highestBand === null) {
+      const msg = `No IHO band detected (likely IENC or non-conforming filenames); using user maxzoom z${userMaxzoom}`;
+      debug(msg);
+      appendLog(chartNumber, msg);
+    }
+    const effectiveOptions: S57ConversionOptions = { ...options, maxzoom: clamp.effective };
+
     const outputName = `${chartNumber || 'enc-chart'}.mbtiles`;
     const outputPath = path.join(chartsDir, outputName);
-    await runTippecanoe(geojsonDir, outputPath, chartNumber, options);
+    await runTippecanoe(geojsonDir, outputPath, chartNumber, effectiveOptions);
 
     if (!fs.existsSync(outputPath)) {
       throw new Error('tippecanoe completed but output file not found');

--- a/test/s57-band.test.js
+++ b/test/s57-band.test.js
@@ -92,6 +92,14 @@ describe('bandClampedMaxzoom', () => {
     assert.strictEqual(r.highestBand, 3);
   });
 
+  it('handles Windows-style paths via path.basename', () => {
+    // Windows path.basename only strips '\' on win32, but the test confirms
+    // forward-slash paths (which path.basename handles cross-platform) work.
+    const r = bandClampedMaxzoom(['C:/Users/u/enc/US3CO100/US3CO100.000'], 16);
+    assert.strictEqual(r.effective, 12);
+    assert.strictEqual(r.highestBand, 3);
+  });
+
   it('mixed conforming + non-conforming uses only the conforming bands', () => {
     // Two NOAA charts + one IENC. Only the NOAA bands count.
     const r = bandClampedMaxzoom(['US3CO100.000', 'US5MA1SK.000', 'IENC_AREA.000'], 16);

--- a/test/s57-band.test.js
+++ b/test/s57-band.test.js
@@ -1,0 +1,108 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { detectEncBand, BAND_MAX_ZOOM, bandClampedMaxzoom } = require('../dist/utils/s57-band');
+
+describe('detectEncBand (IHO Annex E filename convention)', () => {
+  it('parses NOAA filenames', () => {
+    assert.strictEqual(detectEncBand('US3CO100.000'), 3);
+    assert.strictEqual(detectEncBand('US5MA1SK.000'), 5);
+    assert.strictEqual(detectEncBand('US1AK90M.000'), 1);
+    assert.strictEqual(detectEncBand('US6NY12C.000'), 6);
+  });
+
+  it('parses non-NOAA national hydrographic offices following the same convention', () => {
+    assert.strictEqual(detectEncBand('GB401234.000'), 4);
+    assert.strictEqual(detectEncBand('DE521A04.000'), 5);
+    assert.strictEqual(detectEncBand('CA2HF7QC.000'), 2);
+    assert.strictEqual(detectEncBand('AU3WAFRE.000'), 3);
+  });
+
+  it('strips extensions correctly', () => {
+    assert.strictEqual(detectEncBand('US3CO100'), 3); // no extension
+    assert.strictEqual(detectEncBand('US3CO100.000'), 3); // .000
+    assert.strictEqual(detectEncBand('US3CO100.geojson'), 3); // some other ext
+  });
+
+  it('returns null for non-conforming filenames', () => {
+    assert.strictEqual(detectEncBand(''), null);
+    assert.strictEqual(detectEncBand('chart.000'), null);
+    assert.strictEqual(detectEncBand('weird-name.000'), null);
+    assert.strictEqual(detectEncBand('ENC_AREA1.000'), null);
+    assert.strictEqual(detectEncBand('123ABC.000'), null); // starts with digits
+  });
+
+  it('returns null for out-of-range band digits', () => {
+    assert.strictEqual(detectEncBand('US0CO100.000'), null);
+    assert.strictEqual(detectEncBand('US7CO100.000'), null);
+    assert.strictEqual(detectEncBand('US9CO100.000'), null);
+  });
+
+  it('requires uppercase country code (S-57 spec)', () => {
+    assert.strictEqual(detectEncBand('us3CO100.000'), null);
+    assert.strictEqual(detectEncBand('Us3CO100.000'), null);
+  });
+});
+
+describe('BAND_MAX_ZOOM', () => {
+  it('matches the IHO documented native chart scales', () => {
+    assert.strictEqual(BAND_MAX_ZOOM[1], 8);
+    assert.strictEqual(BAND_MAX_ZOOM[2], 10);
+    assert.strictEqual(BAND_MAX_ZOOM[3], 12);
+    assert.strictEqual(BAND_MAX_ZOOM[4], 14);
+    assert.strictEqual(BAND_MAX_ZOOM[5], 16);
+    assert.strictEqual(BAND_MAX_ZOOM[6], 18);
+  });
+});
+
+describe('bandClampedMaxzoom', () => {
+  it('clamps single-band-3 bundles to z12', () => {
+    const r = bandClampedMaxzoom(['US3CO100.000', 'US3CO200.000', 'US3CO300.000'], 16);
+    assert.strictEqual(r.effective, 12);
+    assert.strictEqual(r.highestBand, 3);
+    assert.deepStrictEqual(r.bands, [3, 3, 3]);
+  });
+
+  it('takes the highest band when bundle is mixed', () => {
+    const r = bandClampedMaxzoom(['US3CO100.000', 'US5MA1SK.000', 'US3CO200.000'], 16);
+    assert.strictEqual(r.effective, 16);
+    assert.strictEqual(r.highestBand, 5);
+  });
+
+  it('falls back to user-requested maxzoom when no file conforms (IENC)', () => {
+    const r = bandClampedMaxzoom(['weird.000', 'IENC_PASS_001.000'], 16);
+    assert.strictEqual(r.effective, 16);
+    assert.strictEqual(r.highestBand, null);
+    assert.deepStrictEqual(r.bands, []);
+  });
+
+  it('does not raise the user maxzoom past what they asked for', () => {
+    // Band 5 ceiling is z16, but user only asked for z14 — keep z14.
+    const r = bandClampedMaxzoom(['US5MA1SK.000'], 14);
+    assert.strictEqual(r.effective, 14);
+    assert.strictEqual(r.highestBand, 5);
+  });
+
+  it('handles paths with directory components by taking the basename', () => {
+    const r = bandClampedMaxzoom(
+      ['/tmp/enc/US3CO100/US3CO100.000', '/tmp/enc/US3CO200/US3CO200.000'],
+      16
+    );
+    assert.strictEqual(r.effective, 12);
+    assert.strictEqual(r.highestBand, 3);
+  });
+
+  it('mixed conforming + non-conforming uses only the conforming bands', () => {
+    // Two NOAA charts + one IENC. Only the NOAA bands count.
+    const r = bandClampedMaxzoom(['US3CO100.000', 'US5MA1SK.000', 'IENC_AREA.000'], 16);
+    assert.strictEqual(r.effective, 16); // band 5 wins
+    assert.strictEqual(r.highestBand, 5);
+    assert.deepStrictEqual(r.bands, [3, 5]); // IENC dropped
+  });
+
+  it('empty file list falls back', () => {
+    const r = bandClampedMaxzoom([], 16);
+    assert.strictEqual(r.effective, 16);
+    assert.strictEqual(r.highestBand, null);
+  });
+});

--- a/test/s57-band.test.js
+++ b/test/s57-band.test.js
@@ -56,11 +56,22 @@ describe('BAND_MAX_ZOOM', () => {
 });
 
 describe('bandClampedMaxzoom', () => {
-  it('clamps single-band-3 bundles to z12', () => {
+  it('clamps single-band-3 bundles to z12 and returns deduped bands', () => {
     const r = bandClampedMaxzoom(['US3CO100.000', 'US3CO200.000', 'US3CO300.000'], 16);
     assert.strictEqual(r.effective, 12);
     assert.strictEqual(r.highestBand, 3);
-    assert.deepStrictEqual(r.bands, [3, 3, 3]);
+    // Bands are deduped + sorted for diagnostic stability.
+    assert.deepStrictEqual(r.bands, [3]);
+  });
+
+  it('returns deduped + sorted bands for log/diagnostic stability', () => {
+    // Input order: 5, 3, 3, 5, 4 → output should be [3, 4, 5].
+    const r = bandClampedMaxzoom(
+      ['US5MA1SK.000', 'US3CO100.000', 'US3CO200.000', 'US5NY1SK.000', 'US4PR1AB.000'],
+      16
+    );
+    assert.deepStrictEqual(r.bands, [3, 4, 5]);
+    assert.strictEqual(r.highestBand, 5);
   });
 
   it('takes the highest band when bundle is mixed', () => {

--- a/test/s57-converter.test.js
+++ b/test/s57-converter.test.js
@@ -5,7 +5,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const { _testInternals } = require('../dist/utils/s57-converter');
-const { consolidateGeoJSONByLayer, buildExportScript } = _testInternals;
+const { consolidateGeoJSONByLayer, buildExportScript, bandClampedMaxzoom } = _testInternals;
 
 function writeFC(p, features) {
   fs.writeFileSync(p, JSON.stringify({ type: 'FeatureCollection', features }));
@@ -167,5 +167,25 @@ describe('buildExportScript', () => {
       assert.ok(seq.includes(layer), `sequential branch missing skip layer ${layer}`);
       assert.ok(par.includes(layer), `parallel branch missing skip layer ${layer}`);
     }
+  });
+});
+
+// Smoke that the helper is reachable through s57-converter's _testInternals
+// (the deeper coverage lives in test/s57-band.test.js — this just confirms
+// processS57Zip's wiring uses the same export the test suite does).
+describe('bandClampedMaxzoom (re-export from s57-converter._testInternals)', () => {
+  it('clamps an AQ_ENCs-style band-3 bundle to z12', () => {
+    const r = bandClampedMaxzoom(
+      ['US3CO100.000', 'US3CO200.000', 'US3CO300.000', 'US3CO400.000'],
+      16
+    );
+    assert.strictEqual(r.effective, 12);
+    assert.strictEqual(r.highestBand, 3);
+  });
+
+  it('IENC fallback preserves user maxzoom (regression guard for processS57Zip)', () => {
+    const r = bandClampedMaxzoom(['IENC_PASS_001.000'], 16);
+    assert.strictEqual(r.effective, 16);
+    assert.strictEqual(r.highestBand, null);
   });
 });


### PR DESCRIPTION
## Summary

A 4-chart NOAA Antarctica bundle currently takes ~2 hours at full CPU. CPU is saturated; the work itself is the bottleneck. Half of those zoom levels are doing nothing useful.

NOAA / UKHO / BSH / etc. publish ENC charts at IHO usage bands 1-6, each with a documented native scale. The chart data has only enough geometric precision for that scale. We were telling tippecanoe to emit z9-z16 unconditionally, including 4 zoom levels (z13-z16) where coastal-band-3 charts have no underlying precision to fill the tiles.

The fix detects each chart's band from its IHO Annex E filename (`<CC><band><area>`), takes the highest band in the bundle, and clamps tippecanoe's `-z` to that band's ceiling. MBTiles renderers (Freeboard-SK, MapLibre, OpenLayers) overzoom the captured top-zoom tile naturally, so users see the same chart at any zoom — just much faster to convert.

| IHO band | Native scale | Clamp to |
|---|---|---|
| 1 (Overview) | ~1:3,500,000 | z8 |
| 2 (General) | ~1:700,000 | z10 |
| 3 (Coastal) | ~1:90,000 | z12 |
| 4 (Approach) | ~1:22,000 | z14 |
| 5 (Harbour) | ~1:8,000 | z16 |
| 6 (Berthing) | ~1:3,000 | z18 |

For AQ_ENCs.zip (all band-3) the conversion now runs z9-z12 instead of z9-z16. Expected wall-clock reduction: **30-60%** on a band-3 bundle. Smaller win on band-5 bundles (z16 is already their native ceiling). No win on already-low-zoom user requests.

## What about IENC and non-NOAA charts?

IENC inland charts and any non-conforming filenames don't match the IHO regex. For those, the plan **falls back to the user's existing maxzoom** — IENC conversion behaviour is unchanged from beta.4. Mixed bundles (some conforming + some not) only use the conforming files' bands; non-conforming charts ride along at the chosen ceiling.

A log line surfaces the decision either way:
- `Detected IHO bands [3, 3, 3, 3] (highest = 3) → tippecanoe maxzoom clamped to z12 (was z16)`
- `No IHO band detected (likely IENC or non-conforming filenames); using user maxzoom z16`

## Mixed band bundles

When a user uploads a mix (e.g. coastal band-3 + harbour band-5 charts in one zip), highest band wins → tippecanoe runs to that band's max. The lower-band charts emit at their full request range too — that's wasteful for them but produces correct output. The pathological case (one band-6 chart in a 50-chart band-3 bundle would force z18 across the whole conversion) is rare in practice — NOAA bundle downloads are regionally coherent. If it surfaces in the field, the upgrade path is per-feature `tippecanoe.maxzoom` annotation in a follow-up PR.

## Tested

- `npm run format:check && npm run build && npm test` — 92/92 pass.
- `test/s57-band.test.js` covers `detectEncBand` (NOAA, UKHO, BSH, paths with directories, out-of-range bands, lowercase rejection) and `bandClampedMaxzoom` (single-band, mixed-band, IENC fallback, user-maxzoom ceiling, mixed conforming + non-conforming).
- `test/s57-converter.test.js` extended with regression guard via `_testInternals`.
- Live bench against `1.10.0-beta.4` is queued — the user will time AQ_ENCs end-to-end on the linked Signal K dev server before promoting to stable.

## Out of scope (deliberately)

- **Per-S-57-layer zoom caps** (the earlier draft of the plan). Smaller win, additive — revisit after measuring band-aware impact.
- **Per-band tile-join split** (s57Work `--by-band` mode). Complex; only matters for the rare pathological mixed-band case.
- **`M_COVR.SCAMIN`-based detection.** Filename detection covers the 99% case at zero parse cost; SCAMIN requires unpacking the binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Version**
  * Updated to v1.10.0-beta.5

* **Improvements**
  * Added S-57 ENC chart band detection from chart filenames
  * Automatically clamps map max-zoom based on detected chart bands for improved rendering consistency

* **Tests**
  * Added unit tests covering band detection, max-zoom clamping, mixed inputs, path normalization, and fallback behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->