### PR TITLE
chore(release): 1.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.11.0-beta.1",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.11.0-beta.1",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.11.0-beta.1",
+  "version": "1.11.0",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Promotes 1.11.0-beta.1 to stable. Verified end-to-end against the full NOAA Florida ENC bundle (680 charts, all 6 IHO bands).

## Highlights since 1.10.0
- **Per-band minzoom** — harbour-tier S-57 layers (HRBFAC, ACHARE, BRIDGE, MORFAC, PILBOP, …) emit from z12 instead of cluttering z9–z11 with overplotted harbour symbols. Band floors: 1→z4, 2→z6, 3→z8, 4→z10, 5→z12, 6→z14 (each band's max minus 4). Lossless — no features dropped, just emitted from zooms where they're actually legible. User minzoom is still respected as a floor.
- **--detect-shared-borders** — snaps shared edges between adjacent polygons across chart boundaries (M_COVR cells, LNDARE landmasses). Pure topology compression, no data change.
- **Mixed-band regression test** — locks in the contract that band-5 harbour-tier layers survive consolidation when grouped with band-3 charts.
- **README docs** — documents the harmless `cpu-features --ignore-scripts` warning surfaced by Signal K's plugin CI.

## Tested
- `npm run format:check && npm run build && npm test`: 106/106 pass.
- Full NOAA Florida ENC bundle (680 charts) converted end-to-end against the 1.11.0-beta.1 build. Per-band log line emitted as designed; harbour-tier layers visible at z12+ in Freeboard-SK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released stable version 1.11.0, transitioning from the pre-release candidate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->