### PR TITLE
fix(s57): per-band minzoom via feature-level tippecanoe.minzoom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -236,15 +236,24 @@ async function exportAllLayersToGeoJSON(
 }
 
 // One row per merged layer. `sourceFiles` are the per-chart GeoJSON filenames
-// (basenames, e.g. 'HRBFAC_US5MA1SK.geojson') that fed the merge — the caller
-// uses them to recover IHO band info per layer.
+// (basenames, e.g. 'HRBFAC_US5MA1SK.geojson') that fed the merge — kept for
+// caller diagnostics (per-band log line). Per-feature minzoom is already
+// stamped onto features inside the merged file via `tippecanoe.minzoom`.
 type ConsolidatedLayer = { file: string; sourceFiles: string[] };
 
 // Group per-chart-per-layer GeoJSON files into one merged file per layer.
 // Tippecanoe runs faster with fewer -L args (one merged file per layer) than
 // with N×M args (one per chart × layer). Streams the output so a multi-state
 // bundle's largest layer doesn't have to fit in memory at once.
-function consolidateGeoJSONByLayer(geojsonDir: string): ConsolidatedLayer[] {
+//
+// Each emitted feature carries a `tippecanoe.minzoom` extension property
+// derived from its source chart's IHO band: tippecanoe respects the
+// per-feature `tippecanoe.minzoom` extension and won't emit the feature
+// below that zoom. (Tippecanoe's `-L` JSON form does NOT support per-layer
+// minzoom — silently ignored — so we MUST set it per-feature.) Source
+// charts that don't follow the IHO Annex E filename convention (IENC,
+// hand-named) get no extension property and fall back to the global `-Z`.
+function consolidateGeoJSONByLayer(geojsonDir: string, userMinzoom: number): ConsolidatedLayer[] {
   const files = fs.readdirSync(geojsonDir).filter((f) => f.endsWith('.geojson'));
 
   // Group by layer name. The export script writes 'LAYER_CHART.geojson' for
@@ -275,18 +284,17 @@ function consolidateGeoJSONByLayer(geojsonDir: string): ConsolidatedLayer[] {
   const consolidated: ConsolidatedLayer[] = [];
   for (const [layer, sources] of layerGroups) {
     const out = path.join(mergedDir, `${layer}.geojson`);
-    if (sources.length === 1) {
-      // Single-source layer — just copy. We can't symlink because runTippecanoe
-      // bind-mounts only the merged dir into the container, so a symlink
-      // pointing back into geojsonDir would dangle inside the container.
-      fs.copyFileSync(path.join(geojsonDir, sources[0]), out);
-      consolidated.push({ file: out, sourceFiles: sources });
-      continue;
-    }
     const handle = fs.openSync(out, 'w');
     fs.writeSync(handle, '{"type":"FeatureCollection","features":[\n');
     let first = true;
     for (const source of sources) {
+      // Per-source-chart band → per-feature minzoom. Files in this source
+      // share a band because they all come from the same chart cell, so the
+      // band lookup is one-shot per source file.
+      const band = highestBandForFiles([source]);
+      const bandFloor = band !== null ? BAND_MIN_ZOOM[band] : null;
+      const featureMinzoom = bandFloor !== null ? Math.max(userMinzoom, bandFloor) : null;
+
       let parsed: { features?: unknown[] };
       try {
         parsed = JSON.parse(fs.readFileSync(path.join(geojsonDir, source), 'utf8')) as {
@@ -300,7 +308,9 @@ function consolidateGeoJSONByLayer(geojsonDir: string): ConsolidatedLayer[] {
         if (!first) {
           fs.writeSync(handle, ',\n');
         }
-        fs.writeSync(handle, JSON.stringify(feat));
+        const stamped =
+          featureMinzoom !== null ? withTippecanoeMinzoom(feat, featureMinzoom) : feat;
+        fs.writeSync(handle, JSON.stringify(stamped));
         first = false;
       }
     }
@@ -312,23 +322,33 @@ function consolidateGeoJSONByLayer(geojsonDir: string): ConsolidatedLayer[] {
   return consolidated;
 }
 
-// Build tippecanoe `-L <json>` args with per-layer minzoom set from the IHO
-// band detected in each merged layer's source filenames. Layers whose
-// source charts don't follow the IHO Annex E filename convention (IENC,
-// hand-named) fall back to userMinzoom — same behaviour as before.
-function buildLayerArgs(layers: readonly ConsolidatedLayer[], userMinzoom: number): string[] {
+// Stamp tippecanoe.minzoom on a single feature without mutating the input.
+// Preserves any existing `tippecanoe` extension fields if the source already
+// set them (rare for ogr2ogr output, but harmless to support).
+function withTippecanoeMinzoom(feature: unknown, minzoom: number): unknown {
+  if (typeof feature !== 'object' || feature === null) {
+    return feature;
+  }
+  const f = feature as Record<string, unknown>;
+  const existing =
+    typeof f.tippecanoe === 'object' && f.tippecanoe !== null
+      ? (f.tippecanoe as Record<string, unknown>)
+      : {};
+  return { ...f, tippecanoe: { ...existing, minzoom } };
+}
+
+// Build tippecanoe `-L NAME:FILE` args (the simple form). Per-layer minzoom
+// is *not* settable via `-L` JSON — tippecanoe silently ignores `minzoom`
+// fields there. Per-band minzoom is therefore stamped onto each feature in
+// the consolidator (see `consolidateGeoJSONByLayer`), and tippecanoe honors
+// `feature.tippecanoe.minzoom` natively. This function is just the
+// container-relative path stitching.
+function buildLayerArgs(layers: readonly ConsolidatedLayer[]): string[] {
   const args: string[] = [];
-  for (const { file, sourceFiles } of layers) {
+  for (const { file } of layers) {
     const rel = path.basename(file);
     const layer = path.basename(rel, '.geojson');
-    const band = highestBandForFiles(sourceFiles);
-    const bandFloor = band !== null ? BAND_MIN_ZOOM[band] : null;
-    // Per-layer minzoom = max(user-requested global minzoom, band floor). The
-    // band floor is the smallest zoom at which features captured at this
-    // band's native scale are still legible; never go above it for that
-    // layer, never go below the user's global ask either.
-    const layerMinzoom = bandFloor !== null ? Math.max(userMinzoom, bandFloor) : userMinzoom;
-    args.push('-L', JSON.stringify({ file: `/input/${rel}`, layer, minzoom: layerMinzoom }));
+    args.push('-L', `${layer}:/input/${rel}`);
   }
   return args;
 }
@@ -353,12 +373,12 @@ async function runTippecanoe(
   // tippecanoe. A typical NOAA bundle of 4 charts × ~30 layers used to mean
   // 120 -L args; consolidating drops that to ~30 and cuts tippecanoe's I/O
   // setup proportionally.
-  const mergedLayers = consolidateGeoJSONByLayer(geojsonDir);
+  const mergedLayers = consolidateGeoJSONByLayer(geojsonDir, minzoom);
   if (mergedLayers.length === 0) {
     throw new Error('No valid GeoJSON layers to process');
   }
   const mergedDir = path.dirname(mergedLayers[0].file);
-  const layerArgs = buildLayerArgs(mergedLayers, minzoom);
+  const layerArgs = buildLayerArgs(mergedLayers);
 
   // Log per-band layer breakdown so users can see why low-zoom features differ
   // by band. Counts plus a sample of layer names — full lists would be noisy

--- a/test/s57-converter.test.js
+++ b/test/s57-converter.test.js
@@ -33,7 +33,7 @@ describe('consolidateGeoJSONByLayer', () => {
     writeFC(path.join(dir, 'M_QUAL_US3CO100.geojson'), [point({ kind: 'm-qual' })]);
     writeFC(path.join(dir, 'M_NPUB_US3CO100.geojson'), [point({ kind: 'm-npub' })]);
 
-    const merged = consolidateGeoJSONByLayer(dir);
+    const merged = consolidateGeoJSONByLayer(dir, 9);
     const names = merged.map((m) => path.basename(m.file, '.geojson')).sort();
     assert.deepStrictEqual(names, ['M_COVR', 'M_NPUB', 'M_QUAL']);
 
@@ -51,7 +51,7 @@ describe('consolidateGeoJSONByLayer', () => {
     writeFC(path.join(dir, 'BUAARE_US3CO200.geojson'), [point({ name: 'b' })]);
     writeFC(path.join(dir, 'BUAARE_US3CO400.geojson'), [point({ name: 'c' })]);
 
-    const merged = consolidateGeoJSONByLayer(dir);
+    const merged = consolidateGeoJSONByLayer(dir, 9);
     assert.strictEqual(merged.length, 1);
     assert.strictEqual(path.basename(merged[0].file, '.geojson'), 'BUAARE');
 
@@ -66,7 +66,7 @@ describe('consolidateGeoJSONByLayer', () => {
     writeFC(path.join(dir, 'COALNE.geojson'), [point({ k: 'coalne' })]);
     writeFC(path.join(dir, 'M_COVR.geojson'), [point({ k: 'm-covr' })]);
 
-    const merged = consolidateGeoJSONByLayer(dir);
+    const merged = consolidateGeoJSONByLayer(dir, 9);
     const names = merged.map((m) => path.basename(m.file, '.geojson')).sort();
     assert.deepStrictEqual(names, ['COALNE', 'M_COVR']);
 
@@ -86,14 +86,14 @@ describe('consolidateGeoJSONByLayer', () => {
     fs.writeFileSync(path.join(dir, 'EMPTY_US3CO100.geojson'), '{}');
     writeFC(path.join(dir, 'REAL_US3CO100.geojson'), [point({ k: 'real' })]);
 
-    const merged = consolidateGeoJSONByLayer(dir);
+    const merged = consolidateGeoJSONByLayer(dir, 9);
     const names = merged.map((m) => path.basename(m.file, '.geojson'));
     assert.deepStrictEqual(names, ['REAL']);
   });
 
   it('returns an empty array when there are no usable inputs', () => {
     const dir = fs.mkdtempSync(path.join(tmp, 'none-'));
-    const merged = consolidateGeoJSONByLayer(dir);
+    const merged = consolidateGeoJSONByLayer(dir, 9);
     assert.deepStrictEqual(merged, []);
   });
 
@@ -107,7 +107,7 @@ describe('consolidateGeoJSONByLayer', () => {
     writeFC(path.join(dir, 'M_QUAL_US3CO100.geojson'), [point({ k: 'qual-100' })]);
     writeFC(path.join(dir, 'M_QUAL_US3CO200.geojson'), [point({ k: 'qual-200' })]);
 
-    const merged = consolidateGeoJSONByLayer(dir);
+    const merged = consolidateGeoJSONByLayer(dir, 9);
     const names = merged.map((m) => path.basename(m.file, '.geojson')).sort();
     assert.deepStrictEqual(names, ['M_COVR', 'M_QUAL']);
 
@@ -132,7 +132,7 @@ describe('consolidateGeoJSONByLayer', () => {
     writeFC(path.join(dir, 'MORFAC_US5MA1SK.geojson'), [point({ obj: 'mooring' })]);
     writeFC(path.join(dir, 'PILBOP_US5MA1SK.geojson'), [point({ obj: 'pilot-boarding' })]);
 
-    const merged = consolidateGeoJSONByLayer(dir);
+    const merged = consolidateGeoJSONByLayer(dir, 9);
     const layerNames = new Set(merged.map((m) => path.basename(m.file, '.geojson')));
 
     for (const layer of ['LNDARE', 'DEPARE', 'COALNE']) {
@@ -224,59 +224,104 @@ describe('bandClampedMaxzoom (re-export from s57-converter._testInternals)', () 
   });
 });
 
-describe('buildLayerArgs (per-band minzoom wiring)', () => {
-  function parseLayerArgs(args) {
-    // args is an interleaved list: ['-L', '<json>', '-L', '<json>', …]
-    const parsed = [];
-    for (let i = 0; i < args.length; i += 2) {
-      assert.strictEqual(args[i], '-L');
-      parsed.push(JSON.parse(args[i + 1]));
-    }
-    return parsed;
+describe('buildLayerArgs (simple -L NAME:FILE form)', () => {
+  it('emits one -L LAYER:/input/LAYER.geojson pair per consolidated layer', () => {
+    const layers = [
+      { file: '/some/host/path/HRBFAC.geojson', sourceFiles: ['HRBFAC_US5MA1SK.geojson'] },
+      { file: '/some/host/path/LNDARE.geojson', sourceFiles: ['LNDARE_US3CO100.geojson'] }
+    ];
+    const args = buildLayerArgs(layers);
+    assert.deepStrictEqual(args, [
+      '-L',
+      'HRBFAC:/input/HRBFAC.geojson',
+      '-L',
+      'LNDARE:/input/LNDARE.geojson'
+    ]);
+  });
+
+  it('uses the layer name from the merged file basename', () => {
+    const layers = [{ file: '/anywhere/M_COVR.geojson', sourceFiles: ['M_COVR_US5MA1SK.geojson'] }];
+    assert.deepStrictEqual(buildLayerArgs(layers), ['-L', 'M_COVR:/input/M_COVR.geojson']);
+  });
+});
+
+describe('per-feature tippecanoe.minzoom stamping (band-aware consolidation)', () => {
+  let tmp;
+
+  before(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-charts-feat-minzoom-'));
+  });
+
+  after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function readFeatures(file) {
+    return JSON.parse(fs.readFileSync(file, 'utf8')).features;
   }
 
-  it('uses BAND_MIN_ZOOM[5]=12 for harbour layers and merges-up to highest band', () => {
-    const layers = [
-      { file: '/m/HRBFAC.geojson', sourceFiles: ['HRBFAC_US5MA1SK.geojson'] },
-      {
-        file: '/m/LNDARE.geojson',
-        sourceFiles: ['LNDARE_US3CO100.geojson', 'LNDARE_US5MA1SK.geojson']
-      },
-      { file: '/m/COALNE.geojson', sourceFiles: ['COALNE_US3CO100.geojson'] }
-    ];
-    const parsed = parseLayerArgs(buildLayerArgs(layers, 9));
+  it('stamps tippecanoe.minzoom = BAND_MIN_ZOOM[5] = 12 on band-5 features', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'b5-'));
+    writeFC(path.join(dir, 'HRBFAC_US5MA1SK.geojson'), [point({ obj: 'harbour' })]);
+    const merged = consolidateGeoJSONByLayer(dir, /* userMinzoom */ 9);
+    const fc = readFeatures(merged.find((m) => m.file.endsWith('HRBFAC.geojson')).file);
+    assert.strictEqual(fc.length, 1);
+    assert.strictEqual(fc[0].tippecanoe.minzoom, 12);
+  });
 
-    const hrbfac = parsed.find((p) => p.layer === 'HRBFAC');
-    const lndare = parsed.find((p) => p.layer === 'LNDARE');
-    const coalne = parsed.find((p) => p.layer === 'COALNE');
+  it('stamps per-source band, not per-merged-layer max — multi-band layers get mixed minzoom', () => {
+    // LNDARE features from a band-3 chart and a band-5 chart end up in the
+    // same merged file. Each feature carries the floor for its own source
+    // chart, so band-3 features can emit at z9 (= max(user 9, band-3 floor 8))
+    // while band-5 features only emit from z12. This is *better* than a
+    // layer-wide floor: the band-3 LNDARE outline is visible at z9 while
+    // band-5 detail kicks in at z12.
+    const dir = fs.mkdtempSync(path.join(tmp, 'mixed-'));
+    writeFC(path.join(dir, 'LNDARE_US3CO100.geojson'), [point({ src: 'b3' })]);
+    writeFC(path.join(dir, 'LNDARE_US5MA1SK.geojson'), [point({ src: 'b5' })]);
+    const merged = consolidateGeoJSONByLayer(dir, /* userMinzoom */ 9);
+    const fc = readFeatures(merged[0].file);
+    assert.strictEqual(fc.length, 2);
+    const b3 = fc.find((f) => f.properties.src === 'b3');
+    const b5 = fc.find((f) => f.properties.src === 'b5');
+    assert.strictEqual(b3.tippecanoe.minzoom, 9, 'band-3 floor 8 < user 9 → user wins');
+    assert.strictEqual(b5.tippecanoe.minzoom, 12, 'band-5 floor 12 > user 9 → band wins');
+  });
 
-    assert.strictEqual(hrbfac.minzoom, 12, 'band-5 HRBFAC must start at z12');
-    assert.strictEqual(lndare.minzoom, 12, 'merged 3+5 LNDARE takes the highest band (5) → z12');
+  it('respects userMinzoom as a floor (never goes below user-asked)', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'user-floor-'));
+    writeFC(path.join(dir, 'HRBFAC_US5MA1SK.geojson'), [point({ obj: 'harbour' })]);
+    const merged = consolidateGeoJSONByLayer(dir, /* userMinzoom */ 14);
+    const fc = readFeatures(merged[0].file);
+    assert.strictEqual(fc[0].tippecanoe.minzoom, 14, 'user 14 > band-5 floor 12 → user wins');
+  });
+
+  it('does NOT stamp tippecanoe.minzoom on features from non-conforming sources', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'ienc-'));
+    writeFC(path.join(dir, 'HRBFAC_IENC_AREA.geojson'), [point({ obj: 'harbour' })]);
+    const merged = consolidateGeoJSONByLayer(dir, /* userMinzoom */ 9);
+    const fc = readFeatures(merged[0].file);
     assert.strictEqual(
-      coalne.minzoom,
-      9,
-      'pure band-3 COALNE bounded by user minzoom 9, not floor 8'
+      fc[0].tippecanoe,
+      undefined,
+      'IENC features fall back to the global -Z, no per-feature override'
     );
   });
 
-  it('respects user minzoom as a floor (never below)', () => {
-    const layers = [{ file: '/m/COALNE.geojson', sourceFiles: ['COALNE_US3CO100.geojson'] }];
-    const parsed = parseLayerArgs(buildLayerArgs(layers, 11));
-    assert.strictEqual(parsed[0].minzoom, 11, 'user-asked z11 wins over band-3 floor z8');
-  });
-
-  it('falls back to userMinzoom when sources do not match the IHO Annex E pattern', () => {
-    const layers = [{ file: '/m/X.geojson', sourceFiles: ['X_IENC_AREA.geojson'] }];
-    const parsed = parseLayerArgs(buildLayerArgs(layers, 9));
-    assert.strictEqual(parsed[0].minzoom, 9);
-  });
-
-  it('points the file path at /input (the in-container bind mount) and uses the layer basename', () => {
-    const layers = [
-      { file: '/some/host/path/HRBFAC.geojson', sourceFiles: ['HRBFAC_US5MA1SK.geojson'] }
-    ];
-    const parsed = parseLayerArgs(buildLayerArgs(layers, 9));
-    assert.strictEqual(parsed[0].file, '/input/HRBFAC.geojson');
-    assert.strictEqual(parsed[0].layer, 'HRBFAC');
+  it('preserves any pre-existing tippecanoe.* extension fields', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'preserve-'));
+    const feat = {
+      ...point({ obj: 'harbour' }),
+      tippecanoe: { layer: 'override', maxzoom: 18 }
+    };
+    fs.writeFileSync(
+      path.join(dir, 'HRBFAC_US5MA1SK.geojson'),
+      JSON.stringify({ type: 'FeatureCollection', features: [feat] })
+    );
+    const merged = consolidateGeoJSONByLayer(dir, 9);
+    const out = readFeatures(merged[0].file)[0];
+    assert.strictEqual(out.tippecanoe.minzoom, 12, 'minzoom added');
+    assert.strictEqual(out.tippecanoe.maxzoom, 18, 'pre-existing maxzoom preserved');
+    assert.strictEqual(out.tippecanoe.layer, 'override', 'pre-existing layer preserved');
   });
 });


### PR DESCRIPTION
## Summary
Critical fix for the per-band minzoom feature shipped in 1.11.0 — it wasn't actually working. Bumps to 1.11.1.

## The bug
In 1.11.0 I set per-layer minzoom in tippecanoe's `-L` JSON form: `-L '{"file":"...","layer":"...","minzoom":12}'`. Turns out tippecanoe **silently ignores** `minzoom` in that JSON object — it's not a documented field of the named-layer JSON. So the `.mbtiles` output still emitted band-5 harbour features at z9–z11 along with everything else.

Confirmed empirically against the 1.11.0 FL output: a z9 tile over Miami carried 70 layers including HRBFAC, BERTHS, MORFAC, BCNLAT, BCNSPP — all band-5 stuff that `BAND_MIN_ZOOM[5]=12` was supposed to suppress. A Discord report described the symptom: "all detail at all zooms, unreasonably slow."

## The fix
Stamp `tippecanoe.minzoom` as a **feature property** during consolidation, instead of trying to set it per-layer at CLI time. Tippecanoe natively respects `feature.tippecanoe.minzoom` and won't emit a feature below that zoom — this is the documented mechanism.

Side benefit: per-*source-chart* band detection means a single merged LNDARE file can carry mixed minzoom. Its band-3 features emit from z9 (or wherever user-min puts them) while band-5 detail kicks in at z12. Better than a layer-wide floor.

`buildLayerArgs` reverts to the simple `-L NAME:FILE` form (no JSON).

## Smoke-verified end-to-end
Ran a synthetic mixed-band input through the real tippecanoe container. Decoded the resulting tiles:

```
z=9:  COALNE=1
z=10: COALNE=1
z=11: COALNE=1
z=12: COALNE=1 HRBFAC=1   ← band-5 emerges exactly at the band floor
z=13: COALNE=1 HRBFAC=1
z=14: COALNE=1 HRBFAC=1
```

## Tested
- `npm run format:check && npm run build && npm test` — 109/109 pass (was 106).
- New describe block: `per-feature tippecanoe.minzoom stamping (band-aware consolidation)` covers band-5 stamping, mixed-band per-source minzoom, user-minzoom floor, IENC fallback, and preservation of pre-existing `tippecanoe.*` fields.
- Smoke-tested through a real tippecanoe container as shown above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released patch version 1.11.1

* **Bug Fixes**
  * Enhanced per-feature minzoom level handling for consolidated chart data, now calculated individually based on source chart IHO bands combined with user-specified floor values
  * Streamlined chart layer file generation

* **Tests**
  * Expanded test coverage to validate per-feature minzoom stamping, band combinations, and preservation of existing chart metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->