### PR TITLE
fix(converter): flatten S-57 list-type properties for MVT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.12.2",
+      "version": "1.12.3",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -309,8 +309,9 @@ function consolidateGeoJSONByLayer(geojsonDir: string, userMinzoom: number): Con
         if (!first) {
           fs.writeSync(handle, ',\n');
         }
+        const flattened = flattenListProperties(feat);
         const stamped =
-          featureMinzoom !== null ? withTippecanoeMinzoom(feat, featureMinzoom) : feat;
+          featureMinzoom !== null ? withTippecanoeMinzoom(flattened, featureMinzoom) : flattened;
         fs.writeSync(handle, JSON.stringify(stamped));
         first = false;
       }
@@ -321,6 +322,34 @@ function consolidateGeoJSONByLayer(geojsonDir: string, userMinzoom: number): Con
   }
 
   return consolidated;
+}
+
+// MVT properties must be scalar (string|number|bool). GDAL emits S-57 list
+// attributes (COLOUR, STATUS, COLPAT, CATLIT, CATSPM, …) as JSON arrays;
+// tippecanoe then stringifies them as `["3"]`, which client decoders that
+// split on `,` can't read. Convert arrays to comma-separated strings so
+// downstream code can treat them uniformly.
+function flattenListProperties(feature: unknown): unknown {
+  if (typeof feature !== 'object' || feature === null) {
+    return feature;
+  }
+  const f = feature as Record<string, unknown>;
+  const props = f.properties;
+  if (typeof props !== 'object' || props === null) {
+    return feature;
+  }
+  const p = props as Record<string, unknown>;
+  let changed = false;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(p)) {
+    if (Array.isArray(v)) {
+      out[k] = v.join(',');
+      changed = true;
+    } else {
+      out[k] = v;
+    }
+  }
+  return changed ? { ...f, properties: out } : feature;
 }
 
 // Stamp tippecanoe.minzoom on a single feature without mutating the input.

--- a/test/s57-converter.test.js
+++ b/test/s57-converter.test.js
@@ -149,6 +149,32 @@ describe('consolidateGeoJSONByLayer', () => {
       );
     }
   });
+
+  it('flattens GDAL list-type properties (COLOUR, STATUS, …) to comma-separated strings', () => {
+    // GDAL emits S-57 multi-value attributes (COLOUR, STATUS, COLPAT, CATLIT,
+    // CATSPM, QUASOU, …) as JSON arrays. MVT/tippecanoe can only carry scalar
+    // property values, and would stringify the array as `["3"]` — breaking
+    // client-side decoders that expect `"3"` or `"3,1"`. The consolidator
+    // flattens any array-valued property to a comma-separated string so
+    // downstream code sees a uniform shape.
+    const dir = fs.mkdtempSync(path.join(tmp, 'flatten-'));
+    writeFC(path.join(dir, 'BCNLAT.geojson'), [
+      point({ COLOUR: ['3'], STATUS: ['1'], OBJNAM: 'X', SCAMIN: 29999 }),
+      point({ COLOUR: ['3', '1', '3'], COLPAT: ['1'], OBJNAM: 'Y' }),
+      point({ OBJNAM: 'no-array' })
+    ]);
+
+    const merged = consolidateGeoJSONByLayer(dir, 9);
+    assert.strictEqual(merged.length, 1);
+    const fc = JSON.parse(fs.readFileSync(merged[0].file, 'utf8'));
+    assert.strictEqual(fc.features[0].properties.COLOUR, '3');
+    assert.strictEqual(fc.features[0].properties.STATUS, '1');
+    assert.strictEqual(fc.features[0].properties.OBJNAM, 'X');
+    assert.strictEqual(fc.features[0].properties.SCAMIN, 29999);
+    assert.strictEqual(fc.features[1].properties.COLOUR, '3,1,3');
+    assert.strictEqual(fc.features[1].properties.COLPAT, '1');
+    assert.strictEqual(fc.features[2].properties.OBJNAM, 'no-array');
+  });
 });
 
 describe('buildExportScript', () => {


### PR DESCRIPTION
## Summary

- GDAL emits S-57 multi-value attributes (COLOUR, STATUS, COLPAT, CATLIT, CATSPM, QUASOU, …) as JSON arrays in GeoJSON. MVT/tippecanoe carries only scalar property values and stringifies arrays as `[\"3\"]`, which client decoders (e.g. freeboard-sk's S-57 popover) that split on `,` cannot read.
- Flatten any array-valued property to a comma-separated string in the GeoJSON consolidator before tippecanoe sees the feature. `[\"3\"]` → `\"3\"`, `[\"3\",\"1\",\"3\"]` → `\"3,1,3\"`.
- Bumps version to 1.12.3.

## Tested

- Added unit test in `test/s57-converter.test.js` covering single-value arrays, multi-value arrays, and non-array properties passing through unchanged.
- `npm run format && npm run build && npm test` — all 138 tests pass.
- End-to-end: re-converted `IN_ENCs.zip` against a linked dev build, verified in MVT bytes that `BCNLAT.COLOUR=\"4\"`/`STATUS=\"1\"` are now scalar strings (was `\"[\\\"4\\\"]\"`/`\"[\\\"1\\\"]\"`), and freeboard-sk's popover now displays "Colour: Green / Status: Permanent" for the Michigan City Outer Basin Light.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 1.12.3 now available.

* **Improvements**
  * Multi-valued properties are now correctly formatted as comma-separated strings during data consolidation, ensuring proper downstream processing.

* **Tests**
  * Added test coverage for property formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->