### PR TITLE
fix(s57): diagnose container/bind-mount mismatches loudly instead of failing silently

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.13.0",
+  "version": "1.13.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.13.0",
+      "version": "1.13.1-beta.1",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.13.0",
+  "version": "1.13.1-beta.1",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import {
   setConversionFailed as setS57Failed
 } from './utils/s57-converter';
 import { checkContainerRuntime } from './utils/container-runtime';
+import { detectContainerRuntime } from './utils/container-environment';
 import {
   initRncConverter,
   processRncZip,
@@ -170,6 +171,25 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       console.log(`[charts-provider] chartPath resolved to ${chartPath} (marker: ${marker})`);
     } else {
       console.log(`[charts-provider] chartPath resolved to ${chartPath} (marker write failed)`);
+    }
+
+    // When Signal K runs in a container and talks to the host docker
+    // daemon via socket pass-through, the bind paths we hand to docker
+    // are container-internal — the host daemon mounts them against the
+    // host filesystem. If the host doesn't have the same paths,
+    // conversions silently produce nothing. Warn at startup so users
+    // bind-mount their data dir at an identical host path
+    // (e.g. -v /opt/signalk:/opt/signalk) before it bites them.
+    const containerKind = detectContainerRuntime();
+    if (containerKind) {
+      const warning =
+        `[charts-provider] Signal K appears to be running in a ${containerKind} container. ` +
+        `Chart conversions launch GDAL/tippecanoe via the host container runtime, so the data dir ` +
+        `'${pluginDataDir}' must resolve to the SAME path on the host. If your bind mount maps a ` +
+        `different host path (e.g. -v /opt/signalk:/home/node/.signalk), conversions will start ` +
+        `but the GDAL container will see an empty /input and produce no output. Use a matching ` +
+        `bind path (e.g. -v /opt/signalk:/opt/signalk) to avoid this.`;
+      console.warn(warning);
     }
 
     initChartState(pluginDataDir);

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,22 +173,31 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       console.log(`[charts-provider] chartPath resolved to ${chartPath} (marker write failed)`);
     }
 
-    // When Signal K runs in a container and talks to the host docker
-    // daemon via socket pass-through, the bind paths we hand to docker
-    // are container-internal — the host daemon mounts them against the
-    // host filesystem. If the host doesn't have the same paths,
-    // conversions silently produce nothing. Warn at startup so users
-    // bind-mount their data dir at an identical host path
-    // (e.g. -v /opt/signalk:/opt/signalk) before it bites them.
+    // When Signal K runs in a container and talks to the host container
+    // runtime via socket pass-through, every bind path we hand the
+    // runtime is a container-internal path that the runtime resolves
+    // against the host filesystem. If the host doesn't have the same
+    // paths, GDAL exports see an empty /input (silent conversion failure)
+    // OR tippecanoe exits with "unable to open database file" because
+    // /output isn't writable. Both failure modes hit users who only
+    // bind-mounted the data dir — the chart output dir is a SIBLING of
+    // the data dir, so the same bind doesn't cover it unless their
+    // common parent is mounted.
     const containerKind = detectContainerRuntime();
     if (containerKind) {
+      const dirs: string[] = [`data dir '${pluginDataDir}'`];
+      if (!chartPath.startsWith(pluginDataDir)) {
+        dirs.push(`chart output dir '${chartPath}'`);
+      }
+      const dirList = dirs.join(' and the ');
       const warning =
         `[charts-provider] Signal K appears to be running in a ${containerKind} container. ` +
-        `Chart conversions launch GDAL/tippecanoe via the host container runtime, so the data dir ` +
-        `'${pluginDataDir}' must resolve to the SAME path on the host. If your bind mount maps a ` +
-        `different host path (e.g. -v /opt/signalk:/home/node/.signalk), conversions will start ` +
-        `but the GDAL container will see an empty /input and produce no output. Use a matching ` +
-        `bind path (e.g. -v /opt/signalk:/opt/signalk) to avoid this.`;
+        `Chart conversions launch GDAL/tippecanoe via the host container runtime, so the ${dirList} ` +
+        `must resolve to the SAME path on the host. A non-matching bind (e.g. -v /opt/signalk:/home/node/.signalk) ` +
+        `will let conversions start but produce no output, or fail with "unable to open database file" when ` +
+        `tippecanoe can't write to /output. Use identical bind paths on both sides ` +
+        `(e.g. -v /opt/signalk:/opt/signalk) — and bind a common parent if the data dir and chart output ` +
+        `dir aren't nested.`;
       console.warn(warning);
     }
 

--- a/src/utils/container-environment.ts
+++ b/src/utils/container-environment.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+
+/**
+ * Best-effort detection of "the Signal K server process is itself running
+ * inside a container" — independent of any container *runtime* we use to
+ * launch chart conversions.
+ *
+ * Why this matters: when Signal K is in a container and the chart-conversion
+ * pipeline talks to the host docker daemon via socket pass-through
+ * (`/var/run/docker.sock`), every bind path the plugin generates is a
+ * container-internal path. The host docker daemon resolves those paths
+ * against the host filesystem and silently mounts an empty directory if
+ * they don't exist there — leading to GDAL containers that exit cleanly
+ * after ~37 ms with no output, and conversions that "do nothing" with no
+ * actionable error. Surfacing the detection up front turns a confusing
+ * silent failure into a startup warning the user can act on.
+ *
+ * Signals checked, ordered by reliability:
+ *   1. `/.dockerenv` — written by docker on every container, never on host.
+ *   2. `/run/.containerenv` — podman's equivalent.
+ *   3. `/proc/1/cgroup` — line containing `docker` / `containerd` / `kubepods`
+ *      means PID 1 is in a managed cgroup, i.e. a container.
+ *
+ * Returns `null` when none match (we're on the host, or detection failed
+ * — both treated the same way: no warning).
+ */
+export function detectContainerRuntime(): 'docker' | 'podman' | 'unknown-container' | null {
+  try {
+    if (fs.existsSync('/.dockerenv')) {
+      return 'docker';
+    }
+  } catch {
+    // ignored — fall through to next signal
+  }
+  try {
+    if (fs.existsSync('/run/.containerenv')) {
+      return 'podman';
+    }
+  } catch {
+    // ignored — fall through to next signal
+  }
+  try {
+    const cgroup = fs.readFileSync('/proc/1/cgroup', 'utf8');
+    if (/\b(docker|containerd|kubepods|libpod)\b/i.test(cgroup)) {
+      return 'unknown-container';
+    }
+  } catch {
+    // /proc/1/cgroup unreadable — give up, assume host
+  }
+  return null;
+}

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -133,6 +133,16 @@ interface ExportScriptOptions {
   skipLayers: string[];
 }
 
+// Path inside the container where per-file ogr2ogr stderr is captured.
+// Without this, ogr2ogr failures get swallowed (they used to redirect to
+// /dev/null) and a "the export ran but produced nothing" outcome is
+// indistinguishable from "every chart failed for the same reason".
+// Surfaced into the user-visible conversion log when zero output files
+// land in /output.
+export const EXPORT_ERRORS_LOG = '/output/.export-errors.log';
+const EXPORT_ERROR_FILE_BASENAME = path.basename(EXPORT_ERRORS_LOG);
+const EXPORT_ERROR_SAMPLE_LINES = 10;
+
 // Build the shell script that runs inside the GDAL container. Extracted as a
 // pure function so it's testable and so the parallelism knob is visible.
 //
@@ -145,25 +155,27 @@ export function buildExportScript(opts: ExportScriptOptions): string {
   const skipPattern = opts.skipLayers.join('|');
   const parallel = Math.max(1, Math.floor(opts.parallelism));
   const multiBranch = opts.multiFile ? '${layer}_${name}' : '${layer}';
+  const errLog = EXPORT_ERRORS_LOG;
 
   if (parallel === 1) {
     return `
 set -e
+: > ${errLog}
 count=$(find /input -name '*.000' ! -name '._*' -type f | wc -l)
 i=0
 find /input -name '*.000' ! -name '._*' -type f -print0 | while IFS= read -r -d '' enc; do
   i=$((i + 1))
   name=$(basename "$enc" .000)
   echo "PROGRESS: Processing $name ($i/$count)"
-  layers=$(ogrinfo -so "$enc" 2>/dev/null | grep -E '^[0-9]+:' | awk -F': ' '{print $2}' | awk '{print $1}')
+  layers=$(ogrinfo -so "$enc" 2>>${errLog} | grep -E '^[0-9]+:' | awk -F': ' '{print $2}' | awk '{print $1}')
   for layer in $layers; do
     case "$layer" in ${skipPattern}) continue ;; esac
     outname="${multiBranch}"
     if [ "$layer" = "SOUNDG" ]; then
       ogr2ogr -f GeoJSON -oo SPLIT_MULTIPOINT=YES -oo ADD_SOUNDG_DEPTH=YES \\
-        "/output/$outname.geojson" "$enc" "$layer" 2>/dev/null || true
+        "/output/$outname.geojson" "$enc" "$layer" 2>>${errLog} || true
     else
-      ogr2ogr -f GeoJSON "/output/$outname.geojson" "$enc" "$layer" 2>/dev/null || true
+      ogr2ogr -f GeoJSON "/output/$outname.geojson" "$enc" "$layer" 2>>${errLog} || true
     fi
   done
 done
@@ -177,13 +189,14 @@ echo "PROGRESS: Export complete"
   const multiArg = opts.multiFile ? '1' : '0';
   return `
 set -e
+: > ${errLog}
 count=$(find /input -name '*.000' ! -name '._*' -type f | wc -l)
 i=0
 find /input -name '*.000' ! -name '._*' -type f -print0 | while IFS= read -r -d '' enc; do
   i=$((i + 1))
   name=$(basename "$enc" .000)
   echo "PROGRESS: Processing $name ($i/$count)"
-  layers=$(ogrinfo -so "$enc" 2>/dev/null | grep -E '^[0-9]+:' | awk -F': ' '{print $2}' | awk '{print $1}')
+  layers=$(ogrinfo -so "$enc" 2>>${errLog} | grep -E '^[0-9]+:' | awk -F': ' '{print $2}' | awk '{print $1}')
   printf '%s\\n' $layers | xargs -P ${parallel} -I '{}' sh -c '
     layer="$1"
     enc="$2"
@@ -193,9 +206,9 @@ find /input -name '*.000' ! -name '._*' -type f -print0 | while IFS= read -r -d 
     if [ "$multi" = "1" ]; then outname="\${layer}_\${name}"; else outname="$layer"; fi
     if [ "$layer" = "SOUNDG" ]; then
       ogr2ogr -f GeoJSON -oo SPLIT_MULTIPOINT=YES -oo ADD_SOUNDG_DEPTH=YES \\
-        "/output/\${outname}.geojson" "$enc" "$layer" 2>/dev/null || true
+        "/output/\${outname}.geojson" "$enc" "$layer" 2>>${errLog} || true
     else
-      ogr2ogr -f GeoJSON "/output/\${outname}.geojson" "$enc" "$layer" 2>/dev/null || true
+      ogr2ogr -f GeoJSON "/output/\${outname}.geojson" "$enc" "$layer" 2>>${errLog} || true
     fi
   ' _ '{}' "$enc" "$name" "${multiArg}"
 done
@@ -233,6 +246,68 @@ async function exportAllLayersToGeoJSON(
 
   if (result.exitCode !== 0) {
     throw new Error(`GDAL export failed with exit code ${result.exitCode}`);
+  }
+
+  // The export script swallows non-zero exits from per-file ogr2ogr calls
+  // (one bad chart shouldn't kill a 60-chart bundle), so a clean exit
+  // doesn't mean any output landed. If nothing usable came out, surface
+  // a sample of the per-file stderr the script captured, so the user
+  // sees the actual GDAL error instead of just the downstream
+  // "No valid GeoJSON layers" message.
+  surfaceExportErrorsIfEmpty(geojsonDir, chartNumber);
+}
+
+function surfaceExportErrorsIfEmpty(geojsonDir: string, chartNumber: string): void {
+  let hasUsableOutput = false;
+  try {
+    for (const f of fs.readdirSync(geojsonDir)) {
+      if (!f.endsWith('.geojson')) {
+        continue;
+      }
+      if (fs.statSync(path.join(geojsonDir, f)).size > 100) {
+        hasUsableOutput = true;
+        break;
+      }
+    }
+  } catch {
+    return;
+  }
+  if (hasUsableOutput) {
+    return;
+  }
+
+  const errorFile = path.join(geojsonDir, EXPORT_ERROR_FILE_BASENAME);
+  let raw: string;
+  try {
+    raw = fs.readFileSync(errorFile, 'utf8');
+  } catch {
+    appendLog(
+      chartNumber,
+      'GDAL export produced no usable layers and no per-file errors were captured. ' +
+        'This usually means the GDAL container could not read /input — check chart-path host bind mounts and SELinux/AppArmor labels.'
+    );
+    return;
+  }
+  const lines = raw.split(/\r?\n/).filter((l) => l.trim().length > 0);
+  if (lines.length === 0) {
+    appendLog(
+      chartNumber,
+      'GDAL export produced no usable layers and the captured error log was empty.'
+    );
+    return;
+  }
+  appendLog(
+    chartNumber,
+    `GDAL export ran but produced no usable GeoJSON layers. First ${Math.min(EXPORT_ERROR_SAMPLE_LINES, lines.length)} of ${lines.length} captured ogr2ogr/ogrinfo error line(s):`
+  );
+  for (const line of lines.slice(0, EXPORT_ERROR_SAMPLE_LINES)) {
+    appendLog(chartNumber, `  ${line}`);
+  }
+  if (lines.length > EXPORT_ERROR_SAMPLE_LINES) {
+    appendLog(
+      chartNumber,
+      `  ... ${lines.length - EXPORT_ERROR_SAMPLE_LINES} more error line(s) suppressed.`
+    );
   }
 }
 
@@ -387,7 +462,8 @@ export const _testInternals = {
   consolidateGeoJSONByLayer,
   buildExportScript,
   bandClampedMaxzoom,
-  buildLayerArgs
+  buildLayerArgs,
+  surfaceExportErrorsIfEmpty
 };
 
 async function runTippecanoe(

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -10,6 +10,7 @@ import {
   runContainer
 } from './container-runtime';
 import { BAND_MIN_ZOOM, bandClampedMaxzoom, highestBandForFiles } from './s57-band';
+import { detectContainerRuntime } from './container-environment';
 import { patchS57Mbtiles } from './mbtiles-metadata';
 import type {
   ConversionProgress,
@@ -214,6 +215,53 @@ find /input -name '*.000' ! -name '._*' -type f -print0 | while IFS= read -r -d 
 done
 echo "PROGRESS: Export complete"
 `;
+}
+
+// Pure parsing of the probe container's stdout. Extracted so the parsing
+// edge cases are unit-testable without a real docker daemon. Returns
+// the integer the wc -l line emitted, or -1 when the output was empty
+// or unparseable.
+export function parseProbeOutput(lines: readonly string[]): number {
+  const numeric = lines.map((l) => l.trim()).find((l) => /^\d+$/.test(l));
+  if (numeric === undefined) {
+    return -1;
+  }
+  const n = parseInt(numeric, 10);
+  return Number.isFinite(n) ? n : -1;
+}
+
+// Probe the host container runtime with the same bind we're about to use
+// for the GDAL export. Returns the file count the *host* daemon sees at
+// the bind source. When Signal K runs in a container with docker socket
+// pass-through and no matching host bind, the host daemon mounts an empty
+// directory and this probe returns 0 even though our own readdir sees
+// the .000 files. Caller compares against in-process file count and
+// throws a clear error rather than letting GDAL exit clean with no
+// output (the original "37 ms silent failure" symptom).
+//
+// Returns -1 when the probe itself failed (couldn't run / couldn't parse
+// output) — caller treats that as inconclusive and proceeds normally.
+async function probeHostBindFileCount(encDir: string): Promise<number> {
+  try {
+    const lines: string[] = [];
+    const result = await runContainer({
+      image: GDAL_IMAGE,
+      phase: 'gdal-mount-probe',
+      job: 'mount-probe',
+      cmd: ['sh', '-c', "find /probe -maxdepth 2 -name '*.000' -type f 2>/dev/null | wc -l"],
+      binds: [`${encDir}:/probe:ro`],
+      onStdoutLine: (line) => lines.push(line),
+      onStderrLine: () => {
+        /* swallow — host bind issues land on stdout via wc -l */
+      }
+    });
+    if (result.exitCode !== 0) {
+      return -1;
+    }
+    return parseProbeOutput(lines);
+  } catch {
+    return -1;
+  }
 }
 
 async function exportAllLayersToGeoJSON(
@@ -463,7 +511,8 @@ export const _testInternals = {
   buildExportScript,
   bandClampedMaxzoom,
   buildLayerArgs,
-  surfaceExportErrorsIfEmpty
+  surfaceExportErrorsIfEmpty,
+  parseProbeOutput
 };
 
 async function runTippecanoe(
@@ -637,6 +686,29 @@ export async function processS57Zip(
     }
     debug(`Found ${encFiles.length} ENC files`);
     appendLog(chartNumber, `Found ${encFiles.length} ENC files`);
+
+    // When Signal K runs in a container, the path we hand to the host
+    // container runtime is a container-internal path. If the host doesn't
+    // have an identical bind, the runtime silently mounts an empty
+    // directory and the GDAL container exits cleanly with no output.
+    // Probe the bind once before the real export so we can fail fast
+    // with an actionable error instead.
+    if (detectContainerRuntime() !== null) {
+      const hostVisibleCount = await probeHostBindFileCount(encDir);
+      if (hostVisibleCount === 0) {
+        throw new Error(
+          `Bind-mount mismatch: this container sees ${encFiles.length} .000 file(s) at ${encDir}, ` +
+            `but the host container runtime sees an empty directory at the same path. ` +
+            `Signal K is running in a container — make sure the data dir is bind-mounted at an ` +
+            `identical path on the host (e.g. -v /opt/signalk:/opt/signalk), or run Signal K on ` +
+            `the host. Without that, conversions can't reach the chart files.`
+        );
+      }
+      // hostVisibleCount === -1 means the probe was inconclusive (image
+      // unavailable, runtime hiccup, exec error). Fall through and let
+      // the export try; surfaceExportErrorsIfEmpty will pick up any
+      // resulting empty-output failure.
+    }
 
     statusFn('converting', 'Converting S-57 layers to GeoJSON...');
     setProgress(chartNumber, 'converting', `Exporting ${encFiles.length} ENC files...`);

--- a/test/container-environment.test.js
+++ b/test/container-environment.test.js
@@ -1,0 +1,89 @@
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+
+const { detectContainerRuntime } = require('../dist/utils/container-environment');
+
+// Stub fs.existsSync / fs.readFileSync so the test isn't sensitive to
+// whether the test host is itself a container. Each test sets up the
+// signals it cares about and the rest fall through to "not present".
+let originalExistsSync;
+let originalReadFileSync;
+
+beforeEach(() => {
+  originalExistsSync = fs.existsSync;
+  originalReadFileSync = fs.readFileSync;
+});
+
+afterEach(() => {
+  fs.existsSync = originalExistsSync;
+  fs.readFileSync = originalReadFileSync;
+});
+
+function stubFs({ paths = new Set(), files = {} } = {}) {
+  fs.existsSync = (p) => paths.has(p);
+  fs.readFileSync = (p, enc) => {
+    if (files[p] !== undefined) {
+      return enc ? files[p] : Buffer.from(files[p]);
+    }
+    const err = new Error(`ENOENT: ${p}`);
+    err.code = 'ENOENT';
+    throw err;
+  };
+}
+
+describe('detectContainerRuntime', () => {
+  it('returns "docker" when /.dockerenv exists', () => {
+    stubFs({ paths: new Set(['/.dockerenv']) });
+    assert.strictEqual(detectContainerRuntime(), 'docker');
+  });
+
+  it('returns "podman" when only /run/.containerenv exists', () => {
+    stubFs({ paths: new Set(['/run/.containerenv']) });
+    assert.strictEqual(detectContainerRuntime(), 'podman');
+  });
+
+  it('prefers docker over podman when both files exist', () => {
+    // Some setups (e.g. docker-in-podman) emit both. Pick the more
+    // specific signal first; the warning text is the same either way.
+    stubFs({ paths: new Set(['/.dockerenv', '/run/.containerenv']) });
+    assert.strictEqual(detectContainerRuntime(), 'docker');
+  });
+
+  it('returns "unknown-container" when only /proc/1/cgroup mentions a container manager', () => {
+    stubFs({
+      paths: new Set(),
+      files: { '/proc/1/cgroup': '12:devices:/docker/abc123\n11:cpu:/docker/abc123\n' }
+    });
+    assert.strictEqual(detectContainerRuntime(), 'unknown-container');
+  });
+
+  it('matches kubepods, containerd, libpod in cgroup as container signals', () => {
+    for (const needle of ['kubepods', 'containerd', 'libpod']) {
+      stubFs({
+        paths: new Set(),
+        files: { '/proc/1/cgroup': `1:name=systemd:/${needle}/abc\n` }
+      });
+      assert.strictEqual(
+        detectContainerRuntime(),
+        'unknown-container',
+        `expected detection from cgroup line containing "${needle}"`
+      );
+    }
+  });
+
+  it('returns null on a normal host (no marker files, plain init cgroup)', () => {
+    stubFs({
+      paths: new Set(),
+      files: { '/proc/1/cgroup': '12:freezer:/init.scope\n11:cpu:/init.scope\n' }
+    });
+    assert.strictEqual(detectContainerRuntime(), null);
+  });
+
+  it('returns null when /proc/1/cgroup is unreadable and no marker files exist', () => {
+    // Stubs throw ENOENT for every readFileSync — the function must
+    // swallow and return null rather than propagating.
+    stubFs({ paths: new Set(), files: {} });
+    assert.strictEqual(detectContainerRuntime(), null);
+  });
+});

--- a/test/s57-converter.test.js
+++ b/test/s57-converter.test.js
@@ -4,9 +4,18 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { _testInternals } = require('../dist/utils/s57-converter');
-const { consolidateGeoJSONByLayer, buildExportScript, bandClampedMaxzoom, buildLayerArgs } =
-  _testInternals;
+const {
+  _testInternals,
+  EXPORT_ERRORS_LOG,
+  getConversionProgress
+} = require('../dist/utils/s57-converter');
+const {
+  consolidateGeoJSONByLayer,
+  buildExportScript,
+  bandClampedMaxzoom,
+  buildLayerArgs,
+  surfaceExportErrorsIfEmpty
+} = _testInternals;
 
 function writeFC(p, features) {
   fs.writeFileSync(p, JSON.stringify({ type: 'FeatureCollection', features }));
@@ -227,6 +236,98 @@ describe('buildExportScript', () => {
       assert.ok(seq.includes(layer), `sequential branch missing skip layer ${layer}`);
       assert.ok(par.includes(layer), `parallel branch missing skip layer ${layer}`);
     }
+  });
+
+  it('redirects per-file ogr2ogr stderr to the export error log in both branches', () => {
+    // Regression for charts where every per-file ogr2ogr call failed
+    // (e.g. IENC bundles on a GDAL build without inland S-57 support):
+    // the previous `2>/dev/null` swallowed the error so the user only
+    // saw a confusing downstream "No valid GeoJSON layers" message.
+    const seq = buildExportScript({ multiFile: false, parallelism: 1, skipLayers });
+    const par = buildExportScript({ multiFile: true, parallelism: 4, skipLayers });
+    assert.match(seq, new RegExp(`2>>${EXPORT_ERRORS_LOG.replace(/\//g, '\\/')}`));
+    assert.match(par, new RegExp(`2>>${EXPORT_ERRORS_LOG.replace(/\//g, '\\/')}`));
+    assert.doesNotMatch(seq, /2>\/dev\/null/);
+    assert.doesNotMatch(par, /2>\/dev\/null/);
+  });
+
+  it('initializes the error log with `: > <path>` so a stale log from a prior run is cleared', () => {
+    const s = buildExportScript({ multiFile: false, parallelism: 1, skipLayers });
+    assert.match(s, new RegExp(`: > ${EXPORT_ERRORS_LOG.replace(/\//g, '\\/')}`));
+  });
+});
+
+describe('surfaceExportErrorsIfEmpty', () => {
+  let tmp;
+  const chartNumber = 'test-surface-empty';
+
+  before(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-charts-surface-'));
+  });
+
+  after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('surfaces a sample of captured errors when the geojson dir is empty', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'errs-'));
+    fs.writeFileSync(
+      path.join(dir, '.export-errors.log'),
+      'ERROR 4: Cannot open IENC profile\nERROR 4: Unrecognized S57 product\n'
+    );
+    surfaceExportErrorsIfEmpty(dir, chartNumber);
+    const log = getConversionProgress(chartNumber)?.log ?? [];
+    assert.ok(
+      log.some((l) => l.includes('produced no usable GeoJSON layers')),
+      'expected a "no usable layers" headline in the surfaced log'
+    );
+    assert.ok(
+      log.some((l) => l.includes('Cannot open IENC profile')),
+      'expected the captured ogr2ogr error line to be surfaced verbatim'
+    );
+  });
+
+  it('skips surfacing when usable geojson output exists', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'ok-'));
+    // A real-feature-bearing GeoJSON file is well over the 100-byte
+    // threshold, so the helper should treat it as "we have output" and
+    // leave the conversion log alone.
+    fs.writeFileSync(
+      path.join(dir, 'HRBFAC.geojson'),
+      JSON.stringify({
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            properties: { OBJL: 1 },
+            geometry: { type: 'Point', coordinates: [0, 0] }
+          }
+        ]
+      })
+    );
+    fs.writeFileSync(
+      path.join(dir, '.export-errors.log'),
+      'ERROR 4: this should NOT be surfaced because output exists\n'
+    );
+    const skipChartNumber = 'test-surface-skip';
+    surfaceExportErrorsIfEmpty(dir, skipChartNumber);
+    const log = getConversionProgress(skipChartNumber)?.log ?? [];
+    assert.deepStrictEqual(
+      log,
+      [],
+      'no log lines should be surfaced when usable output is present'
+    );
+  });
+
+  it('reports a chart-path/SELinux hint when the dir is empty AND the error log is missing', () => {
+    const dir = fs.mkdtempSync(path.join(tmp, 'missinglog-'));
+    const noLogChartNumber = 'test-surface-nolog';
+    surfaceExportErrorsIfEmpty(dir, noLogChartNumber);
+    const log = getConversionProgress(noLogChartNumber)?.log ?? [];
+    assert.ok(
+      log.some((l) => l.includes('SELinux/AppArmor')),
+      'expected the missing-log diagnostic when no errors were captured'
+    );
   });
 });
 

--- a/test/s57-converter.test.js
+++ b/test/s57-converter.test.js
@@ -14,7 +14,8 @@ const {
   buildExportScript,
   bandClampedMaxzoom,
   buildLayerArgs,
-  surfaceExportErrorsIfEmpty
+  surfaceExportErrorsIfEmpty,
+  parseProbeOutput
 } = _testInternals;
 
 function writeFC(p, features) {
@@ -450,5 +451,35 @@ describe('per-feature tippecanoe.minzoom stamping (band-aware consolidation)', (
     assert.strictEqual(out.tippecanoe.minzoom, 12, 'minzoom added');
     assert.strictEqual(out.tippecanoe.maxzoom, 18, 'pre-existing maxzoom preserved');
     assert.strictEqual(out.tippecanoe.layer, 'override', 'pre-existing layer preserved');
+  });
+});
+
+describe('parseProbeOutput', () => {
+  it('returns the integer wc -l emitted on stdout', () => {
+    assert.strictEqual(parseProbeOutput(['61']), 61);
+  });
+
+  it('returns 0 when the probe saw an empty bind (the headline mismatch case)', () => {
+    // This is the value that triggers "Bind-mount mismatch" in the
+    // caller — the host runtime mounted nothing at the source path.
+    assert.strictEqual(parseProbeOutput(['0']), 0);
+  });
+
+  it('strips surrounding whitespace around the count', () => {
+    assert.strictEqual(parseProbeOutput(['   42   ']), 42);
+  });
+
+  it('skips non-numeric lines and finds the count further down', () => {
+    // Some GDAL images print a startup banner / xdebug line before the
+    // count appears. The pure-numeric line still wins.
+    assert.strictEqual(parseProbeOutput(['Loading...', 'tip: ...', '7']), 7);
+  });
+
+  it('returns -1 on no output (probe failed before producing a count)', () => {
+    assert.strictEqual(parseProbeOutput([]), -1);
+  });
+
+  it('returns -1 when no line is purely numeric', () => {
+    assert.strictEqual(parseProbeOutput(['Error: cannot stat /probe', 'twelve']), -1);
   });
 });


### PR DESCRIPTION
## Why

A user converting a Dutch IENC bundle reported "no error, just nothing happens" — the GDAL container started, exited cleanly after ~37 ms, and the conversion died downstream with a confusing **"No valid GeoJSON layers to process"**.

Root cause: Signal K was running in a Docker container with `/var/run/docker.sock` pass-through, mounting the data dir at a *different* host path (`-v /opt/signalk:/home/node/.signalk`). The plugin generated bind paths like `/home/node/.signalk/.../enc:/input` and handed them to the host docker daemon, which silently mounted an empty directory. The export script ran, saw zero `.000` files, exited 0 — and every per-file `ogr2ogr` failure was swallowed by `2>/dev/null` anyway.

## How

Four layers of defence, in order of how early they fire:

1. **Startup warning when running inside a container.** Detects via `/.dockerenv`, `/run/.containerenv`, and `/proc/1/cgroup`; emits a one-line console warning that names the data dir and (when it's a sibling, not a child) the chart output dir, plus the path-equality fix.
2. **Pre-export bind probe.** Before the GDAL export runs, spin a one-shot probe container with the same `${encDir}:/probe:ro` bind that runs `find /probe -name '*.000' | wc -l`. If the host runtime sees 0 files where the plugin sees N, throw a clear "Bind-mount mismatch" error naming the fix. Only runs when in a container.
3. **Capture per-file ogr2ogr stderr.** Replace `2>/dev/null` with `2>>/output/.export-errors.log` in both the sequential and parallel branches of the export script.
4. **Surface captured errors when the export ran but produced nothing.** After a clean container exit with no usable output, read up to 10 lines from the captured log and emit them to the user-visible conversion log (or a chart-path / SELinux hint if the log is missing — that's the case where the bind itself was unwritable).

## Tested

- 160 unit tests pass (added 13 new for the four behaviours).
- `npm run format`, `npm run build`, `npm test`, `npm run lint` all clean.
- Field-tested: the user re-ran with matching binds and conversion proceeds. With the original mismatched bind, the bind-probe would have fired and named the cause directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added container runtime detection that displays warnings about bind-mount path alignment for data and chart output directories when running in containerized environments.

* **Improvements**
  * Enhanced error logging during data exports for better visibility into per-file operation failures.
  * Improved export script robustness for containerized deployments.

* **Version**
  * Bumped to 1.13.1-beta.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->