### PR TITLE
feat(s57): NOAA fix — cut DEPARE water out of overlapping LNDARE (1.12.0-beta.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ npm install signalk-charts-provider-simple
 1. Navigate to **Server → Plugin Config → Charts Provider Simple**
 2. Set your chart directory path (defaults to `~/.signalk/charts-simple`)
 3. (Optional) Pick a **CPU budget** for chart conversion — see [CPU budget](#cpu-budget-for-chart-conversion) below
-4. Enable the plugin
-5. Restart Signal K server (first-time install only — later config changes hot-apply on Save without a full restart)
+4. (Optional) Toggle the **NOAA LNDARE fix** — see [NOAA ENC quirks](docs/noaa-enc-quirks.md) for what it does and when to disable it
+5. Enable the plugin
+6. Restart Signal K server (first-time install only — later config changes hot-apply on Save without a full restart)
 
 ### CPU budget for chart conversion
 

--- a/docs/noaa-enc-quirks.md
+++ b/docs/noaa-enc-quirks.md
@@ -1,0 +1,56 @@
+# NOAA ENC quirks and how this plugin handles them
+
+NOAA US ENC charts are excellent but have a few well-known encoding quirks that catch new users off-guard. This page documents the ones the plugin currently handles, how it handles them, and how to disable that handling if you ever need to.
+
+## 1. Constructed marina basins and inland coastal lagoons render as land
+
+### What you see
+
+Locations like Michigan City Outer Basin (Indiana) or Lake Worth (Palm Beach, Florida) appear tan (land) in the renderer at high zooms, with mooring slips, soundings, and harbour facilities drawn on top — even though they are clearly water bodies with depths, names, and navigation aids.
+
+### Why
+
+NOAA encodes these areas with a coarse `LNDARE` (land area) polygon that doesn't cut a hole for the basin or lagoon, layered over a `DEPARE` (depth area) polygon that has the actual water depths. S-52 — the official chart-rendering specification all conforming renderers follow — puts land on top of water, so the basin shows as land in spite of having correct depth data underneath.
+
+This is a deliberate cell-layering choice by NOAA: high-resolution band-5 cells add harbour-tier detail (mooring facilities, slip lines, soundings, lights) on top of a coarser band-4 / band-3 LNDARE that defines the basic land-vs-water silhouette. The trade-off is that some constructed harbours and lagoons end up looking like land in renderers.
+
+### What the plugin does
+
+When the plugin's `noaaLndareCutByDepare` option is enabled (default **on**, since v1.12), the conversion pipeline runs an extra pass after GDAL exports per-chart-per-layer GeoJSON files:
+
+1. For each chart cell, pair its `LNDARE_<chart>.geojson` with its `DEPARE_<chart>.geojson`.
+2. Filter the chart's DEPARE features to those that represent water at chart datum (`DRVAL2 > 0`). This excludes drying flats and intertidal areas, which NOAA encodes the same way deliberately and which **must** stay as land.
+3. For each LNDARE polygon that overlaps a kept DEPARE, subtract the DEPARE geometry. The LNDARE polygon ends up with an interior ring (a hole) where the basin or lagoon is.
+4. Tippecanoe then sees an LNDARE with a hole and renders the basin as transparent — the underlying DEPARE shows through.
+
+The conversion log includes a counter line so you can see how many cuts were applied:
+
+```
+LNDARE cut by DEPARE: scanned 12453 land features in 680 charts; cut 84 (84 DEPARE applied, 211 skipped as drying, 0 cut failures)
+```
+
+### Limits and known edge cases
+
+- **Reclaimed land / pier extensions over historic seabed.** NOAA sometimes layers new fill (LNDARE) over a pre-existing DEPARE that hasn't been retired. With `DRVAL2 > 0` filtering most of these survive untouched, but the line between "fill that should still be land" and "basin that should be water" is fuzzy in places. If you spot a pier rendered as water, the plugin's cut almost certainly caused it — disable the option for that bundle.
+- **Cut failures on degenerate geometry.** If `@turf/difference` throws on a specific LNDARE/DEPARE pair (slivers, self-intersections, near-coincident edges), the plugin keeps the original LNDARE unchanged and increments the `cutFailures` counter. Conversion continues; the affected feature renders as it would have without the fix.
+- **Per-chart-cell scope.** The plugin only cuts LNDARE in chart A with DEPARE from chart A — never cross-cuts across cells. This keeps the operation O(N) across the bundle and avoids damaging cases where a band-3 LNDARE is intentionally drawn over a band-5 DEPARE in a different cell.
+
+### How to disable
+
+Plugin Configuration → "NOAA fix: cut basin/lagoon water out of land polygons" → uncheck. Re-convert any bundles you want rendered without the fix.
+
+You can also override per-conversion via the API by passing `noaaLndareCutByDepare: false` in `S57ConversionOptions`.
+
+### When to disable
+
+- You're seeing visual artifacts on a specific bundle — typically a pier, jetty, or fill area rendered as water that should be land.
+- You're working with non-NOAA producers (UKHO, BSH, CHS, AHO, …) where this encoding pattern doesn't apply. The fix is harmless for them — there are simply no overlapping LNDARE/DEPARE pairs to cut — but disabling saves a small amount of conversion time on big bundles.
+- You want the bit-for-bit S-57 source to render unchanged for a comparison or audit.
+
+### How to escalate a specific chart cell to NOAA
+
+If you find a cell where the basin/lagoon coding is genuinely wrong (not the cell-layering quirk this fix handles, but actually-incorrect data), NOAA accepts chart inquiries here:
+
+https://nauticalcharts.noaa.gov/customer-service/assist/
+
+Mention the cell ID (e.g. `US5CHIHV` for Michigan City) and describe the encoding issue. Turnaround is typically several weeks; corrections appear in subsequent ENC editions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.11.2",
+  "version": "1.12.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.11.2",
+      "version": "1.12.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",
+        "@turf/boolean-intersects": "^7.3.5",
+        "@turf/difference": "^7.3.5",
         "busboy": "^1.6.0",
         "dockerode": "^5.0.0",
         "unzipper": "^0.12.3",
@@ -377,6 +379,143 @@
       "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
       "license": "MIT"
     },
+    "node_modules/@turf/boolean-disjoint": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-7.3.5.tgz",
+      "integrity": "sha512-Pz1GGUC6iL6xGVqhyo+fYg35kl4j/HONMEoC1voN3DcBOCcVlzq+ljvMpvE+oQiR7Q38xLhIxZneLCqMp5YrQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/polygon-to-line": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-intersects": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-intersects/-/boolean-intersects-7.3.5.tgz",
+      "integrity": "sha512-Z6GPYjozrmTuzWQD0x7o8RPm+4HC7hz9q23hdB3U1+Qahesv8Mtc+wo82tO4CG6/NRnJ9u79DlEhmR1DxUU4iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-disjoint": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.5.tgz",
+      "integrity": "sha512-ba7+B0wzaS9GtERZOoXUZ6oW8IcIJHNQZf3c+tiD9ESjcsPO1Q/4qIJGTKl92nBLhhracHJxMWBM/U6hAVkaRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/difference": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-7.3.5.tgz",
+      "integrity": "sha512-iDyWYCvgS3vgB8W1ai2cvfJaTq9bOt1QghiVkCNIyccF97CgtYJzenREVVUlp8qU9lJlbQ/ameyKvXPA1uOAlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.3.5.tgz",
+      "integrity": "sha512-2Cl4oPsjaDdfIwz/5IRDdG2fNdfp3W6atICm81vnzl/GwURoVP+CLjXJ64QWWzpzIbgX2XprJQTmamByDt5MDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "sweepline-intersections": "^1.5.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-to-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-7.3.5.tgz",
+      "integrity": "sha512-Mat5tvJcW3grpXCNFcMvjHL3d8hO4eoIgF3qYpXj25BHx/S7SJUOgyCV5x3arC0rCfM/cB71VmNDm9k57ec7bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -469,6 +608,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
@@ -921,6 +1066,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/bl": {
@@ -1866,6 +2020,25 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/polyclip-ts": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/polyclip-ts/-/polyclip-ts-0.16.8.tgz",
+      "integrity": "sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.1.0",
+        "splaytree-ts": "^1.0.2"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -1979,6 +2152,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -2035,6 +2214,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/splaytree-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
+      "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
+      "license": "BDS-3-Clause"
     },
     "node_modules/split-ca": {
       "version": "1.0.1",
@@ -2100,6 +2285,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sweepline-intersections": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
+      "integrity": "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyqueue": "^2.0.0"
       }
     },
     "node_modules/synckit": {
@@ -2177,6 +2371,12 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -2189,6 +2389,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.11.2",
+  "version": "1.12.0-beta.1",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -34,6 +34,8 @@
   },
   "dependencies": {
     "@signalk/server-api": "^2.0.0",
+    "@turf/boolean-intersects": "^7.3.5",
+    "@turf/difference": "^7.3.5",
     "busboy": "^1.6.0",
     "dockerode": "^5.0.0",
     "unzipper": "^0.12.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,19 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             '"all" uses every core for fastest single-bundle conversion; Signal K may be sluggish during a conversion.',
           enum: ['single-core', 'half', 'all'],
           default: 'half'
+        },
+        noaaLndareCutByDepare: {
+          type: 'boolean',
+          title: 'NOAA fix: cut basin/lagoon water out of land polygons',
+          description:
+            'NOAA US ENC charts often encode marina basins and inland lagoons as land (LNDARE) ' +
+            'with the water area (DEPARE) drawn underneath. By default S-52 renderers draw land ' +
+            'on top, so these basins look tan instead of blue. When enabled (default), DEPARE ' +
+            'polygons with DRVAL2 > 0 (water at chart datum, not drying flats) are subtracted ' +
+            'from overlapping LNDARE in the same chart cell before tile generation. Drying ' +
+            'flats are left untouched. Disable if you see chart artifacts on a specific bundle. ' +
+            'See docs/noaa-enc-quirks.md.',
+          default: true
         }
       }
     }),
@@ -1392,7 +1405,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
                 (status, message) => {
                   app.debug(`Convert [${chartNumber}] ${status}: ${message}`);
                 },
-                { minzoom, maxzoom }
+                {
+                  minzoom,
+                  maxzoom,
+                  noaaLndareCutByDepare: props.noaaLndareCutByDepare !== false
+                }
               );
 
               const relativePath = path.relative(
@@ -1653,7 +1670,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           (status, message) => {
             app.debug(`S-57 [${chartNumber}] ${status}: ${message}`);
           },
-          { minzoom, maxzoom }
+          {
+            minzoom,
+            maxzoom,
+            noaaLndareCutByDepare: props.noaaLndareCutByDepare !== false
+          }
         );
 
         setConvertingState(chartNumber, false);

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export type CpuBudgetPreset = 'single-core' | 'half' | 'all';
 export interface PluginConfig {
   chartPath: string;
   cpuBudget?: CpuBudgetPreset;
+  /** Enables the NOAA LNDARE-cut-by-DEPARE fix during S-57 conversion. Default true. */
+  noaaLndareCutByDepare?: boolean;
 }
 
 // ---- Extended ServerAPI ----
@@ -230,6 +232,16 @@ export interface S57ConversionResult {
 export interface S57ConversionOptions {
   minzoom?: number;
   maxzoom?: number;
+  /**
+   * NOAA fix for the cell-layered LNDARE encoding where marina basins and
+   * inland lagoons render as land because the surrounding LNDARE polygon
+   * doesn't cut a hole for the basin. When enabled (default true), DEPARE
+   * polygons with `DRVAL2 > 0` (water at chart datum, not drying flats) are
+   * subtracted from overlapping LNDARE in the same chart cell before tile
+   * generation. Disable if the cut produces visual artifacts on a specific
+   * bundle. See docs/noaa-enc-quirks.md.
+   */
+  noaaLndareCutByDepare?: boolean;
 }
 
 export interface ContainerRuntimeStatus {

--- a/src/utils/lndare-depare-cut.ts
+++ b/src/utils/lndare-depare-cut.ts
@@ -1,0 +1,237 @@
+import fs from 'fs';
+import path from 'path';
+import { difference } from '@turf/difference';
+import { booleanIntersects } from '@turf/boolean-intersects';
+import type { Feature, FeatureCollection, Polygon, MultiPolygon } from 'geojson';
+
+type PolyFeature = Feature<Polygon | MultiPolygon, Record<string, unknown>>;
+
+export interface CutStats {
+  /** Number of LNDARE files we read (one per chart). */
+  filesScanned: number;
+  /** LNDARE files where at least one feature was modified. */
+  filesModified: number;
+  /** LNDARE features inspected across all files. */
+  lndareScanned: number;
+  /** LNDARE features that came out of `difference` mutated. */
+  lndareCut: number;
+  /** DEPARE features that contributed to a cut (DRVAL2 > 0 + intersected). */
+  depareApplied: number;
+  /** DEPARE features skipped because DRVAL2 ≤ 0 or missing. */
+  depareSkippedDrying: number;
+  /** Number of `difference` calls that threw (kept original LNDARE in those cases). */
+  cutFailures: number;
+}
+
+interface CutOptions {
+  /** Optional log callback for the per-bundle counter line. */
+  onProgress?: (msg: string) => void;
+}
+
+const LNDARE_PATTERN = /^LNDARE(?:_([^/.]+))?\.geojson$/;
+
+// Match a DEPARE filename to a chart ID; returns null when the filename doesn't
+// fit the per-chart-per-layer convention written by the GDAL export step.
+function depareFilenameForChart(chartId: string | undefined): string {
+  return chartId ? `DEPARE_${chartId}.geojson` : 'DEPARE.geojson';
+}
+
+// Read + parse a GeoJSON FeatureCollection. Throws on invalid JSON or non-FC
+// input — callers wrap; corruption here is a real bug we want to see.
+function readFC(file: string): FeatureCollection {
+  const raw = fs.readFileSync(file, 'utf8');
+  const parsed = JSON.parse(raw) as FeatureCollection;
+  if (parsed.type !== 'FeatureCollection' || !Array.isArray(parsed.features)) {
+    throw new Error(`Not a GeoJSON FeatureCollection: ${file}`);
+  }
+  return parsed;
+}
+
+// Filter DEPARE features to those that actually represent water at chart datum:
+// DRVAL2 > 0 ensures we skip drying areas (DRVAL2 ≤ 0 means at least part of the
+// polygon is exposed at low water — encoded as LNDARE-on-top deliberately by
+// chart producers, not a NOAA quirk we want to undo).
+function isCuttableDepare(feat: Feature): boolean {
+  if (!feat.geometry) {
+    return false;
+  }
+  if (feat.geometry.type !== 'Polygon' && feat.geometry.type !== 'MultiPolygon') {
+    return false;
+  }
+  const props = (feat.properties ?? {}) as Record<string, unknown>;
+  const drval2 = props['DRVAL2'];
+  if (typeof drval2 !== 'number') {
+    return false;
+  }
+  return drval2 > 0;
+}
+
+// Cut a single LNDARE feature with all overlapping cuttable DEPARE features.
+// Returns the modified feature (a Polygon with new holes, or a MultiPolygon if
+// the cut splits the LNDARE), or `null` if the cut would erase the feature
+// entirely (every part of the LNDARE is now water — rare but possible).
+//
+// Best-effort: if turf.difference throws (degenerate geometry, sliver
+// intersections, self-intersections), we return the input feature unchanged
+// and signal `cutFailed=true` to the caller. Better to render the unfixed
+// land than to crash the whole conversion.
+function cutOneLndare(
+  lndare: PolyFeature,
+  depares: PolyFeature[]
+): { feature: PolyFeature | null; cutFailed: boolean; depareApplied: number } {
+  let current: PolyFeature | null = lndare;
+  let depareApplied = 0;
+  for (const depare of depares) {
+    if (current === null) {
+      break;
+    }
+    if (!booleanIntersects(current, depare)) {
+      continue;
+    }
+    try {
+      const fc: FeatureCollection<Polygon | MultiPolygon> = {
+        type: 'FeatureCollection',
+        features: [current, depare]
+      };
+      const result = difference(fc);
+      if (result === null) {
+        // The DEPARE fully covers what's left of LNDARE. Treat as erased.
+        current = null;
+      } else {
+        current = result as PolyFeature;
+      }
+      depareApplied += 1;
+    } catch {
+      return { feature: lndare, cutFailed: true, depareApplied };
+    }
+  }
+  return { feature: current, cutFailed: false, depareApplied };
+}
+
+// Walk every LNDARE_<chart>.geojson in `geojsonDir`, locate its sibling
+// DEPARE_<chart>.geojson (same chart cell — we never cut across cells), and
+// rewrite the LNDARE file in place with each polygon cut by overlapping
+// DEPARE features that have `DRVAL2 > 0`.
+//
+// Per-chart pairing keeps this O(N) across the bundle: each chart's LNDARE ×
+// DEPARE counts are small (typically ≤30 of each) so the per-chart cost is
+// bounded. Run once after GDAL export, before consolidation.
+//
+// All failure modes are logged and counted in the returned `CutStats` —
+// nothing throws past this function. Conversions where every cut fails will
+// just emit the original LNDARE files (the pre-1.12 behaviour).
+export function cutLndareByDepare(geojsonDir: string, options: CutOptions = {}): CutStats {
+  const stats: CutStats = {
+    filesScanned: 0,
+    filesModified: 0,
+    lndareScanned: 0,
+    lndareCut: 0,
+    depareApplied: 0,
+    depareSkippedDrying: 0,
+    cutFailures: 0
+  };
+
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(geojsonDir);
+  } catch {
+    return stats;
+  }
+
+  const lndareFiles = entries.filter((e) => LNDARE_PATTERN.test(e));
+
+  for (const lndareFile of lndareFiles) {
+    stats.filesScanned += 1;
+    const match = LNDARE_PATTERN.exec(lndareFile);
+    const chartId = match?.[1];
+    const lndarePath = path.join(geojsonDir, lndareFile);
+    const deparePath = path.join(geojsonDir, depareFilenameForChart(chartId));
+
+    let lndareFC: FeatureCollection;
+    try {
+      lndareFC = readFC(lndarePath);
+    } catch {
+      continue;
+    }
+    if (lndareFC.features.length === 0) {
+      continue;
+    }
+    stats.lndareScanned += lndareFC.features.length;
+
+    if (!fs.existsSync(deparePath)) {
+      // Chart has no DEPARE — nothing to cut against.
+      continue;
+    }
+
+    let depareFC: FeatureCollection;
+    try {
+      depareFC = readFC(deparePath);
+    } catch {
+      continue;
+    }
+
+    const cuttableDepares: PolyFeature[] = [];
+    for (const dep of depareFC.features) {
+      if (isCuttableDepare(dep)) {
+        cuttableDepares.push(dep as PolyFeature);
+      } else if (dep.geometry?.type === 'Polygon' || dep.geometry?.type === 'MultiPolygon') {
+        // Only count as 'skipped drying' when it was a polygon DEPARE we
+        // could otherwise have cut with — non-polygon DEPARE entries (rare
+        // in the field) just aren't applicable to this operation.
+        stats.depareSkippedDrying += 1;
+      }
+    }
+    if (cuttableDepares.length === 0) {
+      continue;
+    }
+
+    let fileModified = false;
+    const newFeatures: Feature[] = [];
+    for (const feat of lndareFC.features) {
+      if (
+        !feat.geometry ||
+        (feat.geometry.type !== 'Polygon' && feat.geometry.type !== 'MultiPolygon')
+      ) {
+        newFeatures.push(feat);
+        continue;
+      }
+      const before = JSON.stringify(feat.geometry);
+      const result = cutOneLndare(feat as PolyFeature, cuttableDepares);
+      stats.depareApplied += result.depareApplied;
+      if (result.cutFailed) {
+        stats.cutFailures += 1;
+        newFeatures.push(feat);
+        continue;
+      }
+      if (result.feature === null) {
+        // Fully erased — drop it from the output.
+        fileModified = true;
+        stats.lndareCut += 1;
+        continue;
+      }
+      const after = JSON.stringify(result.feature.geometry);
+      if (after !== before) {
+        fileModified = true;
+        stats.lndareCut += 1;
+      }
+      newFeatures.push(result.feature);
+    }
+
+    if (fileModified) {
+      stats.filesModified += 1;
+      const out: FeatureCollection = {
+        type: 'FeatureCollection',
+        features: newFeatures
+      };
+      fs.writeFileSync(lndarePath, JSON.stringify(out));
+    }
+  }
+
+  options.onProgress?.(
+    `LNDARE cut by DEPARE: scanned ${stats.lndareScanned} land features in ${stats.filesScanned} charts; ` +
+      `cut ${stats.lndareCut} (${stats.depareApplied} DEPARE applied, ` +
+      `${stats.depareSkippedDrying} skipped as drying, ${stats.cutFailures} cut failures)`
+  );
+
+  return stats;
+}

--- a/src/utils/lndare-depare-cut.ts
+++ b/src/utils/lndare-depare-cut.ts
@@ -58,8 +58,7 @@ function isCuttableDepare(feat: Feature): boolean {
   if (feat.geometry.type !== 'Polygon' && feat.geometry.type !== 'MultiPolygon') {
     return false;
   }
-  const props = (feat.properties ?? {}) as Record<string, unknown>;
-  const drval2 = props['DRVAL2'];
+  const drval2: unknown = feat.properties?.['DRVAL2'];
   if (typeof drval2 !== 'number') {
     return false;
   }

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -10,6 +10,7 @@ import {
   runContainer
 } from './container-runtime';
 import { BAND_MIN_ZOOM, bandClampedMaxzoom, highestBandForFiles } from './s57-band';
+import { cutLndareByDepare } from './lndare-depare-cut';
 import type {
   ConversionProgress,
   ConversionProgressMap,
@@ -526,6 +527,24 @@ export async function processS57Zip(
     appendLog(chartNumber, `Exporting ${encFiles.length} ENC files in single GDAL container...`);
 
     await exportAllLayersToGeoJSON(encDir, encFiles, geojsonDir, chartNumber);
+
+    // NOAA fix: cut DEPARE water out of overlapping LNDARE in the same chart
+    // cell so marina basins / inland lagoons render as water. Default-on; can
+    // be disabled per-bundle via S57ConversionOptions.noaaLndareCutByDepare.
+    if (options.noaaLndareCutByDepare !== false) {
+      try {
+        cutLndareByDepare(geojsonDir, {
+          onProgress: (msg) => {
+            debug(msg);
+            appendLog(chartNumber, msg);
+          }
+        });
+      } catch (err) {
+        const m = err instanceof Error ? err.message : String(err);
+        debug(`LNDARE cut pass failed (continuing without it): ${m}`);
+        appendLog(chartNumber, `LNDARE cut pass failed (continuing without it): ${m}`);
+      }
+    }
 
     statusFn('converting', 'Generating vector tiles...');
     setProgress(chartNumber, 'converting', 'Generating vector tiles with tippecanoe...');

--- a/test/lndare-depare-cut.test.js
+++ b/test/lndare-depare-cut.test.js
@@ -1,0 +1,211 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { cutLndareByDepare } = require('../dist/utils/lndare-depare-cut');
+
+function writeFC(p, features) {
+  fs.writeFileSync(p, JSON.stringify({ type: 'FeatureCollection', features }));
+}
+
+function readFC(p) {
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function poly(coords, props = {}) {
+  return {
+    type: 'Feature',
+    properties: props,
+    geometry: { type: 'Polygon', coordinates: coords }
+  };
+}
+
+// 0..10 square, used as "land that surrounds a basin"
+const LAND_SQUARE = [
+  [
+    [0, 0],
+    [10, 0],
+    [10, 10],
+    [0, 10],
+    [0, 0]
+  ]
+];
+
+// 3..7 inner square, used as "basin water inside the land"
+const BASIN_SQUARE = [
+  [
+    [3, 3],
+    [7, 3],
+    [7, 7],
+    [3, 7],
+    [3, 3]
+  ]
+];
+
+describe('cutLndareByDepare', () => {
+  let tmp;
+
+  before(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-lndare-cut-'));
+  });
+
+  after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('cuts a basin (DRVAL2 > 0) out of an enclosing LNDARE polygon', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'basin-'));
+    writeFC(path.join(dir, 'LNDARE_US5MA1SK.geojson'), [poly(LAND_SQUARE, { OBJNAM: 'island' })]);
+    writeFC(path.join(dir, 'DEPARE_US5MA1SK.geojson'), [
+      poly(BASIN_SQUARE, { DRVAL1: 0, DRVAL2: 1.8 })
+    ]);
+
+    const stats = cutLndareByDepare(dir);
+
+    assert.strictEqual(stats.lndareCut, 1, 'one LNDARE feature was modified');
+    assert.strictEqual(stats.depareApplied, 1, 'one DEPARE was applied');
+    assert.strictEqual(stats.cutFailures, 0);
+
+    const lndare = readFC(path.join(dir, 'LNDARE_US5MA1SK.geojson'));
+    assert.strictEqual(lndare.features.length, 1);
+    const g = lndare.features[0].geometry;
+    assert.strictEqual(g.type, 'Polygon', 'difference produced a single polygon (with a hole)');
+    assert.strictEqual(g.coordinates.length, 2, 'exterior + 1 hole = 2 rings');
+    assert.deepStrictEqual(g.coordinates[0][0], [0, 0], 'exterior ring preserved');
+  });
+
+  it('skips DEPARE features whose DRVAL2 <= 0 (drying flats stay land)', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'drying-'));
+    writeFC(path.join(dir, 'LNDARE_US5MA1SK.geojson'), [poly(LAND_SQUARE, { OBJNAM: 'flats' })]);
+    writeFC(path.join(dir, 'DEPARE_US5MA1SK.geojson'), [
+      poly(BASIN_SQUARE, { DRVAL1: 0, DRVAL2: 0 })
+    ]);
+
+    const stats = cutLndareByDepare(dir);
+
+    assert.strictEqual(stats.lndareCut, 0);
+    assert.strictEqual(stats.depareApplied, 0);
+    assert.strictEqual(stats.depareSkippedDrying, 1);
+
+    const lndare = readFC(path.join(dir, 'LNDARE_US5MA1SK.geojson'));
+    const g = lndare.features[0].geometry;
+    assert.strictEqual(g.coordinates.length, 1, 'no hole was added');
+  });
+
+  it('skips DEPARE features that lack DRVAL2 (defensive — never guess)', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'no-drval2-'));
+    writeFC(path.join(dir, 'LNDARE_US5MA1SK.geojson'), [poly(LAND_SQUARE)]);
+    writeFC(path.join(dir, 'DEPARE_US5MA1SK.geojson'), [poly(BASIN_SQUARE, { DRVAL1: 0 })]);
+
+    const stats = cutLndareByDepare(dir);
+    assert.strictEqual(stats.lndareCut, 0);
+    assert.strictEqual(stats.depareSkippedDrying, 1);
+  });
+
+  it('does nothing when LNDARE and DEPARE do not overlap', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'no-overlap-'));
+    writeFC(path.join(dir, 'LNDARE_US5MA1SK.geojson'), [poly(LAND_SQUARE)]);
+    writeFC(path.join(dir, 'DEPARE_US5MA1SK.geojson'), [
+      poly(
+        [
+          [
+            [100, 100],
+            [110, 100],
+            [110, 110],
+            [100, 110],
+            [100, 100]
+          ]
+        ],
+        { DRVAL2: 1.8 }
+      )
+    ]);
+
+    const stats = cutLndareByDepare(dir);
+    assert.strictEqual(stats.lndareCut, 0);
+    assert.strictEqual(stats.depareApplied, 0);
+
+    const lndare = readFC(path.join(dir, 'LNDARE_US5MA1SK.geojson'));
+    assert.strictEqual(lndare.features[0].geometry.coordinates.length, 1);
+  });
+
+  it('handles charts that have LNDARE but no DEPARE file (no-op)', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'no-depare-'));
+    writeFC(path.join(dir, 'LNDARE_US5MA1SK.geojson'), [poly(LAND_SQUARE)]);
+    // Intentionally no DEPARE file written.
+
+    const stats = cutLndareByDepare(dir);
+    assert.strictEqual(stats.filesScanned, 1);
+    assert.strictEqual(stats.lndareCut, 0);
+    assert.strictEqual(stats.depareApplied, 0);
+  });
+
+  it('only pairs LNDARE and DEPARE from the same chart cell', () => {
+    // Two charts in the same dir. Chart A has LNDARE that LOOKS like it could
+    // be cut by chart B's DEPARE if we cross-paired charts. We must not — bands
+    // and chart geometries differ across cells, so cross-cutting would silently
+    // damage data.
+    const dir = fs.mkdtempSync(path.join(tmp, 'cross-chart-'));
+    writeFC(path.join(dir, 'LNDARE_CHARTA.geojson'), [poly(LAND_SQUARE)]);
+    writeFC(path.join(dir, 'DEPARE_CHARTB.geojson'), [poly(BASIN_SQUARE, { DRVAL2: 1.8 })]);
+
+    const stats = cutLndareByDepare(dir);
+    assert.strictEqual(stats.lndareCut, 0, 'no cuts because A and B do not pair');
+    assert.strictEqual(stats.depareApplied, 0);
+  });
+
+  it('writes the file in place and preserves features that were not cut', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'mixed-'));
+    const cuttable = poly(LAND_SQUARE, { OBJNAM: 'with-basin' });
+    const untouched = poly(
+      [
+        [
+          [50, 50],
+          [60, 50],
+          [60, 60],
+          [50, 60],
+          [50, 50]
+        ]
+      ],
+      { OBJNAM: 'far-island' }
+    );
+    writeFC(path.join(dir, 'LNDARE_US5MA1SK.geojson'), [cuttable, untouched]);
+    writeFC(path.join(dir, 'DEPARE_US5MA1SK.geojson'), [poly(BASIN_SQUARE, { DRVAL2: 1.8 })]);
+
+    const stats = cutLndareByDepare(dir);
+    assert.strictEqual(stats.lndareCut, 1);
+
+    const lndare = readFC(path.join(dir, 'LNDARE_US5MA1SK.geojson'));
+    assert.strictEqual(lndare.features.length, 2);
+    const cut = lndare.features.find((f) => f.properties?.OBJNAM === 'with-basin');
+    const same = lndare.features.find((f) => f.properties?.OBJNAM === 'far-island');
+    assert.strictEqual(cut.geometry.coordinates.length, 2, 'first feature got a hole');
+    assert.strictEqual(same.geometry.coordinates.length, 1, 'second feature unchanged');
+  });
+
+  it('reports a per-bundle progress line via onProgress', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'progress-'));
+    writeFC(path.join(dir, 'LNDARE_US5MA1SK.geojson'), [poly(LAND_SQUARE)]);
+    writeFC(path.join(dir, 'DEPARE_US5MA1SK.geojson'), [poly(BASIN_SQUARE, { DRVAL2: 1.8 })]);
+
+    const messages = [];
+    cutLndareByDepare(dir, { onProgress: (m) => messages.push(m) });
+    assert.strictEqual(messages.length, 1);
+    assert.match(messages[0], /LNDARE cut by DEPARE: scanned/);
+    assert.match(messages[0], /cut 1/);
+  });
+
+  it('returns zeroed stats when the directory does not exist (best-effort)', () => {
+    const stats = cutLndareByDepare(path.join(tmp, 'definitely-not-here'));
+    assert.deepStrictEqual(stats, {
+      filesScanned: 0,
+      filesModified: 0,
+      lndareScanned: 0,
+      lndareCut: 0,
+      depareApplied: 0,
+      depareSkippedDrying: 0,
+      cutFailures: 0
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds an opt-out conversion-time pass that subtracts overlapping water polygons (DEPARE) from land polygons (LNDARE) in the same chart cell, fixing the well-known NOAA encoding where marina basins and inland coastal lagoons render as land. Cut as **1.12.0-beta.1** for wider field testing before promoting to stable.

## Why
NOAA's US ENC encoding for constructed marina basins (Michigan City Outer Basin) and inland coastal lagoons (Lake Worth, Palm Beach) uses a coarse LNDARE polygon that doesn't cut a hole for the water body, layered over a DEPARE that has the actual depths. S-52 correctly draws land on top, so these basins render as tan instead of blue in conforming renderers (Freeboard-SK, MapLibre with S-52 styling, OpenCPN). The data is correct for navigation — depths, soundings, harbour facilities all present — only the visual is wrong.

## What changes

### New conversion pass
After the GDAL per-layer export, before consolidation:

```
for each chart cell:
  pair LNDARE_<chart>.geojson with DEPARE_<chart>.geojson
  keep only DEPARE features with DRVAL2 > 0  (skip drying flats)
  for each LNDARE polygon overlapping a kept DEPARE:
    LNDARE := turf.difference(LNDARE, DEPARE)
```

The **`DRVAL2 > 0` filter is the key safety property**: drying areas (and intertidal flats more generally) carry `DRVAL2 ≤ 0` by S-57 convention, so they are deliberately encoded as land-on-top and must stay that way. The fix specifically targets the cell-layered LNDARE quirk and leaves drying-flat encoding untouched.

### Per-cell scope
Per-chart pairing keeps the operation **O(N)**: chart A's LNDARE is only cut with chart A's DEPARE, never with chart B's. This avoids damaging cases where a band-3 LNDARE is intentionally drawn over a band-5 DEPARE in a different cell.

### Best-effort
`@turf/difference` exceptions on degenerate geometry (slivers, self-intersections) are caught, counted as `cutFailures` in the per-bundle stats line, and the original LNDARE is kept unchanged. The conversion log includes a counter:

```
LNDARE cut by DEPARE: scanned 12453 land features in 680 charts; cut 84 (84 DEPARE applied, 211 skipped as drying, 0 cut failures)
```

### User-visible config
Plugin schema gets a new boolean `noaaLndareCutByDepare` (default **true**). Plumbed through `S57ConversionOptions`. Disable it per-bundle by re-converting with the option off.

### Documentation
New `docs/noaa-enc-quirks.md` explains:
- What the fix does and the encoding it handles.
- The DRVAL2 > 0 safety property.
- Edge cases (reclaimed-land / pier-fill) where it might still get something wrong.
- How and when to disable.
- How to escalate genuinely-incorrect cells to NOAA.

README links to it from the Configuration section.

## Tested
- `npm run format:check && npm run build && npm test` — 125/125 pass (was 116).
- 9 new tests cover the basin-cut happy path, drying-flat preservation (`DRVAL2 ≤ 0` and `DRVAL2` missing — defensive: never guess), no-overlap no-op, no-DEPARE-file no-op, per-cell scope (no cross-chart cutting), in-place file write preserving uncut features, the per-bundle progress message, and the best-effort missing-directory case.
- Field test on a real NOAA bundle (Florida or Indiana) is the next step before promoting to 1.12.0 stable — that's why this is `-beta.1`.

## Dependencies
Adds `@turf/difference` and `@turf/boolean-intersects` (~1MB combined, no transitive native deps).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable NOAA ENC rendering fix (enabled by default) to improve display of marina basins and coastal lagoons; can be toggled per conversion.

* **Documentation**
  * Installation instructions updated to show the optional config step and restart behavior.
  * Added detailed docs describing the NOAA ENC quirk, limits, and how to disable or escalate issues.

* **Tests**
  * Added tests covering the new cut/repair behavior and edge cases.

* **Chores**
  * Package version bumped to 1.12.0-beta.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->