### PR TITLE
fix(container-runtime): Start container with the current user's UID a…

### DIFF
--- a/src/utils/container-runtime.ts
+++ b/src/utils/container-runtime.ts
@@ -16,6 +16,8 @@ export interface RunOptions {
   job?: string;
   onStdoutLine?: (line: string) => void;
   onStderrLine?: (line: string) => void;
+  /** Override the user the container runs as (format: "uid[:gid]" or "user[:group]") */
+  user?: string;
 }
 
 interface ResolvedClient {
@@ -239,6 +241,14 @@ export async function runContainer(opts: RunOptions): Promise<{ exitCode: number
   }
 
   const createOptions: Docker.ContainerCreateOptions = {
+    // By default, run the container as the current process UID:GID so files
+    // created by the container are owned by the invoking user. Allow this
+    // to be overridden via `opts.user`.
+    User:
+      opts.user ??
+      (typeof process.getuid === 'function' && typeof process.getgid === 'function'
+        ? `${process.getuid()}:${process.getgid()}`
+        : undefined),
     name: buildContainerName(opts.phase, opts.job),
     Image: opts.image,
     Cmd: opts.cmd,


### PR DESCRIPTION
…nd GUID

Containers started by the container runtime were running under the root user, resulting in root-owned files being created. This resulted in the metadata patch erroring due to permissions.

Fix: Permeate the current user's UID and GID to the container runtime, so that files created by the container runtime are owned by the current user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Containers now support user execution configuration. The container automatically defaults to the invoking process's user and group ID when not explicitly specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->