### PR TITLE
chore(release): 1.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.10.0-beta.5",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.10.0-beta.5",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.10.0-beta.5",
+  "version": "1.10.0",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Promote the `1.10.0-beta.5` line to stable. Field-tested against a real NOAA Antarctica bundle (AQ_ENCs.zip) on the linked Signal K dev server with `cpuBudget=all`; band-aware maxzoom clamping confirmed working. No new code in this PR — just the version bump and refreshed package-lock.

## What 1.10.x ships vs 1.9.x

- **Container runtime via dockerode socket** instead of shelling out to `podman`. Bare-metal install now needs the podman API socket (`systemctl --user enable --now podman.socket`); containerized Signal K just mounts `/var/run/docker.sock` (or the Podman socket). New `docs/running-in-docker.md` covers the setup. Closes #7.
- **CPU budget plugin option** (`single-core` / `half` / `all`) with hot-apply. `all` parallelizes GDAL export via `xargs -P` so every core is busy in both phases.
- **GeoJSON consolidation** per layer before tippecanoe — drops `-L` argument count from charts × layers to just layers.
- **IHO-band-aware tippecanoe maxzoom**: filename-detected band → native ceiling (band 3 = z12, band 5 = z16, …). Renderers overzoom naturally; visual output unchanged. AQ_ENCs.zip went from ~2h on beta.4 to materially faster on beta.5.
- **SOUNDG depth values** now reach the rendered output (`SPLIT_MULTIPOINT` + `ADD_SOUNDG_DEPTH` GDAL options). Renderer-side fix for the labels lives upstream in Freeboard-SK.
- **App Store screenshots** wired into `signalk.screenshots[]`.

Default `cpuBudget` is `half` — existing users see no behaviour change unless they pick a different preset.

## Tested

- `npm run format:check && npm run build && npm test` — 94/94 pass.
- Field-tested: AQ_ENCs.zip end-to-end conversion on linked dev Signal K (host: 6-core box, `cpuBudget=all`, band-3 clamp to z12). Output mbtiles renders correctly in Freeboard-SK at all zooms via overzoom.
- All five 1.10.0-beta tags published to npm under the `beta` dist-tag during the bedding-in period; CI green for each.

## Tag plan

After merge:
- Pull main, tag `v1.10.0`, push tag.
- Publish workflow ships to npm `latest` (the `latest` dist-tag will move from `1.9.3` to `1.10.0`); GitHub Release marked stable (no `-beta.` / `-rc.` suffix).
- Beta dist-tag stays at `1.10.0-beta.5` until the next beta cycle starts.

Closes the 1.10.0 milestone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Released version 1.10.0 as a stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->