### PR TITLE
chore(release): 1.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.13.1-beta.1",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.13.1-beta.1",
+      "version": "1.13.1",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.13.1-beta.1",
+  "version": "1.13.1",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Promotes the four fixes from `1.13.1-beta.1` to a stable release. Beta validated by Marcel — both the silent-failure path and the new bind-mount-mismatch error fire correctly.

## Includes (since 1.13.0)

- **fix(s57): surface swallowed ogr2ogr errors when the export produces nothing** — capture per-file stderr, surface up to 10 lines into the user-visible conversion log when the export ran but produced no usable output.
- **feat(s57): warn at startup when running inside a container** — detect docker/podman/generic-container at startup and warn about the path-equality requirement.
- **fix(s57): probe host bind before GDAL export to fail fast on path mismatch** — one-shot probe container against `${encDir}:/probe`; if the host runtime sees 0 files where we see N, throw a clear "Bind-mount mismatch" error naming the fix.
- **fix(s57): cover chart output dir in the in-container startup warning** — name both data dir and chart output dir (when they don't share a parent) and add the "unable to open database file" failure mode to the warning.

## Validated against the original failing case

User reported a Dutch IENC bundle that converted on Podman but produced no output on Docker (signalk-server in a container, mismatched binds). Beta installed cleanly; the new bind probe fires the explicit mismatch error before GDAL runs, naming both the source path and the missing-files diagnosis. Original silent 37 ms exit with downstream "No valid GeoJSON layers" no longer happens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 1.13.1 released as stable (transitioned from beta release).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->