### PR TITLE
fix(container): skip User flag on rootless Podman (1.12.1-beta.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.1-beta.2",
+  "version": "1.12.1-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.12.1-beta.2",
+      "version": "1.12.1-beta.3",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.1-beta.2",
+  "version": "1.12.1-beta.3",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/container-runtime.ts
+++ b/src/utils/container-runtime.ts
@@ -203,6 +203,46 @@ function sanitizeNamePart(s: string): string {
   return s.replace(/[^a-zA-Z0-9_.-]/g, '-').slice(0, 60);
 }
 
+/**
+ * Decide what (if anything) to pass as `User` on a container create.
+ *
+ * The rules differ by container runtime:
+ *
+ *   - **Rootful Docker / rootful Podman**: by default the container runs as
+ *     root inside, so anything it writes through a bind mount comes back
+ *     owned by `root:root` on the host. The (non-root) Signal K Node
+ *     process then can't open that file for writing — sqlite reports
+ *     "attempt to write a readonly database" when the post-tippecanoe
+ *     metadata patcher tries to fix `type=overlay`. Forcing
+ *     `User=<uid>:<gid>` makes the container write as the invoking user
+ *     directly, so file ownership is correct from the start.
+ *
+ *   - **Rootless Podman**: setting `User=<uid>:<gid>` *breaks* writes.
+ *     Rootless Podman runs in a user namespace where the host's UID is
+ *     mapped to root inside; bind-mounted directories are visible as
+ *     `root:root` from inside the namespace. Adding `--user 1000:1000`
+ *     forces the in-container process to a UID that doesn't own the
+ *     bind-mount, so `ogr2ogr` fails with `Permission denied`. Without
+ *     the flag, Podman's namespace already maps the container's root back
+ *     to the host user — files come out owned correctly.
+ *
+ *   - **Windows**: `process.getuid` is undefined; Docker Desktop does its
+ *     own UID translation. Leave User unset.
+ *
+ * Detection: rootless Podman uses a per-user socket at
+ * `/run/user/<uid>/podman/podman.sock`. Anything else (including rootful
+ * Podman at `/run/podman/podman.sock`) falls into the "set User" branch.
+ */
+export function defaultContainerUser(socketPath: string | null): string | undefined {
+  if (typeof process.getuid !== 'function' || typeof process.getgid !== 'function') {
+    return undefined;
+  }
+  if (socketPath && /\/run\/user\/\d+\/podman\/podman\.sock$/.test(socketPath)) {
+    return undefined;
+  }
+  return `${process.getuid()}:${process.getgid()}`;
+}
+
 function buildContainerName(
   phase: string | undefined,
   job: string | undefined
@@ -241,21 +281,7 @@ export async function runContainer(opts: RunOptions): Promise<{ exitCode: number
   }
 
   const createOptions: Docker.ContainerCreateOptions = {
-    // By default, run the container as the current process UID:GID so files
-    // created by the container are owned by the invoking user. Without this
-    // (default behaviour), rootful Docker / rootful Podman would produce
-    // files owned by root on the host, which breaks anything we do
-    // afterwards that needs to write — most visibly the post-tippecanoe
-    // metadata patch, which fails with "attempt to write a readonly
-    // database". Allow this to be overridden via `opts.user` for the rare
-    // case where a container needs an explicit user. process.getuid is
-    // undefined on Windows; Docker Desktop does its own UID translation
-    // there, so we leave User unset.
-    User:
-      opts.user ??
-      (typeof process.getuid === 'function' && typeof process.getgid === 'function'
-        ? `${process.getuid()}:${process.getgid()}`
-        : undefined),
+    User: opts.user ?? defaultContainerUser(resolved.socketPath),
     name: buildContainerName(opts.phase, opts.job),
     Image: opts.image,
     Cmd: opts.cmd,

--- a/test/container-runtime.test.js
+++ b/test/container-runtime.test.js
@@ -165,16 +165,15 @@ skipOnWindows('container-runtime', () => {
       lastCreatePayload = null;
     });
 
-    it('runs the container as the host process UID:GID', async () => {
-      // Day reported on Discord: containers were running as root inside,
+    it('runs the container as the host process UID:GID against a Docker-style socket', async () => {
+      // Original symptom (Day on Discord): containers ran as root inside,
       // producing root-owned files on the host that the (non-root) Signal K
       // Node process couldn't write to later — the metadata patch failed
       // with "attempt to write a readonly database". Setting User to the
       // host process's uid:gid makes file ownership match the consumer.
+      // The mock socket here lives under /tmp (not a /run/user/<uid>/podman
+      // path), so it's treated as Docker / rootful Podman.
       if (typeof process.getuid !== 'function' || typeof process.getgid !== 'function') {
-        // Defensive: this branch shouldn't be reachable on Linux/macOS but
-        // means the assertion below would be wrong on a hypothetical Node
-        // build without these calls.
         return;
       }
       await runtime.runContainer({
@@ -188,6 +187,77 @@ skipOnWindows('container-runtime', () => {
         `${process.getuid()}:${process.getgid()}`,
         'User must match the host UID:GID so bind-mount file ownership is correct'
       );
+    });
+
+    it('honours an explicit opts.user override', async () => {
+      await runtime.runContainer({
+        image: 'busybox',
+        cmd: ['true'],
+        user: '0:0'
+      });
+      assert.strictEqual(lastCreatePayload.User, '0:0');
+    });
+
+    describe('defaultContainerUser()', () => {
+      // Direct unit tests on the helper — easier than smuggling a fake
+      // socket path through the mock-Docker harness. The function is
+      // exported precisely so it's testable in isolation.
+      it('returns uid:gid for a Docker socket path', () => {
+        if (typeof process.getuid !== 'function') {
+          return;
+        }
+        const got = runtime.defaultContainerUser('/var/run/docker.sock');
+        assert.strictEqual(got, `${process.getuid()}:${process.getgid()}`);
+      });
+
+      it('returns uid:gid for a rootful-Podman socket path', () => {
+        if (typeof process.getuid !== 'function') {
+          return;
+        }
+        const got = runtime.defaultContainerUser('/run/podman/podman.sock');
+        assert.strictEqual(got, `${process.getuid()}:${process.getgid()}`);
+      });
+
+      it('returns undefined for a rootless-Podman socket (skip User)', () => {
+        // Rootless Podman maps the host user to root inside its user
+        // namespace; bind-mounted dirs appear root-owned to the in-container
+        // process. Forcing --user uid:gid in that namespace breaks
+        // bind-mount writes ("Permission denied" from ogr2ogr). Without
+        // the flag, Podman maps writes back to the host user correctly.
+        const got = runtime.defaultContainerUser(
+          `/run/user/${process.getuid?.() ?? 1000}/podman/podman.sock`
+        );
+        assert.strictEqual(got, undefined);
+      });
+
+      it('returns undefined when getuid is not available (Windows etc.)', () => {
+        // Stub out getuid to mimic a runtime without it. Restore after.
+        const origUid = process.getuid;
+        Object.defineProperty(process, 'getuid', { value: undefined, configurable: true });
+        try {
+          assert.strictEqual(runtime.defaultContainerUser('/var/run/docker.sock'), undefined);
+        } finally {
+          Object.defineProperty(process, 'getuid', { value: origUid, configurable: true });
+        }
+      });
+
+      it('returns uid:gid when socketPath is null (defensive fall-through)', () => {
+        if (typeof process.getuid !== 'function') {
+          return;
+        }
+        // The runContainer codepath only ever calls this helper after
+        // resolveClient() succeeds, so socketPath is never null in
+        // practice. If a future caller invokes it with null, we fall
+        // through to the Docker-style default — that's the strictly
+        // more common runtime, and a Docker user with root-owned files
+        // is exactly the bug we're solving. Rootless-Podman users on
+        // an unrecognised socket path are an unreachable edge today;
+        // we revisit if it shows up.
+        assert.strictEqual(
+          runtime.defaultContainerUser(null),
+          `${process.getuid()}:${process.getgid()}`
+        );
+      });
     });
 
     it('passes through bind mounts and labels', async () => {


### PR DESCRIPTION
## Summary
**Regression fix for #43 / #44.** Setting `User=<uid>:<gid>` on container create — which Day's #43 added to fix root-owned files on Docker — breaks rootless Podman, which is what most Signal K appstore installs use. Bumps to **1.12.1-beta.3**.

## What broke
A user reported a fresh conversion under 1.12.1-beta.2 failing with:

```
PROGRESS: Export complete
S-57 ENC conversion: failed (No valid GeoJSON layers to process)
```

i.e. GDAL ran, declared "Export complete", but produced zero output files. Reproduced locally:

```
$ podman run --rm --user 1000:1000 \
    -v /tmp/uid-debug/in:/input:ro \
    -v /tmp/uid-debug/out:/output \
    ghcr.io/osgeo/gdal:alpine-small-latest \
    ogr2ogr -f GeoJSON /output/LNDARE.geojson /input/US5CHIHV/US5CHIHV.000 LNDARE
ERROR 4: Failed to create GeoJSON datasource: /output/LNDARE.geojson: Permission denied
```

In rootless Podman, the host UID is mapped to root *inside* the user namespace; bind-mounted directories appear as `root:root` from the in-container view. Adding `--user 1000:1000` forces the in-container process to a UID that doesn't own the bind-mount root, and ogr2ogr can't write.

Without `--user`, rootless Podman maps the in-container root back to the host user — files come back owned correctly without us doing anything.

## The fix
Detect rootless Podman by socket path and skip the `User` flag for it. Everything else keeps Day's fix.

| Runtime | Socket | User |
|---|---|---|
| Rootless Podman | `/run/user/<uid>/podman/podman.sock` | unset (namespace handles it) |
| Rootful Podman | `/run/podman/podman.sock` | `<uid>:<gid>` |
| Docker | `/var/run/docker.sock` | `<uid>:<gid>` |
| Windows / no `getuid` | n/a | unset |

New exported helper `defaultContainerUser(socketPath)` carries the logic. `runContainer` calls it instead of inlining. The `opts.user` override path (from #43) is preserved.

## Tested
- `npm run format:check && npm run build && npm test` — 137/137 pass (was 131).
- 6 new unit tests on `defaultContainerUser` covering: Docker socket, rootless Podman socket, rootful Podman socket, no `getuid` (Windows), null socketPath (defensive fall-through), and `opts.user` override.
- Local `cr review --plain` — 1 finding (test-name/assertion mismatch I'd introduced); fixed in the same commit.
- Reproduction of the original failure → fix verified end-to-end against a real rootless Podman + ghcr.io/osgeo/gdal:alpine-small-latest container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container runtime user detection and configuration. The system now intelligently identifies the container runtime environment in use (Docker, rootful Podman, or rootless Podman) and applies the appropriate user settings to ensure better compatibility and more reliable container execution across different setups.

* **Chores**
  * Package version updated to 1.12.1-beta.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->