### PR TITLE
chore(release): 1.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.13.0-beta.1",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.13.0-beta.1",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.13.0-beta.1",
+  "version": "1.13.0",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Promote 1.13.0-beta.1 to 1.13.0 stable. Beta has been verified end-to-end on a fresh signalk install (issue #52 reproducer).

Includes since 1.12.3:
- fix(rnc): tag tilelayer metadata via `node:sqlite` instead of in-container `sqlite3`, since `ghcr.io/osgeo/gdal:alpine-small-latest` dropped the sqlite3 CLI binary (#53, closes #52)

After merge, tag `v1.13.0` to trigger the publish workflow (GitHub Release + npm publish under `latest`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.13.0 as a stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->