### PR TITLE
feat(s57): per-band minzoom + --detect-shared-borders for tippecanoe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.10.1-beta.1",
+  "version": "1.11.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.10.1-beta.1",
+      "version": "1.11.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.10.1-beta.1",
+  "version": "1.11.0-beta.1",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/s57-band.ts
+++ b/src/utils/s57-band.ts
@@ -36,6 +36,64 @@ export const BAND_MAX_ZOOM: Record<number, number> = {
 };
 
 /**
+ * Sensible tippecanoe minzoom for each IHO band: each band's ceiling minus 4.
+ * Band-3 features start emitting at z8 (~150 km tile), band-5 at z12 (~10 km
+ * tile), band-6 at z14. Below these zooms the features overplot into
+ * illegible blobs anyway, so emitting tiles there only wastes bytes and CPU
+ * without adding navigational value.
+ */
+export const BAND_MIN_ZOOM: Record<number, number> = {
+  1: 4, // Overview  ceiling z8
+  2: 6, // General   ceiling z10
+  3: 8, // Coastal   ceiling z12
+  4: 10, // Approach ceiling z14
+  5: 12, // Harbour  ceiling z16
+  6: 14 // Berthing  ceiling z18
+};
+
+/**
+ * Pull the chart-ID portion out of a per-chart-per-layer filename like
+ * 'HRBFAC_US5MA1SK.geojson'. The consolidator (s57-converter.ts) writes
+ * these as `<LAYER>_<CHART>.geojson` for multi-chart bundles, where LAYER
+ * is uppercase letters/underscores with no digits and CHART always has
+ * digits (NOAA chart IDs follow the IHO Annex E filename convention).
+ *
+ * For files already named '<CHART>.geojson' (single-chart bundles or raw
+ * .000 inputs), returns the basename minus extension unchanged.
+ */
+function extractChartId(filename: string): string {
+  const base = path.basename(filename).replace(/\.[^.]+$/, '');
+  const underscore = base.lastIndexOf('_');
+  if (underscore === -1) {
+    return base;
+  }
+  const tail = base.slice(underscore + 1);
+  return /\d/.test(tail) ? tail : base;
+}
+
+/**
+ * Band of the highest-resolution chart that contributed to a consolidated
+ * S-57 layer. After consolidation, each merged file is the union of features
+ * from one or more source charts; the layer's *effective* band is the
+ * highest among its sources, because that's the smallest scale at which any
+ * of those features were captured. Returns `null` for IENC / non-conforming
+ * filenames.
+ *
+ * Accepts both raw chart names (e.g. 'US5MA1SK.000') and per-layer-per-chart
+ * filenames produced by the GDAL export step (e.g. 'HRBFAC_US5MA1SK.geojson').
+ */
+export function highestBandForFiles(filenames: readonly string[]): number | null {
+  let highest: number | null = null;
+  for (const f of filenames) {
+    const b = detectEncBand(extractChartId(f));
+    if (b !== null && (highest === null || b > highest)) {
+      highest = b;
+    }
+  }
+  return highest;
+}
+
+/**
  * Resolve the effective tippecanoe maxzoom for a bundle of ENC files.
  * Highest band in the bundle wins; user-requested maxzoom is the ceiling
  * (we never raise it past what the user asked for).

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -9,7 +9,7 @@ import {
   pullImage as runtimePullImage,
   runContainer
 } from './container-runtime';
-import { bandClampedMaxzoom } from './s57-band';
+import { BAND_MIN_ZOOM, bandClampedMaxzoom, highestBandForFiles } from './s57-band';
 import type {
   ConversionProgress,
   ConversionProgressMap,
@@ -235,11 +235,16 @@ async function exportAllLayersToGeoJSON(
   }
 }
 
+// One row per merged layer. `sourceFiles` are the per-chart GeoJSON filenames
+// (basenames, e.g. 'HRBFAC_US5MA1SK.geojson') that fed the merge — the caller
+// uses them to recover IHO band info per layer.
+type ConsolidatedLayer = { file: string; sourceFiles: string[] };
+
 // Group per-chart-per-layer GeoJSON files into one merged file per layer.
 // Tippecanoe runs faster with fewer -L args (one merged file per layer) than
 // with N×M args (one per chart × layer). Streams the output so a multi-state
 // bundle's largest layer doesn't have to fit in memory at once.
-function consolidateGeoJSONByLayer(geojsonDir: string): string[] {
+function consolidateGeoJSONByLayer(geojsonDir: string): ConsolidatedLayer[] {
   const files = fs.readdirSync(geojsonDir).filter((f) => f.endsWith('.geojson'));
 
   // Group by layer name. The export script writes 'LAYER_CHART.geojson' for
@@ -267,7 +272,7 @@ function consolidateGeoJSONByLayer(geojsonDir: string): string[] {
   const mergedDir = path.join(geojsonDir, '.merged');
   fs.mkdirSync(mergedDir, { recursive: true });
 
-  const mergedFiles: string[] = [];
+  const consolidated: ConsolidatedLayer[] = [];
   for (const [layer, sources] of layerGroups) {
     const out = path.join(mergedDir, `${layer}.geojson`);
     if (sources.length === 1) {
@@ -275,7 +280,7 @@ function consolidateGeoJSONByLayer(geojsonDir: string): string[] {
       // bind-mounts only the merged dir into the container, so a symlink
       // pointing back into geojsonDir would dangle inside the container.
       fs.copyFileSync(path.join(geojsonDir, sources[0]), out);
-      mergedFiles.push(out);
+      consolidated.push({ file: out, sourceFiles: sources });
       continue;
     }
     const handle = fs.openSync(out, 'w');
@@ -301,16 +306,38 @@ function consolidateGeoJSONByLayer(geojsonDir: string): string[] {
     }
     fs.writeSync(handle, '\n]}\n');
     fs.closeSync(handle);
-    mergedFiles.push(out);
+    consolidated.push({ file: out, sourceFiles: sources });
   }
 
-  return mergedFiles;
+  return consolidated;
+}
+
+// Build tippecanoe `-L <json>` args with per-layer minzoom set from the IHO
+// band detected in each merged layer's source filenames. Layers whose
+// source charts don't follow the IHO Annex E filename convention (IENC,
+// hand-named) fall back to userMinzoom — same behaviour as before.
+function buildLayerArgs(layers: readonly ConsolidatedLayer[], userMinzoom: number): string[] {
+  const args: string[] = [];
+  for (const { file, sourceFiles } of layers) {
+    const rel = path.basename(file);
+    const layer = path.basename(rel, '.geojson');
+    const band = highestBandForFiles(sourceFiles);
+    const bandFloor = band !== null ? BAND_MIN_ZOOM[band] : null;
+    // Per-layer minzoom = max(user-requested global minzoom, band floor). The
+    // band floor is the smallest zoom at which features captured at this
+    // band's native scale are still legible; never go above it for that
+    // layer, never go below the user's global ask either.
+    const layerMinzoom = bandFloor !== null ? Math.max(userMinzoom, bandFloor) : userMinzoom;
+    args.push('-L', JSON.stringify({ file: `/input/${rel}`, layer, minzoom: layerMinzoom }));
+  }
+  return args;
 }
 
 export const _testInternals = {
   consolidateGeoJSONByLayer,
   buildExportScript,
-  bandClampedMaxzoom
+  bandClampedMaxzoom,
+  buildLayerArgs
 };
 
 async function runTippecanoe(
@@ -326,16 +353,36 @@ async function runTippecanoe(
   // tippecanoe. A typical NOAA bundle of 4 charts × ~30 layers used to mean
   // 120 -L args; consolidating drops that to ~30 and cuts tippecanoe's I/O
   // setup proportionally.
-  const mergedFiles = consolidateGeoJSONByLayer(geojsonDir);
-  if (mergedFiles.length === 0) {
+  const mergedLayers = consolidateGeoJSONByLayer(geojsonDir);
+  if (mergedLayers.length === 0) {
     throw new Error('No valid GeoJSON layers to process');
   }
-  const mergedDir = path.dirname(mergedFiles[0]);
-  const layerArgs: string[] = [];
-  for (const f of mergedFiles) {
-    const rel = path.basename(f);
-    const layer = path.basename(rel, '.geojson');
-    layerArgs.push('-L', `${layer}:/input/${rel}`);
+  const mergedDir = path.dirname(mergedLayers[0].file);
+  const layerArgs = buildLayerArgs(mergedLayers, minzoom);
+
+  // Log per-band layer breakdown so users can see why low-zoom features differ
+  // by band. Counts plus a sample of layer names — full lists would be noisy
+  // (a state bundle has ~40 layers per band).
+  const byBand = new Map<number | null, string[]>();
+  for (const { file, sourceFiles } of mergedLayers) {
+    const b = highestBandForFiles(sourceFiles);
+    const layer = path.basename(file, '.geojson');
+    const list = byBand.get(b) ?? [];
+    list.push(layer);
+    byBand.set(b, list);
+  }
+  const sortedBands = [...byBand.entries()].sort(
+    ([a], [b]) => (a ?? Number.POSITIVE_INFINITY) - (b ?? Number.POSITIVE_INFINITY)
+  );
+  for (const [band, layers] of sortedBands) {
+    const floor = band !== null ? BAND_MIN_ZOOM[band] : minzoom;
+    const effectiveFloor = Math.max(minzoom, floor);
+    const sample = layers.slice(0, 6).join(', ');
+    const more = layers.length > 6 ? `, …` : '';
+    appendLog(
+      chartNumber,
+      `Band ${band ?? 'unknown'}: ${layers.length} layers from z${effectiveFloor} (${sample}${more})`
+    );
   }
 
   const tippecanoeThreads = getCpuBudget().tippecanoeThreadsPerJob;
@@ -366,6 +413,7 @@ async function runTippecanoe(
       String(minzoom),
       '--no-tile-size-limit',
       '--no-feature-limit',
+      '--detect-shared-borders',
       '--force',
       ...layerArgs
     ],

--- a/test/s57-band.test.js
+++ b/test/s57-band.test.js
@@ -1,7 +1,13 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
 
-const { detectEncBand, BAND_MAX_ZOOM, bandClampedMaxzoom } = require('../dist/utils/s57-band');
+const {
+  detectEncBand,
+  BAND_MAX_ZOOM,
+  BAND_MIN_ZOOM,
+  bandClampedMaxzoom,
+  highestBandForFiles
+} = require('../dist/utils/s57-band');
 
 describe('detectEncBand (IHO Annex E filename convention)', () => {
   it('parses NOAA filenames', () => {
@@ -52,6 +58,48 @@ describe('BAND_MAX_ZOOM', () => {
     assert.strictEqual(BAND_MAX_ZOOM[4], 14);
     assert.strictEqual(BAND_MAX_ZOOM[5], 16);
     assert.strictEqual(BAND_MAX_ZOOM[6], 18);
+  });
+});
+
+describe('BAND_MIN_ZOOM', () => {
+  it('uses ceiling-minus-4 for every band', () => {
+    assert.strictEqual(BAND_MIN_ZOOM[1], 4);
+    assert.strictEqual(BAND_MIN_ZOOM[2], 6);
+    assert.strictEqual(BAND_MIN_ZOOM[3], 8);
+    assert.strictEqual(BAND_MIN_ZOOM[4], 10);
+    assert.strictEqual(BAND_MIN_ZOOM[5], 12);
+    assert.strictEqual(BAND_MIN_ZOOM[6], 14);
+  });
+
+  it('every band has min < max so tippecanoe gets a non-empty zoom range', () => {
+    for (const band of [1, 2, 3, 4, 5, 6]) {
+      assert.ok(BAND_MIN_ZOOM[band] < BAND_MAX_ZOOM[band], `band ${band}`);
+    }
+  });
+});
+
+describe('highestBandForFiles', () => {
+  it('returns the highest band among conforming filenames', () => {
+    assert.strictEqual(
+      highestBandForFiles(['HRBFAC_US5MA1SK.geojson', 'LNDARE_US3CO100.geojson']),
+      5
+    );
+  });
+
+  it('ignores non-conforming filenames (IENC, hand-named) when others conform', () => {
+    assert.strictEqual(highestBandForFiles(['HRBFAC_US5MA1SK.geojson', 'WEIRD_NAME.geojson']), 5);
+  });
+
+  it('returns null when nothing conforms', () => {
+    assert.strictEqual(highestBandForFiles(['weird.geojson', 'IENC_PASS_001.geojson']), null);
+  });
+
+  it('returns null for empty input', () => {
+    assert.strictEqual(highestBandForFiles([]), null);
+  });
+
+  it('takes the basename so directory-prefixed paths still work', () => {
+    assert.strictEqual(highestBandForFiles(['/tmp/enc/HRBFAC_US5MA1SK.geojson']), 5);
   });
 });
 

--- a/test/s57-converter.test.js
+++ b/test/s57-converter.test.js
@@ -5,7 +5,8 @@ const os = require('node:os');
 const path = require('node:path');
 
 const { _testInternals } = require('../dist/utils/s57-converter');
-const { consolidateGeoJSONByLayer, buildExportScript, bandClampedMaxzoom } = _testInternals;
+const { consolidateGeoJSONByLayer, buildExportScript, bandClampedMaxzoom, buildLayerArgs } =
+  _testInternals;
 
 function writeFC(p, features) {
   fs.writeFileSync(p, JSON.stringify({ type: 'FeatureCollection', features }));
@@ -33,12 +34,12 @@ describe('consolidateGeoJSONByLayer', () => {
     writeFC(path.join(dir, 'M_NPUB_US3CO100.geojson'), [point({ kind: 'm-npub' })]);
 
     const merged = consolidateGeoJSONByLayer(dir);
-    const names = merged.map((p) => path.basename(p, '.geojson')).sort();
+    const names = merged.map((m) => path.basename(m.file, '.geojson')).sort();
     assert.deepStrictEqual(names, ['M_COVR', 'M_NPUB', 'M_QUAL']);
 
     // Each merged file should contain exactly its own feature, not all three
     // smashed together.
-    for (const file of merged) {
+    for (const { file } of merged) {
       const fc = JSON.parse(fs.readFileSync(file, 'utf8'));
       assert.strictEqual(fc.features.length, 1, `${file} should hold one feature`);
     }
@@ -52,9 +53,9 @@ describe('consolidateGeoJSONByLayer', () => {
 
     const merged = consolidateGeoJSONByLayer(dir);
     assert.strictEqual(merged.length, 1);
-    assert.strictEqual(path.basename(merged[0], '.geojson'), 'BUAARE');
+    assert.strictEqual(path.basename(merged[0].file, '.geojson'), 'BUAARE');
 
-    const fc = JSON.parse(fs.readFileSync(merged[0], 'utf8'));
+    const fc = JSON.parse(fs.readFileSync(merged[0].file, 'utf8'));
     assert.strictEqual(fc.features.length, 3);
     const names = fc.features.map((f) => f.properties.name).sort();
     assert.deepStrictEqual(names, ['a', 'b', 'c']);
@@ -66,13 +67,13 @@ describe('consolidateGeoJSONByLayer', () => {
     writeFC(path.join(dir, 'M_COVR.geojson'), [point({ k: 'm-covr' })]);
 
     const merged = consolidateGeoJSONByLayer(dir);
-    const names = merged.map((p) => path.basename(p, '.geojson')).sort();
+    const names = merged.map((m) => path.basename(m.file, '.geojson')).sort();
     assert.deepStrictEqual(names, ['COALNE', 'M_COVR']);
 
     // Output must be a real file, not a symlink — the caller bind-mounts only
     // the merged dir into the container, so a symlink to the parent geojsonDir
     // would dangle.
-    for (const file of merged) {
+    for (const { file } of merged) {
       const lst = fs.lstatSync(file);
       assert.ok(!lst.isSymbolicLink(), `${file} must not be a symlink`);
       const fc = JSON.parse(fs.readFileSync(file, 'utf8'));
@@ -86,7 +87,7 @@ describe('consolidateGeoJSONByLayer', () => {
     writeFC(path.join(dir, 'REAL_US3CO100.geojson'), [point({ k: 'real' })]);
 
     const merged = consolidateGeoJSONByLayer(dir);
-    const names = merged.map((p) => path.basename(p, '.geojson'));
+    const names = merged.map((m) => path.basename(m.file, '.geojson'));
     assert.deepStrictEqual(names, ['REAL']);
   });
 
@@ -107,10 +108,10 @@ describe('consolidateGeoJSONByLayer', () => {
     writeFC(path.join(dir, 'M_QUAL_US3CO200.geojson'), [point({ k: 'qual-200' })]);
 
     const merged = consolidateGeoJSONByLayer(dir);
-    const names = merged.map((p) => path.basename(p, '.geojson')).sort();
+    const names = merged.map((m) => path.basename(m.file, '.geojson')).sort();
     assert.deepStrictEqual(names, ['M_COVR', 'M_QUAL']);
 
-    for (const file of merged) {
+    for (const { file } of merged) {
       const fc = JSON.parse(fs.readFileSync(file, 'utf8'));
       assert.strictEqual(fc.features.length, 2);
     }
@@ -132,16 +133,12 @@ describe('consolidateGeoJSONByLayer', () => {
     writeFC(path.join(dir, 'PILBOP_US5MA1SK.geojson'), [point({ obj: 'pilot-boarding' })]);
 
     const merged = consolidateGeoJSONByLayer(dir);
-    const layerNames = new Set(merged.map((p) => path.basename(p, '.geojson')));
+    const layerNames = new Set(merged.map((m) => path.basename(m.file, '.geojson')));
 
     for (const layer of ['LNDARE', 'DEPARE', 'COALNE']) {
       assert.ok(layerNames.has(layer), `bulk layer ${layer} should be merged`);
-      const fc = JSON.parse(
-        fs.readFileSync(
-          merged.find((p) => p.endsWith(`${layer}.geojson`)),
-          'utf8'
-        )
-      );
+      const entry = merged.find((m) => m.file.endsWith(`${layer}.geojson`));
+      const fc = JSON.parse(fs.readFileSync(entry.file, 'utf8'));
       assert.strictEqual(fc.features.length, 3, `${layer} should have 3 features (1 per chart)`);
     }
 
@@ -224,5 +221,62 @@ describe('bandClampedMaxzoom (re-export from s57-converter._testInternals)', () 
     const r = bandClampedMaxzoom(['IENC_PASS_001.000'], 16);
     assert.strictEqual(r.effective, 16);
     assert.strictEqual(r.highestBand, null);
+  });
+});
+
+describe('buildLayerArgs (per-band minzoom wiring)', () => {
+  function parseLayerArgs(args) {
+    // args is an interleaved list: ['-L', '<json>', '-L', '<json>', …]
+    const parsed = [];
+    for (let i = 0; i < args.length; i += 2) {
+      assert.strictEqual(args[i], '-L');
+      parsed.push(JSON.parse(args[i + 1]));
+    }
+    return parsed;
+  }
+
+  it('uses BAND_MIN_ZOOM[5]=12 for harbour layers and merges-up to highest band', () => {
+    const layers = [
+      { file: '/m/HRBFAC.geojson', sourceFiles: ['HRBFAC_US5MA1SK.geojson'] },
+      {
+        file: '/m/LNDARE.geojson',
+        sourceFiles: ['LNDARE_US3CO100.geojson', 'LNDARE_US5MA1SK.geojson']
+      },
+      { file: '/m/COALNE.geojson', sourceFiles: ['COALNE_US3CO100.geojson'] }
+    ];
+    const parsed = parseLayerArgs(buildLayerArgs(layers, 9));
+
+    const hrbfac = parsed.find((p) => p.layer === 'HRBFAC');
+    const lndare = parsed.find((p) => p.layer === 'LNDARE');
+    const coalne = parsed.find((p) => p.layer === 'COALNE');
+
+    assert.strictEqual(hrbfac.minzoom, 12, 'band-5 HRBFAC must start at z12');
+    assert.strictEqual(lndare.minzoom, 12, 'merged 3+5 LNDARE takes the highest band (5) → z12');
+    assert.strictEqual(
+      coalne.minzoom,
+      9,
+      'pure band-3 COALNE bounded by user minzoom 9, not floor 8'
+    );
+  });
+
+  it('respects user minzoom as a floor (never below)', () => {
+    const layers = [{ file: '/m/COALNE.geojson', sourceFiles: ['COALNE_US3CO100.geojson'] }];
+    const parsed = parseLayerArgs(buildLayerArgs(layers, 11));
+    assert.strictEqual(parsed[0].minzoom, 11, 'user-asked z11 wins over band-3 floor z8');
+  });
+
+  it('falls back to userMinzoom when sources do not match the IHO Annex E pattern', () => {
+    const layers = [{ file: '/m/X.geojson', sourceFiles: ['X_IENC_AREA.geojson'] }];
+    const parsed = parseLayerArgs(buildLayerArgs(layers, 9));
+    assert.strictEqual(parsed[0].minzoom, 9);
+  });
+
+  it('points the file path at /input (the in-container bind mount) and uses the layer basename', () => {
+    const layers = [
+      { file: '/some/host/path/HRBFAC.geojson', sourceFiles: ['HRBFAC_US5MA1SK.geojson'] }
+    ];
+    const parsed = parseLayerArgs(buildLayerArgs(layers, 9));
+    assert.strictEqual(parsed[0].file, '/input/HRBFAC.geojson');
+    assert.strictEqual(parsed[0].layer, 'HRBFAC');
   });
 });


### PR DESCRIPTION
## Summary
- Adds per-band minzoom to tippecanoe `-L` args via `BAND_MIN_ZOOM` (each band's max minus 4): band-3 coastal layers start at z8, band-5 harbour layers at z12, band-6 berthing at z14. Below those zooms the features overplot into illegible blobs and add no navigational value, so emitting them there only wastes CPU and tile bytes.
- Adds `--detect-shared-borders` to tippecanoe always — snaps shared edges between adjacent polygons (M_COVR cells, LNDARE landmasses across chart edges). Pure topology compression, no data change.
- Bumps to 1.11.0-beta.1 because the on-disk `.mbtiles` zoom shape changes.

## Implementation
- `BAND_MIN_ZOOM` and `highestBandForFiles()` added to `src/utils/s57-band.ts`. `highestBandForFiles` extracts the chart-ID portion of `LAYER_CHART.geojson` filenames before parsing the IHO band.
- `consolidateGeoJSONByLayer` now returns `{ file, sourceFiles }[]` so the tippecanoe arg builder can recover the per-layer band info that was previously discarded.
- New `buildLayerArgs()` produces JSON-form `-L` args with per-layer `minzoom`. (Tippecanoe's simple `LAYER:FILE` form does not support per-layer minzoom.)
- `runTippecanoe` now logs a per-band breakdown so users can see why band-5 features don't appear at z9.

## User impact
Goal stated by the user: "as a user I expect a usable chart that I can use coastal and inside a harbour, not only some pixels of it." At z9 you now get a clean coastal view; at z12+ harbour symbols emerge. No data is dropped — features still appear at every zoom from their band's floor up to the bundle ceiling.

## Tested
- `npm run format:check && npm run build && npm test`: 106/106 pass (was 95).
- 11 new tests cover `BAND_MIN_ZOOM`, `highestBandForFiles` (including the multi-chart filename pattern), the new consolidator return shape, and `buildLayerArgs` minzoom logic.
- Manual real-bundle conversion smoke test will run once this branch is checked out locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for IHO ENC band detection to determine appropriate minimum zoom levels for chart layers.
  * Enhanced map tile generation with improved shared border detection.

* **Chores**
  * Version bumped to 1.11.0-beta.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->