### PR TITLE
docs(readme): document the cpu-features --ignore-scripts CI warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ systemctl --user enable --now podman.socket
 
 Conversion concurrency is configurable — see the [CPU budget](#cpu-budget-for-chart-conversion) section. MBTiles charts (display only, no conversion) work without any container runtime.
 
+### Known install warnings
+
+Signal K's appstore installs plugins with `--ignore-scripts`, so any optional native addons in the dependency tree won't compile. CI flags one such case for this plugin:
+
+> `Optional native addons found: cpu-features. App Store uses --ignore-scripts so these will not be compiled.`
+
+This is harmless. `cpu-features` is a transitive optional dependency of `ssh2`, pulled in by `dockerode`. The plugin only ever talks to a local Docker/Podman Unix socket, so the SSH transport (and its native crypto accelerator) is never used. The warning is informational; the plugin runs fully without the addon.
+
 ## Legal Notice
 
 ### Chart Metadata Editing


### PR DESCRIPTION
## Summary
- Adds a short \"Known install warnings\" section to README explaining the `cpu-features` warning surfaced by Signal K's plugin CI.
- No code change, no version bump.

## Why
Signal K's appstore installs plugins with `--ignore-scripts`, so any optional native addons never compile. CI correctly flags `cpu-features` for this plugin. It is a transitive optional dependency of `ssh2`, pulled in by `dockerode`. We only ever talk to a local Docker/Podman socket, never to a remote daemon over SSH, so the SSH transport (and its native crypto accelerator) is never executed at runtime. The warning is harmless — but anyone re-investigating it should not have to repeat the dependency walk.

## Tested
- README renders correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified an app store warning about optional native dependencies, explaining that the warning is informational and does not affect plugin functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->