### PR TITLE
chore(release): 1.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.1-beta.3",
+  "version": "1.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.12.1-beta.3",
+      "version": "1.12.1",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.1-beta.3",
+  "version": "1.12.1",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Promotes `1.12.1-beta.3` to stable. End-to-end verified against the NOAA Indiana ENC bundle (484 charts) on rootless Podman: 256 MB output, owned by the host user, `type=S-57` + `name=S-57 IN_ENCs` set as exactly one row each.

## Highlights since 1.12.0

### Metadata patch finally works (#42, beta.1)
Tippecanoe's `metadata` table has no UNIQUE constraint on `name`, so our `INSERT OR REPLACE` appended instead of replacing. Files ended up with two rows for `type` (tippecanoe's `overlay` plus our `S-57`) and SELECT order decided which downstream consumers saw. Fixed by switching to `DELETE` + `INSERT` inside a transaction, with verify-after-write and a single retry on transient failure. Also self-heals files written by the broken patcher in earlier versions.

### Container ownership fix (#43, beta.2 — by @dleone13-terp)
Conversion containers ran as root inside, producing root-owned files on the host. The non-root Signal K Node process then couldn't write the metadata patch — sqlite reported "attempt to write a readonly database". Setting `User=<uid>:<gid>` on container create makes file ownership match the consumer.

### Rootless-Podman regression fix (#45, beta.3)
The `User` flag from beta.2 broke rootless Podman: in Podman's user namespace the host UID is mapped to root inside, and forcing `User=<uid>:<gid>` makes the in-container process a UID that doesn't own the bind-mount. Detect rootless Podman by socket path (`/run/user/<uid>/podman/podman.sock`) and skip the flag for that runtime; everything else (Docker, rootful Podman, Docker Desktop) keeps the User flag.

### Loud failure logging (#42, beta.1)
Previous versions caught failures from the metadata patcher into `app.debug()` so they were invisible by default. The patcher now logs through both `appendLog` (visible in the conversion UI) and `console.warn` (server stdout regardless of debug flag). This is what surfaced the root-cause for the container ownership fix above.

## Tested
- `npm run format:check && npm run build && npm test` — 137/137 pass (was 117 in 1.12.0).
- 8 new tests across the helper boundaries: happy path, drying-flat preservation, duplicate-row regression guard, self-heal of files written by older patcher, transaction-rollback shape, throwing `onMessage`/sleep callbacks, `runContainer` `User` wiring, and `defaultContainerUser` runtime detection.
- Local end-to-end: NOAA Indiana ENC bundle conversion succeeds, file is ~256 MB owned by `dirk:dirk`, metadata is `type=S-57` / `name=S-57 IN_ENCs` with one row each.
- Local `cr review --plain` was clean on each beta as it landed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 1.12.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->