### PR TITLE
fix(rnc): set tilelayer metadata via node:sqlite, not in-container sqlite3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.3",
+  "version": "1.13.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.12.3",
+      "version": "1.13.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.12.3",
+  "version": "1.13.0-beta.1",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/mbtiles-metadata.ts
+++ b/src/utils/mbtiles-metadata.ts
@@ -208,3 +208,117 @@ export async function patchS57Mbtiles(
     message: lastError || 'MBTiles metadata patch failed (unknown reason)'
   };
 }
+
+export interface SetTypeResult {
+  ok: boolean;
+  type: string | null;
+  attempts: number;
+  message: string;
+}
+
+/**
+ * Set just the `type` row in an MBTiles `metadata` table. Used by the RNC/KAP
+ * pipeline to tag the GDAL-produced MBTiles as `tilelayer` so Signal K knows
+ * to serve it as a raster tile source.
+ *
+ * Same atomicity guarantees as patchS57Mbtiles (DELETE + INSERT + verify in a
+ * transaction; one retry on transient lock). Best-effort, never throws.
+ *
+ * Replaces an earlier in-container `sqlite3` shell-out, which broke when the
+ * upstream `ghcr.io/osgeo/gdal:alpine-small-latest` image stopped including
+ * the sqlite3 CLI binary (issue #52).
+ */
+export async function setMbtilesType(
+  outputPath: string,
+  wantedType: string,
+  options: PatchOptions = {}
+): Promise<SetTypeResult> {
+  const sleeper = options.sleep ?? sleep;
+  const retryMs = options.retryDelayMs ?? DEFAULT_RETRY_MS;
+  const log = (m: string): void => {
+    try {
+      options.onMessage?.(m);
+    } catch {
+      /* best-effort logging */
+    }
+  };
+
+  if (!fs.existsSync(outputPath)) {
+    const message = `MBTiles file does not exist: ${outputPath}`;
+    log(message);
+    return { ok: false, type: null, attempts: 0, message };
+  }
+
+  const sqlite = loadSqlite();
+  if (!sqlite.ok) {
+    log(sqlite.reason);
+    return { ok: false, type: null, attempts: 0, message: sqlite.reason };
+  }
+
+  let lastError = '';
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    if (attempt === 2) {
+      log(`Retrying MBTiles type tag after ${retryMs}ms…`);
+      try {
+        await sleeper(retryMs);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log(`Sleep before retry threw (continuing): ${msg}`);
+      }
+    }
+    try {
+      const db = new sqlite.DatabaseSync(outputPath);
+      let inTransaction = false;
+      try {
+        db.exec('BEGIN TRANSACTION');
+        inTransaction = true;
+        db.exec("DELETE FROM metadata WHERE name = 'type'");
+        db.prepare("INSERT INTO metadata (name, value) VALUES ('type', ?)").run(wantedType);
+
+        const typeRow = db.prepare("SELECT value FROM metadata WHERE name = 'type'").get();
+        const gotType =
+          typeof typeRow === 'object' && typeRow !== null && 'value' in typeRow
+            ? String(typeRow.value)
+            : null;
+
+        if (gotType !== wantedType) {
+          db.exec('ROLLBACK');
+          inTransaction = false;
+          lastError = `MBTiles type tag verify failed: type='${gotType}' (wanted '${wantedType}')`;
+          log(lastError);
+          continue;
+        }
+
+        db.exec('COMMIT');
+        inTransaction = false;
+        const message =
+          attempt === 1
+            ? `Set MBTiles type=${wantedType}`
+            : `Set MBTiles type=${wantedType} on retry`;
+        log(message);
+        return { ok: true, type: gotType, attempts: attempt, message };
+      } finally {
+        if (inTransaction) {
+          try {
+            db.exec('ROLLBACK');
+          } catch {
+            /* already committed or no transaction */
+          }
+        }
+        db.close();
+      }
+    } catch (err) {
+      lastError = `MBTiles type tag failed (attempt ${attempt}/2): ${
+        err instanceof Error ? err.message : String(err)
+      }`;
+      log(lastError);
+    }
+  }
+
+  return {
+    ok: false,
+    type: null,
+    attempts: 2,
+    message: lastError || 'MBTiles type tag failed (unknown reason)'
+  };
+}

--- a/src/utils/rnc-converter.ts
+++ b/src/utils/rnc-converter.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import unzipper from 'unzipper';
 import { checkContainerRuntime, imageExists, pullImage, runContainer } from './container-runtime';
+import { setMbtilesType } from './mbtiles-metadata';
 import type {
   ConversionProgress,
   ConversionProgressMap,
@@ -288,20 +289,10 @@ export async function processRncZip(
         appendLog(chartNumber, `Warning: gdaladdo failed for ${friendly}`);
       }
 
-      const tagResult = await runContainer({
-        image: GDAL_IMAGE,
-        phase: 'sqlite-tag',
-        job: baseName,
-        cmd: [
-          'sqlite3',
-          containerOutput,
-          "INSERT OR REPLACE INTO metadata (name, value) VALUES ('type', 'tilelayer')"
-        ],
-        binds: [`${chartsDir}:/output`],
-        onStdoutLine: (line) => appendLog(chartNumber, line),
-        onStderrLine: (line) => appendLog(chartNumber, line)
+      const tagResult = await setMbtilesType(path.join(chartsDir, outputName), 'tilelayer', {
+        onMessage: (msg) => appendLog(chartNumber, msg)
       });
-      if (tagResult.exitCode !== 0) {
+      if (!tagResult.ok) {
         appendLog(chartNumber, `Warning: failed to set tilelayer metadata for ${friendly}`);
       }
 
@@ -463,20 +454,10 @@ export async function processPilotTar(
         appendLog(chartNumber, `Warning: gdaladdo failed for ${friendly}`);
       }
 
-      const tagResult = await runContainer({
-        image: GDAL_IMAGE,
-        phase: 'sqlite-tag',
-        job: baseName,
-        cmd: [
-          'sqlite3',
-          containerOutput,
-          "INSERT OR REPLACE INTO metadata (name, value) VALUES ('type', 'tilelayer')"
-        ],
-        binds: [`${chartsDir}:/output`],
-        onStdoutLine: (line) => appendLog(chartNumber, line),
-        onStderrLine: (line) => appendLog(chartNumber, line)
+      const tagResult = await setMbtilesType(path.join(chartsDir, outputName), 'tilelayer', {
+        onMessage: (msg) => appendLog(chartNumber, msg)
       });
-      if (tagResult.exitCode !== 0) {
+      if (!tagResult.ok) {
         appendLog(chartNumber, `Warning: failed to set tilelayer metadata for ${friendly}`);
       }
 

--- a/test/mbtiles-metadata.test.js
+++ b/test/mbtiles-metadata.test.js
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { patchS57Mbtiles } = require('../dist/utils/mbtiles-metadata');
+const { patchS57Mbtiles, setMbtilesType } = require('../dist/utils/mbtiles-metadata');
 
 // Build a synthetic MBTiles file shaped like tippecanoe's output: empty
 // metadata table with the columns the patcher writes. We don't need actual
@@ -310,5 +310,68 @@ describe('patchS57Mbtiles', () => {
     } finally {
       db2.close();
     }
+  });
+});
+
+describe('setMbtilesType', () => {
+  let tmp;
+
+  before(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-mbtiles-settype-'));
+  });
+
+  after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('sets type=tilelayer on a fresh MBTiles, preserving unrelated metadata', async () => {
+    const file = path.join(tmp, 'fresh.mbtiles');
+    makeFakeMbtiles(file, { format: 'png' });
+
+    const result = await setMbtilesType(file, 'tilelayer');
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.type, 'tilelayer');
+    assert.strictEqual(result.attempts, 1);
+
+    const meta = readMetadata(file);
+    assert.strictEqual(meta.type, 'tilelayer');
+    assert.strictEqual(meta.format, 'png', 'unrelated metadata keys are preserved');
+  });
+
+  it('replaces an existing type without leaving duplicate rows', async () => {
+    const file = path.join(tmp, 'existing.mbtiles');
+    makeFakeMbtiles(file, { type: 'overlay', format: 'png' });
+
+    const result = await setMbtilesType(file, 'tilelayer');
+    assert.strictEqual(result.ok, true);
+
+    const { DatabaseSync } = require('node:sqlite');
+    const db = new DatabaseSync(file);
+    try {
+      const rows = db.prepare("SELECT value FROM metadata WHERE name = 'type'").all();
+      assert.strictEqual(rows.length, 1, 'no duplicate type rows');
+      assert.strictEqual(rows[0].value, 'tilelayer');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('returns ok=false (not throw) when the file is missing', async () => {
+    const result = await setMbtilesType(path.join(tmp, 'nope.mbtiles'), 'tilelayer');
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.attempts, 0);
+    assert.match(result.message, /does not exist/);
+  });
+
+  it('forwards progress messages via onMessage', async () => {
+    const file = path.join(tmp, 'logged.mbtiles');
+    makeFakeMbtiles(file, {});
+    const messages = [];
+    await setMbtilesType(file, 'tilelayer', { onMessage: (m) => messages.push(m) });
+    assert.ok(
+      messages.some((m) => m.includes('Set MBTiles type=tilelayer')),
+      'logs the success message'
+    );
   });
 });


### PR DESCRIPTION
## Summary

The RNC/KAP and Pilot conversion pipelines invoked `sqlite3` inside the GDAL container to tag the produced MBTiles as `tilelayer`. The upstream `ghcr.io/osgeo/gdal:alpine-small-latest` image recently dropped the sqlite3 CLI from its package set (the alpine-small flavour is now ~40MB smaller), so fresh installs that pull a current image fail the conversion with:

```
OCI runtime create failed: ... exec: "sqlite3": executable file not found in $PATH
```

This is a `:latest`-tag drift — the plugin code didn't change, but the image content did.

Replace both shell-outs with a host-side `setMbtilesType` helper that uses Node's built-in `node:sqlite` (the module the rest of the plugin already relies on, per `CLAUDE.md`). Same atomicity model as `patchS57Mbtiles`: BEGIN / DELETE / INSERT / verify / COMMIT in a transaction, with one retry on transient lock. Best-effort; never throws.

Bumps version to 1.13.0-beta.1 for a pre-release.

Closes #52.

## Tested

- Added 4 unit tests in `test/mbtiles-metadata.test.js` covering: fresh MBTiles tagged, existing type replaced without duplicate rows, missing-file returns `ok=false`, onMessage forwarding. All 142 tests pass.
- `npm run format && npm run build && npm test` clean.
- `cr review --plain`: no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.13.0-beta.1

* **Improvements**
  * Optimized MBTiles metadata tagging with enhanced reliability, automatic retry on transient failures, and improved error handling

* **Tests**
  * Added comprehensive test coverage for metadata operations including edge cases and error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->