### PR TITLE
test(container): tests + 1.12.1-beta.2 bump for the host-UID fix from #43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.1-beta.1",
+  "version": "1.12.1-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.12.1-beta.1",
+      "version": "1.12.1-beta.2",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.1-beta.1",
+  "version": "1.12.1-beta.2",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/container-runtime.ts
+++ b/src/utils/container-runtime.ts
@@ -242,8 +242,15 @@ export async function runContainer(opts: RunOptions): Promise<{ exitCode: number
 
   const createOptions: Docker.ContainerCreateOptions = {
     // By default, run the container as the current process UID:GID so files
-    // created by the container are owned by the invoking user. Allow this
-    // to be overridden via `opts.user`.
+    // created by the container are owned by the invoking user. Without this
+    // (default behaviour), rootful Docker / rootful Podman would produce
+    // files owned by root on the host, which breaks anything we do
+    // afterwards that needs to write — most visibly the post-tippecanoe
+    // metadata patch, which fails with "attempt to write a readonly
+    // database". Allow this to be overridden via `opts.user` for the rare
+    // case where a container needs an explicit user. process.getuid is
+    // undefined on Windows; Docker Desktop does its own UID translation
+    // there, so we leave User unset.
     User:
       opts.user ??
       (typeof process.getuid === 'function' && typeof process.getgid === 'function'

--- a/test/container-runtime.test.js
+++ b/test/container-runtime.test.js
@@ -15,15 +15,25 @@ const SOCKET_PATH = path.join(SOCKET_DIR, 'mock.sock');
 
 let mockServer;
 let mockBehavior = 'docker';
+// Captures the most recent /containers/create body so tests can assert on it.
+let lastCreatePayload = null;
 
 function jsonResponse(res, body, status = 200) {
   res.writeHead(status, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify(body));
 }
 
+function readBody(req) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+  });
+}
+
 function startMockServer() {
   return new Promise((resolve, reject) => {
-    mockServer = http.createServer((req, res) => {
+    mockServer = http.createServer(async (req, res) => {
       const url = req.url.replace(/^\/v[0-9.]+/, '');
       if (url === '/_ping') {
         res.writeHead(200);
@@ -45,6 +55,32 @@ function startMockServer() {
           res.writeHead(500);
           res.end();
         }
+        return;
+      }
+      // Minimal /containers/create + lifecycle for runContainer's happy path.
+      if (req.method === 'POST' && url.startsWith('/containers/create')) {
+        const body = await readBody(req);
+        try {
+          lastCreatePayload = JSON.parse(body);
+        } catch {
+          lastCreatePayload = null;
+        }
+        jsonResponse(res, { Id: 'mock-container', Warnings: [] }, 201);
+        return;
+      }
+      if (req.method === 'POST' && url.match(/^\/containers\/[^/]+\/attach/)) {
+        // Hijack to a raw stream and immediately end it (no stdout/stderr).
+        res.writeHead(200, { 'Content-Type': 'application/vnd.docker.raw-stream' });
+        res.end();
+        return;
+      }
+      if (req.method === 'POST' && url.match(/^\/containers\/[^/]+\/start/)) {
+        res.writeHead(204);
+        res.end();
+        return;
+      }
+      if (req.method === 'POST' && url.match(/^\/containers\/[^/]+\/wait/)) {
+        jsonResponse(res, { StatusCode: 0 });
         return;
       }
       res.writeHead(404);
@@ -120,6 +156,58 @@ skipOnWindows('container-runtime', () => {
       const second = await runtime.checkContainerRuntime();
       assert.strictEqual(second.available, true);
       assert.strictEqual(second.engine, 'docker');
+    });
+  });
+
+  describe('runContainer()', () => {
+    beforeEach(() => {
+      mockBehavior = 'docker';
+      lastCreatePayload = null;
+    });
+
+    it('runs the container as the host process UID:GID', async () => {
+      // Day reported on Discord: containers were running as root inside,
+      // producing root-owned files on the host that the (non-root) Signal K
+      // Node process couldn't write to later — the metadata patch failed
+      // with "attempt to write a readonly database". Setting User to the
+      // host process's uid:gid makes file ownership match the consumer.
+      if (typeof process.getuid !== 'function' || typeof process.getgid !== 'function') {
+        // Defensive: this branch shouldn't be reachable on Linux/macOS but
+        // means the assertion below would be wrong on a hypothetical Node
+        // build without these calls.
+        return;
+      }
+      await runtime.runContainer({
+        image: 'busybox',
+        cmd: ['true'],
+        binds: ['/tmp/in:/input:ro']
+      });
+      assert.ok(lastCreatePayload, 'container create was called');
+      assert.strictEqual(
+        lastCreatePayload.User,
+        `${process.getuid()}:${process.getgid()}`,
+        'User must match the host UID:GID so bind-mount file ownership is correct'
+      );
+    });
+
+    it('passes through bind mounts and labels', async () => {
+      await runtime.runContainer({
+        image: 'busybox',
+        cmd: ['true'],
+        binds: ['/host:/in:ro', '/out:/out'],
+        phase: 'gdal-export',
+        job: 'IN_ENCs'
+      });
+      assert.deepStrictEqual(lastCreatePayload.HostConfig.Binds, ['/host:/in:ro', '/out:/out']);
+      assert.strictEqual(
+        lastCreatePayload.Labels['io.signalk.charts-provider.plugin'],
+        'signalk-charts-provider-simple'
+      );
+      assert.strictEqual(
+        lastCreatePayload.Labels['io.signalk.charts-provider.phase'],
+        'gdal-export'
+      );
+      assert.strictEqual(lastCreatePayload.Labels['io.signalk.charts-provider.job'], 'IN_ENCs');
     });
   });
 });


### PR DESCRIPTION
## Summary
Tests + version bump for the host-UID fix landed in #43. Bumps to **1.12.1-beta.2** so the fix can ship to npm `beta`.

## Why
PR #43 by @dleone13-terp added the actual fix: setting the container's `User` field to the invoking process's UID:GID. Same root cause we'd both diagnosed independently — Day reported the bug AND fixed it, which is great.

This PR layers on top so the behaviour is locked in by tests and so the fix can be cut as a beta release.

## What changes
- **Two new tests** in `test/container-runtime.test.js` using the existing mock-Docker-API harness. The harness already had `_ping` / `version` endpoints; this PR extends it with a minimal `/containers/create` + lifecycle so we can assert on the create payload.
  - `runs the container as the host process UID:GID` — captures the `/containers/create` POST body and asserts `User === '${getuid()}:${getgid()}'`. Locks in #43's behaviour against future refactors.
  - `passes through bind mounts and labels` — pins the rest of the create payload shape (binds, labels for plugin/phase/job).
- **Slight wording expansion** of the `User` comment in `container-runtime.ts` so the next reader knows specifically which downstream failure mode this prevents (the "attempt to write a readonly database" error from #42's loud-logging).
- **Version bump** 1.12.1-beta.1 → 1.12.1-beta.2.

## Tested
- `npm run format:check && npm run build && npm test` — 131/131 pass (was 129).
- Local `cr review --plain` — clean, no findings.

## Note on history
This PR was originally an independent implementation of the same fix; rebased onto main after #43 merged so the runtime change isn't duplicated. The remaining diff is just tests + bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Container runtime now automatically detects and applies host user/group identifiers to containers when available.

* **Tests**
  * Extended test coverage for container creation, user/group ID mapping, bind mounts, and lifecycle handling.

* **Documentation**
  * Clarified runtime behavior around user mapping on Windows and when running with rootful Docker/Podman.

* **Chores**
  * Version bumped to 1.12.1-beta.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->