### PR TITLE
fix(tippecanoe): preserve polygon holes at maximum zoom (1.12.0-beta.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.0-beta.2",
+  "version": "1.12.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.12.0-beta.2",
+      "version": "1.12.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.0-beta.2",
+  "version": "1.12.0-beta.3",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -435,6 +435,15 @@ async function runTippecanoe(
       '--no-tile-size-limit',
       '--no-feature-limit',
       '--detect-shared-borders',
+      // Preserve interior rings (holes) at the user's maxzoom. Tippecanoe's
+      // default tiny-polygon reduction silently drops holes that fall below
+      // a size threshold relative to the tile, which kills the basin/lagoon
+      // cut-outs we just made — a 300m basin at z16 has its hole removed
+      // at maxzoom even though it survives perfectly at z13..z15. This flag
+      // only affects the highest zoom, lower zooms keep the size-aware
+      // reduction (which is correct there — a basin too small to render at
+      // z12 *should* be omitted).
+      '--no-tiny-polygon-reduction-at-maximum-zoom',
       '--force',
       ...layerArgs
     ],


### PR DESCRIPTION
## Summary
Fixes a tippecanoe interaction where polygon holes (interior rings) get silently dropped at the user's maxzoom, killing the basin/lagoon cut-outs introduced in 1.12.0-beta.1. Bumps to **1.12.0-beta.3**.

## What I observed
After installing 1.12.0-beta.2 and re-converting `IN_ENCs.zip`, the Michigan City Outer Basin still appeared as land in Freeboard-SK at z16. Decoded the freshly-generated `.mbtiles` tile-by-tile over the basin coordinates:

```
z=12: 8 LNDARE features, 0 with holes  (basin too small at z12 to be a feature)
z=13: 8 LNDARE features, 1 with a hole  ← cut survived
z=14: 3 LNDARE features, 2 with holes   ← cut survived
z=15: 3 LNDARE features, 1 with a hole  ← cut survived
z=16: 3 LNDARE features, 0 with holes   ← cut DROPPED at maxzoom
```

So the cut works, the basin gets a hole, the hole carries through three zoom levels — and then disappears at the highest one, which is exactly where the user notices it.

## Cause
Tippecanoe's default tiny-polygon reduction removes interior rings whose area falls below a size threshold relative to the tile. A 300m basin at z16 trips that threshold, even though geometrically the hole is fine. (Lower zooms have a more permissive threshold relative to the larger meters-per-pixel.)

## Fix
Add `--no-tiny-polygon-reduction-at-maximum-zoom` to the tippecanoe argv. This flag only affects the highest zoom level — lower zooms keep the size-aware reduction that legitimately omits a 300m basin from a 5km z12 tile. Targeted, no other behaviour change.

## Tested
- `npm run format:check && npm run build && npm test` — 126/126 pass.
- No new tests: this is a one-flag addition to a single argv array. The behaviour is end-to-end only and tippecanoe's flag semantics are tested upstream.
- Field test (re-converting `IN_ENCs.zip` and re-decoding the basin tile) is the next step before promoting 1.12.0 to stable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced map tile generation to retain interior geographic features at maximum zoom levels.

* **Chores**
  * Version bumped to 1.12.0-beta.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->