### PR TITLE
feat(diagnostics): drop a marker file at the resolved chart path on startup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,12 @@ import {
 } from './utils/rnc-converter';
 import { processGshhg, processShpBasemap } from './utils/s57-converter';
 import { getCpuBudget, setCpuBudget } from './utils/concurrency';
+import { writeChartPathMarker } from './utils/path-marker';
+
+// Read at module load so the marker file always reflects the running build.
+// `require` keeps this synchronous and avoids dragging package.json into the
+// emitted dist (tsc resolves it through CommonJS interop).
+const pluginVersion: string = (require('../package.json') as { version: string }).version;
 import type {
   ExtendedServerAPI,
   PluginConfig,
@@ -152,6 +158,18 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       app.setPluginError(`Chart directory is not writable: ${chartPath}`);
       app.setPluginStatus('Started (no chart directory)');
       return;
+    }
+
+    // Drop a marker file at the resolved chart path. Lets users (especially
+    // running under Docker/Podman) confirm the bind mount points where they
+    // expect by looking for this file on the host filesystem.
+    const marker = writeChartPathMarker(chartPath, pluginVersion, {
+      onError: (msg) => app.debug(msg)
+    });
+    if (marker) {
+      console.log(`[charts-provider] chartPath resolved to ${chartPath} (marker: ${marker})`);
+    } else {
+      console.log(`[charts-provider] chartPath resolved to ${chartPath} (marker write failed)`);
     }
 
     initChartState(pluginDataDir);

--- a/src/utils/path-marker.ts
+++ b/src/utils/path-marker.ts
@@ -1,0 +1,75 @@
+import fs from 'fs';
+import path from 'path';
+
+export const MARKER_FILENAME = '.charts-provider-marker.json';
+
+export interface ContainerHints {
+  /** Whether well-known container indicator files exist on the running filesystem. */
+  isLikelyContainer: boolean;
+  /** $HOME at startup, useful when comparing host vs in-container paths. */
+  homeEnv: string | undefined;
+  /** Effective UID, useful when explaining permission mismatches with the host. */
+  uid: number | undefined;
+}
+
+export interface ChartPathMarker {
+  version: string;
+  chartPath: string;
+  writtenAt: string;
+  containerHints: ContainerHints;
+}
+
+// Detect whether the plugin is running inside a Docker / Podman container by
+// looking for the well-known indicator files those runtimes drop into the
+// container filesystem. Best-effort — a wrapped runtime that hides them won't
+// be flagged. Used only for marker diagnostics, not for behaviour gating.
+export function detectContainerHints(): ContainerHints {
+  let isLikelyContainer = false;
+  try {
+    isLikelyContainer = fs.existsSync('/.dockerenv') || fs.existsSync('/run/.containerenv');
+  } catch {
+    isLikelyContainer = false;
+  }
+  const uid = typeof process.getuid === 'function' ? process.getuid() : undefined;
+  return {
+    isLikelyContainer,
+    homeEnv: process.env.HOME,
+    uid
+  };
+}
+
+// Write a small marker JSON file at the resolved chart path so users can
+// confirm whether the plugin is writing where they expect (especially under
+// Docker/Podman bind mounts). The marker contains the chart path, plugin
+// version, last-startup timestamp, and a few container hints.
+//
+// If the host can see this file at <chartPath>/.charts-provider-marker.json,
+// the bind mount is wired correctly. If they can't, the plugin is writing to
+// a path inside the container that isn't surfaced to the host.
+//
+// Best-effort: failures are reported via the optional `onError` callback and
+// then swallowed — this is purely diagnostic and must never block startup.
+export function writeChartPathMarker(
+  chartPath: string,
+  version: string,
+  options: {
+    now?: Date;
+    onError?: (msg: string) => void;
+  } = {}
+): string | null {
+  const markerPath = path.join(chartPath, MARKER_FILENAME);
+  const marker: ChartPathMarker = {
+    version,
+    chartPath,
+    writtenAt: (options.now ?? new Date()).toISOString(),
+    containerHints: detectContainerHints()
+  };
+  try {
+    fs.writeFileSync(markerPath, JSON.stringify(marker, null, 2) + '\n');
+    return markerPath;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    options.onError?.(`Failed to write chart path marker: ${message}`);
+    return null;
+  }
+}

--- a/test/path-marker.test.js
+++ b/test/path-marker.test.js
@@ -1,0 +1,121 @@
+const { describe, it, before, after, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  writeChartPathMarker,
+  detectContainerHints,
+  MARKER_FILENAME
+} = require('../dist/utils/path-marker');
+
+describe('writeChartPathMarker', () => {
+  let tmp;
+
+  before(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-charts-marker-'));
+  });
+
+  after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('writes the marker JSON at <chartPath>/.charts-provider-marker.json', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'happy-'));
+    const written = writeChartPathMarker(dir, '1.11.2', {
+      now: new Date('2026-04-29T05:32:14.123Z')
+    });
+
+    assert.strictEqual(
+      written,
+      path.join(dir, MARKER_FILENAME),
+      'returned path matches the documented filename inside chartPath'
+    );
+    assert.ok(fs.existsSync(written), 'marker file should be present on disk');
+  });
+
+  it('persists the documented schema (version, chartPath, writtenAt, containerHints)', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'schema-'));
+    const written = writeChartPathMarker(dir, '1.11.2', {
+      now: new Date('2026-04-29T05:32:14.123Z')
+    });
+    const parsed = JSON.parse(fs.readFileSync(written, 'utf8'));
+
+    // Locked shape so future tooling consumers can rely on it.
+    assert.deepStrictEqual(Object.keys(parsed).sort(), [
+      'chartPath',
+      'containerHints',
+      'version',
+      'writtenAt'
+    ]);
+    assert.strictEqual(parsed.version, '1.11.2');
+    assert.strictEqual(parsed.chartPath, dir);
+    assert.strictEqual(parsed.writtenAt, '2026-04-29T05:32:14.123Z');
+    assert.strictEqual(typeof parsed.containerHints, 'object');
+    assert.deepStrictEqual(Object.keys(parsed.containerHints).sort(), [
+      'homeEnv',
+      'isLikelyContainer',
+      'uid'
+    ]);
+    assert.strictEqual(typeof parsed.containerHints.isLikelyContainer, 'boolean');
+  });
+
+  it('overwrites the marker on each call (timestamp updates)', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'overwrite-'));
+    const t1 = new Date('2026-04-29T05:00:00.000Z');
+    const t2 = new Date('2026-04-29T06:00:00.000Z');
+
+    const w1 = writeChartPathMarker(dir, '1.11.2', { now: t1 });
+    const w2 = writeChartPathMarker(dir, '1.11.2', { now: t2 });
+
+    // Same target file, second write overwrites the first.
+    assert.strictEqual(w1, w2);
+    const parsed = JSON.parse(fs.readFileSync(w2, 'utf8'));
+    assert.strictEqual(parsed.writtenAt, t2.toISOString());
+  });
+
+  it('returns null and reports via onError when the path is not writable', () => {
+    // Point at a directory that doesn't exist — fs.writeFileSync will throw.
+    const dir = path.join(tmp, 'definitely-not-here', 'nested');
+    const errors = [];
+    const result = writeChartPathMarker(dir, '1.11.2', {
+      onError: (msg) => errors.push(msg)
+    });
+
+    assert.strictEqual(result, null);
+    assert.strictEqual(errors.length, 1);
+    assert.match(errors[0], /Failed to write chart path marker/);
+  });
+
+  it('does not throw when onError is not provided (best-effort)', () => {
+    const dir = path.join(tmp, 'still-not-here');
+    assert.doesNotThrow(() => writeChartPathMarker(dir, '1.11.2'));
+  });
+});
+
+describe('detectContainerHints', () => {
+  it('returns the documented shape with the correct types', () => {
+    const hints = detectContainerHints();
+    assert.deepStrictEqual(Object.keys(hints).sort(), ['homeEnv', 'isLikelyContainer', 'uid']);
+    assert.strictEqual(typeof hints.isLikelyContainer, 'boolean');
+    // homeEnv may be undefined in unusual environments; uid undefined on Windows.
+    if (hints.homeEnv !== undefined) {
+      assert.strictEqual(typeof hints.homeEnv, 'string');
+    }
+    if (hints.uid !== undefined) {
+      assert.strictEqual(typeof hints.uid, 'number');
+    }
+  });
+
+  it('reports isLikelyContainer correctly for the host this test runs on', () => {
+    // Pure consistency check: the value must agree with the indicator-file
+    // probe regardless of which environment runs the suite.
+    const expected = fs.existsSync('/.dockerenv') || fs.existsSync('/run/.containerenv');
+    assert.strictEqual(detectContainerHints().isLikelyContainer, expected);
+  });
+});
+
+// Silence unused-import warning when the `beforeEach`/`afterEach` hooks aren't used.
+void beforeEach;
+void afterEach;


### PR DESCRIPTION
## Summary
On every plugin startup, drop a small JSON marker file at the resolved chart path so users can confirm whether the plugin is writing where they expect — particularly helpful when running under Docker/Podman with bind mounts. Bumps to 1.11.2.

## Why
A Discord report described running Signal K in a container with `~/.signalk` bind-mounted to an unexpected host location. The plugin's `app.getDataDirPath()` resolved to `/home/node/.signalk/...` *inside* the container; that directory existed inside the container's filesystem, so the plugin wrote there happily — but those files weren't surfaced to the host. The plugin worked, the user just couldn't see his charts.

`fs.existsSync` can't distinguish a bind-mounted path from a fresh container-internal directory; both look identical. So instead of trying to detect the misconfiguration heuristically, this gives the user a way to verify it themselves.

## What changes

### Marker file
At startup, after the chart-directory writability check passes, the plugin writes `<chartPath>/.charts-provider-marker.json`:

```json
{
  "version": "1.11.2",
  "chartPath": "/home/node/.signalk/charts-simple",
  "writtenAt": "2026-04-29T05:32:14.123Z",
  "containerHints": {
    "isLikelyContainer": true,
    "homeEnv": "/home/node",
    "uid": 1000
  }
}
```

If the host can see this file at the expected path, the bind mount is wired correctly. If it can't, the user has hard evidence of where the plugin actually wrote — they can reconfigure the mount to match.

### Log line
The resolved chart path (and marker file path) is now logged at info level — `console.log` rather than `app.debug` — so it surfaces in Signal K logs without needing the debug flag flipped.

### Best-effort
Marker write failures go to `app.debug` and do not block startup. The marker is purely diagnostic; the plugin still functions if the write fails.

## Files
- `src/utils/path-marker.ts` (new) — `writeChartPathMarker`, `detectContainerHints`, `MARKER_FILENAME`.
- `src/index.ts` — call the helper after the writability check; log info line; read plugin version from `package.json` once.
- `test/path-marker.test.js` (new) — covers the happy path, schema stability (locked field set), overwrite-on-startup, write-failure path with `onError`, no-throw without `onError`, and the `detectContainerHints` shape.

## Tested
- `npm run format:check && npm run build && npm test` — 116/116 pass (was 109).
- Marker file shape locked by the schema test so future tooling consumers (e.g. an external "find my charts dir" CLI) can rely on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin now generates diagnostic metadata markers during startup to record chart path information and capture system environment details.

* **Tests**
  * Added comprehensive test coverage for marker functionality, including validation of metadata persistence, environment detection, and error handling scenarios.

* **Chores**
  * Version bumped to 1.11.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->