### PR TITLE
fix(s57): drop -maxdepth from bind probe (1.13.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.13.1",
+      "version": "1.13.2",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -248,7 +248,12 @@ async function probeHostBindFileCount(encDir: string): Promise<number> {
       image: GDAL_IMAGE,
       phase: 'gdal-mount-probe',
       job: 'mount-probe',
-      cmd: ['sh', '-c', "find /probe -maxdepth 2 -name '*.000' -type f 2>/dev/null | wc -l"],
+      // Mirror the export's find exactly (unbounded depth, skip macOS
+      // ._-resource files). The original `-maxdepth 2` was a guess that
+      // false-positived the mismatch error on real-world NL IENC ZIPs
+      // whose .000 files nest deeper than two levels — the probe saw
+      // 0 while the export saw N.
+      cmd: ['sh', '-c', "find /probe -name '*.000' ! -name '._*' -type f 2>/dev/null | wc -l"],
       binds: [`${encDir}:/probe:ro`],
       onStdoutLine: (line) => lines.push(line),
       onStderrLine: () => {


### PR DESCRIPTION
Marcel hit a false-positive bind-mismatch error after fixing his original bind:

> on line 230 in the check you have max depth 2 / for some of the files the maxdepth of 2 is not enough / I increased it and then it was working fine

Root cause: the probe used `find /probe -maxdepth 2` while the real export uses unbounded `find /input`. A ZIP whose `.000` files nest deeper than two levels (real-world NL IENC bundles do) made the probe report 0 even when the host bind resolved correctly, so the new bind-mismatch error fired falsely and aborted before GDAL could run.

## Fix

Mirror the export's find exactly: drop `-maxdepth`, also skip macOS `._`-resource files (`! -name '._*'`) for symmetry with the export's filter.

## Notes

The 1.13.1 probe still works for the case it was added for (real bind mismatch). This patch just removes the false-positive on deep ZIP layouts. No new tests — the existing `parseProbeOutput` tests cover the parse path, and the probe-vs-export find arguments are now identical by inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.13.2
* **Bug Fixes**
  * Improved file detection to recursively count electronic chart files and properly exclude macOS system resource files, enhancing accuracy of file inventory operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->