### PR TITLE
fix(diagnostics): keep marker schema stable on Windows (1.12.0-beta.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.0-beta.1",
+  "version": "1.12.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.12.0-beta.1",
+      "version": "1.12.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.0-beta.1",
+  "version": "1.12.0-beta.2",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/path-marker.ts
+++ b/src/utils/path-marker.ts
@@ -6,10 +6,10 @@ export const MARKER_FILENAME = '.charts-provider-marker.json';
 export interface ContainerHints {
   /** Whether well-known container indicator files exist on the running filesystem. */
   isLikelyContainer: boolean;
-  /** $HOME at startup, useful when comparing host vs in-container paths. */
-  homeEnv: string | undefined;
-  /** Effective UID, useful when explaining permission mismatches with the host. */
-  uid: number | undefined;
+  /** $HOME at startup, useful when comparing host vs in-container paths. `null` when unset. */
+  homeEnv: string | null;
+  /** Effective UID, useful when explaining permission mismatches. `null` on platforms without `process.getuid` (Windows). */
+  uid: number | null;
 }
 
 export interface ChartPathMarker {
@@ -30,10 +30,16 @@ export function detectContainerHints(): ContainerHints {
   } catch {
     isLikelyContainer = false;
   }
-  const uid = typeof process.getuid === 'function' ? process.getuid() : undefined;
+  // Use `null` (not `undefined`) for missing values so JSON.stringify keeps
+  // the keys in the marker file. The marker is a documented schema —
+  // tooling consumers shouldn't have to handle "key sometimes absent" on
+  // platforms where the value can't be obtained (Windows lacks
+  // `process.getuid`; `$HOME` may be unset in stripped environments).
+  const uid: number | null = typeof process.getuid === 'function' ? process.getuid() : null;
+  const homeEnv: string | null = process.env.HOME ?? null;
   return {
     isLikelyContainer,
-    homeEnv: process.env.HOME,
+    homeEnv,
     uid
   };
 }

--- a/test/path-marker.test.js
+++ b/test/path-marker.test.js
@@ -99,12 +99,39 @@ describe('detectContainerHints', () => {
     const hints = detectContainerHints();
     assert.deepStrictEqual(Object.keys(hints).sort(), ['homeEnv', 'isLikelyContainer', 'uid']);
     assert.strictEqual(typeof hints.isLikelyContainer, 'boolean');
-    // homeEnv may be undefined in unusual environments; uid undefined on Windows.
-    if (hints.homeEnv !== undefined) {
-      assert.strictEqual(typeof hints.homeEnv, 'string');
-    }
-    if (hints.uid !== undefined) {
-      assert.strictEqual(typeof hints.uid, 'number');
+    // homeEnv is `null` when $HOME is unset; uid is `null` on Windows
+    // (process.getuid is undefined there). Either way, the keys are always
+    // present so the marker schema is platform-stable.
+    assert.ok(
+      hints.homeEnv === null || typeof hints.homeEnv === 'string',
+      `homeEnv must be string|null, got ${typeof hints.homeEnv}`
+    );
+    assert.ok(
+      hints.uid === null || typeof hints.uid === 'number',
+      `uid must be number|null, got ${typeof hints.uid}`
+    );
+  });
+
+  it('emits explicit null (not undefined) when uid or homeEnv is unavailable', () => {
+    // Regression guard for Windows: Node has no `process.getuid` there, so
+    // the previous implementation produced `uid: undefined`, and
+    // JSON.stringify dropped the key from the marker file. The schema must
+    // be stable across platforms, so the helper must coerce to `null` and
+    // the marker must round-trip through JSON with all three keys present.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-charts-marker-stable-'));
+    try {
+      const written = writeChartPathMarker(dir, '1.0.0');
+      const parsed = JSON.parse(fs.readFileSync(written, 'utf8'));
+      assert.deepStrictEqual(Object.keys(parsed.containerHints).sort(), [
+        'homeEnv',
+        'isLikelyContainer',
+        'uid'
+      ]);
+      // null is allowed; undefined is not (the latter would drop the key).
+      assert.notStrictEqual(parsed.containerHints.uid, undefined);
+      assert.notStrictEqual(parsed.containerHints.homeEnv, undefined);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## Summary
Fixes the path-marker schema instability on Windows that surfaced after the 1.12.0-beta.1 publish (Signal K plugin CI's Windows runners flagged it). Bumps to **1.12.0-beta.2**. Carries the LNDARE-cut fix from beta.1 unchanged.

## The bug
The marker file's documented schema includes `containerHints.uid` and `containerHints.homeEnv`. `detectContainerHints()` returned `undefined` for both when the platform couldn't supply them (e.g. `process.getuid` doesn't exist on Windows). `JSON.stringify` drops `undefined`-valued keys, so on Windows the marker file silently missed the `uid` key, and the schema regression test failed:

```
✖ persists the documented schema (version, chartPath, writtenAt, containerHints)
```

## The fix
Coerce missing values to `null` (which JSON keeps) instead of `undefined` (which it drops). Same treatment for `homeEnv` so a stripped-environment Linux box also gets a stable schema.

Type signatures change correspondingly: `string | undefined` → `string | null`, `number | undefined` → `number | null`. Internal-only API — the on-disk marker JSON shape is what's documented for tooling consumers, and that's what stays stable.

## Regression guard
New test in `test/path-marker.test.js` asserts neither `uid` nor `homeEnv` is `undefined` after a round-trip through JSON, so a future refactor can't silently revert this.

## Tested
- `npm run format:check && npm run build && npm test` — 126/126 pass (was 125).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 1.12.0-beta.2.

* **Tests**
  * Enhanced test coverage for path marker functionality with new regression tests to ensure consistent schema serialization across different platform environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->