### PR TITLE
test(s57-converter): regression test for mixed-band harbour preservation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.10.0",
+  "version": "1.10.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.10.0",
+      "version": "1.10.1-beta.1",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.10.0",
+  "version": "1.10.1-beta.1",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/s57-converter.test.js
+++ b/test/s57-converter.test.js
@@ -115,6 +115,43 @@ describe('consolidateGeoJSONByLayer', () => {
       assert.strictEqual(fc.features.length, 2);
     }
   });
+
+  it('mixed-band bundles preserve harbour-tier layers from band-5 charts', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'mixed-band-'));
+
+    for (const chart of ['US3CO100', 'US3CO200', 'US5MA1SK']) {
+      writeFC(path.join(dir, `LNDARE_${chart}.geojson`), [point({ src: chart })]);
+      writeFC(path.join(dir, `DEPARE_${chart}.geojson`), [point({ src: chart })]);
+      writeFC(path.join(dir, `COALNE_${chart}.geojson`), [point({ src: chart })]);
+    }
+
+    writeFC(path.join(dir, 'HRBFAC_US5MA1SK.geojson'), [point({ obj: 'harbour' })]);
+    writeFC(path.join(dir, 'ACHARE_US5MA1SK.geojson'), [point({ obj: 'anchorage' })]);
+    writeFC(path.join(dir, 'BRIDGE_US5MA1SK.geojson'), [point({ obj: 'bridge' })]);
+    writeFC(path.join(dir, 'MORFAC_US5MA1SK.geojson'), [point({ obj: 'mooring' })]);
+    writeFC(path.join(dir, 'PILBOP_US5MA1SK.geojson'), [point({ obj: 'pilot-boarding' })]);
+
+    const merged = consolidateGeoJSONByLayer(dir);
+    const layerNames = new Set(merged.map((p) => path.basename(p, '.geojson')));
+
+    for (const layer of ['LNDARE', 'DEPARE', 'COALNE']) {
+      assert.ok(layerNames.has(layer), `bulk layer ${layer} should be merged`);
+      const fc = JSON.parse(
+        fs.readFileSync(
+          merged.find((p) => p.endsWith(`${layer}.geojson`)),
+          'utf8'
+        )
+      );
+      assert.strictEqual(fc.features.length, 3, `${layer} should have 3 features (1 per chart)`);
+    }
+
+    for (const layer of ['HRBFAC', 'ACHARE', 'BRIDGE', 'MORFAC', 'PILBOP']) {
+      assert.ok(
+        layerNames.has(layer),
+        `harbour-tier layer ${layer} from US5MA1SK must survive consolidation`
+      );
+    }
+  });
 });
 
 describe('buildExportScript', () => {


### PR DESCRIPTION
## Summary
- Adds a regression test in `consolidateGeoJSONByLayer` proving that harbour-tier S-57 layers (HRBFAC, ACHARE, BRIDGE, MORFAC, PILBOP) from a band-5 chart survive consolidation in a mixed-band bundle, alongside bulk band-3 layers (LNDARE, DEPARE, COALNE).
- The 1.10.0 band-aware-maxzoom pipeline already does the right thing here (highest band wins, no input filtering by band). This test locks the contract in so a future refactor that accidentally filtered or grouped files on band-derived properties would fail loudly.
- Bumps version to 1.10.1-beta.1.

## Tested
- `npm run format:check && npm run build && npm test` — 95/95 pass (was 94).
- Negative-test sanity: temporarily injected a band-5 file filter into `consolidateGeoJSONByLayer`, confirmed the new test fails with the exact harbour-tier assertion message, then reverted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to `1.10.1-beta.1`.

* **Tests**
  * Added test coverage for GeoJSON layer consolidation with multiple charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->