### PR TITLE
chore(release): 1.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.0-beta.4",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.12.0-beta.4",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.0-beta.4",
+  "version": "1.12.0",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Promotes `1.12.0-beta.4` to stable. The simplification-flag change tested cleanly across NOAA Florida (680 charts) and Indiana (484 charts) bundles.

## Highlights since 1.11.2

### Coastline & polygon detail at high zoom (1.12.0-beta.4)
- Switched tippecanoe args to `--no-simplification`, `--no-tiny-polygon-reduction`, `--buffer=80` so coastline detail survives end-to-end through the user's maxzoom. Output `.mbtiles` ~30% larger but accurate at z16.
- Fixes a class of "thin features collapse to a tile-filling blob at maxzoom" regressions (rivers, lakes, narrow harbour features).

### Per-feature minzoom by IHO band (1.11.0 / 1.11.1)
- Band-5 harbour-tier S-57 layers (HRBFAC, ACHARE, BRIDGE, MORFAC, BCNLAT, BCNSPP, BUISGL, …) emit from z12.
- Band-3 coastal layers from z9, band-4 approach from z10, band-6 berthing from z14.
- Per-source-chart band detection means a single merged LNDARE file can carry mixed minzoom — band-3 features visible at z9 while band-5 detail kicks in at z12.

### Other 1.11.x changes carried forward
- Bundle-wide maxzoom clamping by highest-detected IHO band (1.10.0).
- Mixed-band harbour-tier preservation regression test (1.10.1).
- `--detect-shared-borders` for cleaner polygon edges across chart cells (1.11.0).
- Chart path marker file at startup so Docker users can verify bind-mount placement (1.11.2).
- Per-band conversion log line and chart-path resolved-path log line for self-diagnosis.
- README documents the harmless `cpu-features --ignore-scripts` warning.

## Withdrawn during beta
The `noaaLndareCutByDepare` feature shipped in 1.12.0-beta.[1-3] was withdrawn in beta.4. It turned out to be solving the wrong problem — the visual issue at high zoom was tippecanoe's default simplification destroying coastline detail, not LNDARE/DEPARE polygon overlap. The new flag combination addresses the same class of bugs (rivers, lakes, harbour detail at z16) without the dependency on `@turf` and without a user-facing toggle.

## Known limitation
A subset of NOAA-specific encodings — notably Michigan City Outer Basin (Indiana) and Lake Worth lagoon (Palm Beach, Florida) — encode the basin as solid LNDARE + adjacent DEPARE rather than land-with-hole-of-water. These render as land at z16 because of S-52's land-on-top paint order. The renderer-side fix is in upstream review at [SignalK/freeboard-sk#370](https://github.com/SignalK/freeboard-sk/pull/370) and does not gate this release.

## Tested
- `npm run format:check && npm run build && npm test` — 117/117 pass.
- Local `cr review --plain` clean on the beta.4 branch.
- End-to-end conversion of NOAA Florida (680 charts) and Indiana (484 charts) bundles, basin tiles decoded to verify coastline detail and per-band minzoom behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 1.12.0 is now available as a stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->