### PR TITLE
chore(release): 1.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Version bump 1.12.1 → 1.12.2
- No runtime code changes since 1.12.1
- Picks up dev-deps refresh (eslint 10.3.0, typescript-eslint 8.59.1, #47) and CLAUDE.md addition (#48)

After merge, tag `v1.12.2` to trigger the publish workflow (GitHub Release + npm publish).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump: Incremented patch version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->