### PR TITLE
feat: meaningful chart name in MBTiles metadata (1.14.0-beta.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.13.2",
+  "version": "1.14.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.13.2",
+      "version": "1.14.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.13.2",
+  "version": "1.14.0-beta.1",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,8 @@ import {
 } from './utils/s57-converter';
 import { checkContainerRuntime } from './utils/container-runtime';
 import { detectContainerRuntime } from './utils/container-environment';
+import { cleanCatalogTitle } from './utils/catalog-title';
+import { setMbtilesDisplayName } from './utils/mbtiles-metadata';
 import {
   initRncConverter,
   processRncZip,
@@ -901,6 +903,26 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         await fs.promises.rename(sourcePath, targetPath);
         app.debug(`Renamed chart from ${sourcePath} to ${targetPath}`);
 
+        // Patch the MBTiles `metadata.name` row to match the new label
+        // so consumers (Freeboard-SK, OpenCPN-Web) display the renamed
+        // chart by its new name and not the stale value tippecanoe (or
+        // an earlier rename) wrote. Best-effort — a failure here doesn't
+        // abort the rename, the file move already succeeded.
+        try {
+          const dnResult = await setMbtilesDisplayName(targetPath, nameWithoutExt, undefined, {
+            onMessage: (m) => app.debug(`rename-chart: ${m}`)
+          });
+          if (!dnResult.ok) {
+            console.warn(
+              `[charts-provider] WARNING: ${dnResult.message} (${path.basename(targetPath)})`
+            );
+          }
+        } catch (mdErr) {
+          app.debug(
+            `rename-chart metadata patch threw: ${mdErr instanceof Error ? mdErr.message : String(mdErr)}`
+          );
+        }
+
         await refreshChartProviders();
 
         const oldChartId = path.basename(chartPathBody).replace(/\.mbtiles$/, '');
@@ -1539,6 +1561,14 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           return;
         }
 
+        // Look up the chart's catalog title so the converter can write
+        // the cleaned label into MBTiles metadata.name (and the full
+        // original title into metadata.description). Manual uploads
+        // don't go through this path so they keep the existing
+        // 'S-57 <chartNumber>' default.
+        const cachedCatalog = getCachedCatalog(catalogFile);
+        const chartTitle = cachedCatalog?.charts.find((c) => c.number === chartNumber)?.title;
+
         if (classification.format === 's57-zip') {
           handleS57Download(
             res,
@@ -1550,7 +1580,8 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             targetDir,
             chartPath,
             minzoom,
-            maxzoom
+            maxzoom,
+            chartTitle
           );
         } else if (classification.format === 'rnc-zip') {
           handleRncDownload(
@@ -1646,7 +1677,8 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     targetDir: string,
     chartPath: string,
     minzoom: number | undefined,
-    maxzoom: number | undefined
+    maxzoom: number | undefined,
+    chartTitle: string | undefined
   ): void {
     const tmpDownloadDir = path.join(app.getDataDirPath(), `s57-download-${Date.now()}`);
     fs.mkdirSync(tmpDownloadDir, { recursive: true });
@@ -1675,6 +1707,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       }
 
       try {
+        const displayName = chartTitle ? cleanCatalogTitle(chartTitle) : undefined;
         const result = await processS57Zip(
           zipPath,
           targetDir,
@@ -1682,7 +1715,12 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           (status, message) => {
             app.debug(`S-57 [${chartNumber}] ${status}: ${message}`);
           },
-          { minzoom, maxzoom }
+          {
+            minzoom,
+            maxzoom,
+            displayName: displayName || undefined,
+            displayDescription: chartTitle || undefined
+          }
         );
 
         setConvertingState(chartNumber, false);

--- a/src/types.ts
+++ b/src/types.ts
@@ -230,6 +230,20 @@ export interface S57ConversionResult {
 export interface S57ConversionOptions {
   minzoom?: number;
   maxzoom?: number;
+  /**
+   * Optional human-friendly chart label written into the MBTiles
+   * `metadata.name` row after conversion. When the conversion is driven
+   * by a catalog click this is the cleaned catalog title; manual
+   * uploads leave it undefined and the existing metadata stays in
+   * place. See `cleanCatalogTitle` in `utils/catalog-title.ts`.
+   */
+  displayName?: string;
+  /**
+   * Optional longer text written into MBTiles `metadata.description`.
+   * Typically the full original (un-cleaned) catalog title so chart
+   * provenance survives in clients that surface description.
+   */
+  displayDescription?: string;
 }
 
 export interface ContainerRuntimeStatus {

--- a/src/utils/catalog-title.ts
+++ b/src/utils/catalog-title.ts
@@ -1,0 +1,41 @@
+/**
+ * Strip the noise suffixes that catalog vendors append to chart titles, so
+ * the result is a clean human label suitable for the MBTiles `name` row.
+ *
+ * Real-world examples observed in NL_IENC_Catalog.json:
+ *   'Zeeland met Diepte - 2026 - Week 19 - 47 MB (0)'
+ *   'Waddenzee met Diepte 2026 - Week 18– 25 MB (1)'         (en-dash, no space)
+ *   'Port of Rotterdam 2026-04-21 (2)'                       (no size suffix)
+ *   'Nederland (excl Zeeland, Waddenzee) 2026-02-19 - 46MB (3)'  (mid-title parens)
+ *   '20260216_U7Inland_Closed Edition_NL (4)'                (no size, trailing index)
+ *
+ * Stripped:
+ *   - Trailing `(N)` only when it sits at the very end (so 'excl Zeeland, Waddenzee'
+ *     mid-title is preserved).
+ *   - Trailing size pattern: optional dash/en-dash/em-dash + digits + optional
+ *     space + MB.
+ *
+ * NOT stripped: year/week markers ('2026 - Week 19'), parens-with-text inside
+ * the title, anything else. Those are part of the chart identity.
+ *
+ * Pure helper, no side effects. Returns the trimmed cleaned string. If the
+ * input is empty/whitespace, returns an empty string.
+ */
+export function cleanCatalogTitle(raw: string): string {
+  if (typeof raw !== 'string') {
+    return '';
+  }
+  let s = raw.trim();
+  if (s === '') {
+    return '';
+  }
+
+  // Strip trailing index ` (N)` only at the very end.
+  s = s.replace(/\s*\(\d+\)\s*$/, '');
+
+  // Strip trailing size: optional [-–—] followed by digits, optional space, MB.
+  // Only at the very end after the index has been removed.
+  s = s.replace(/\s*[-–—]?\s*\d+\s*MB\s*$/i, '');
+
+  return s.trim();
+}

--- a/src/utils/mbtiles-metadata.ts
+++ b/src/utils/mbtiles-metadata.ts
@@ -322,3 +322,147 @@ export async function setMbtilesType(
     message: lastError || 'MBTiles type tag failed (unknown reason)'
   };
 }
+
+export interface SetDisplayNameResult {
+  ok: boolean;
+  name: string | null;
+  description: string | null;
+  attempts: number;
+  message: string;
+}
+
+/**
+ * Set the `name` row (and optionally the `description` row) in an MBTiles
+ * `metadata` table. Used after the conversion pipeline finishes so the
+ * chart shows up in clients (Freeboard-SK, OpenCPN-Web) under a friendly
+ * label instead of tippecanoe's `/output/0.mbtiles`.
+ *
+ * `description` is only written when supplied — undefined leaves any
+ * existing row in place. Same atomicity guarantees as patchS57Mbtiles
+ * (DELETE + INSERT + verify in a transaction; one retry on transient
+ * lock). Best-effort, never throws.
+ */
+export async function setMbtilesDisplayName(
+  outputPath: string,
+  wantedName: string,
+  wantedDescription: string | undefined,
+  options: PatchOptions = {}
+): Promise<SetDisplayNameResult> {
+  const sleeper = options.sleep ?? sleep;
+  const retryMs = options.retryDelayMs ?? DEFAULT_RETRY_MS;
+  const log = (m: string): void => {
+    try {
+      options.onMessage?.(m);
+    } catch {
+      /* best-effort logging */
+    }
+  };
+
+  if (!fs.existsSync(outputPath)) {
+    const message = `MBTiles file does not exist: ${outputPath}`;
+    log(message);
+    return { ok: false, name: null, description: null, attempts: 0, message };
+  }
+
+  const sqlite = loadSqlite();
+  if (!sqlite.ok) {
+    log(sqlite.reason);
+    return { ok: false, name: null, description: null, attempts: 0, message: sqlite.reason };
+  }
+
+  let lastError = '';
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    if (attempt === 2) {
+      log(`Retrying MBTiles display-name patch after ${retryMs}ms…`);
+      try {
+        await sleeper(retryMs);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log(`Sleep before retry threw (continuing): ${msg}`);
+      }
+    }
+    try {
+      const db = new sqlite.DatabaseSync(outputPath);
+      let inTransaction = false;
+      try {
+        db.exec('BEGIN TRANSACTION');
+        inTransaction = true;
+        db.exec("DELETE FROM metadata WHERE name = 'name'");
+        db.prepare("INSERT INTO metadata (name, value) VALUES ('name', ?)").run(wantedName);
+        if (wantedDescription !== undefined) {
+          db.exec("DELETE FROM metadata WHERE name = 'description'");
+          db.prepare("INSERT INTO metadata (name, value) VALUES ('description', ?)").run(
+            wantedDescription
+          );
+        }
+
+        const nameRow = db.prepare("SELECT value FROM metadata WHERE name = 'name'").get();
+        const gotName =
+          typeof nameRow === 'object' && nameRow !== null && 'value' in nameRow
+            ? String(nameRow.value)
+            : null;
+
+        let gotDescription: string | null = null;
+        if (wantedDescription !== undefined) {
+          const descRow = db.prepare("SELECT value FROM metadata WHERE name = 'description'").get();
+          gotDescription =
+            typeof descRow === 'object' && descRow !== null && 'value' in descRow
+              ? String(descRow.value)
+              : null;
+        }
+
+        if (gotName !== wantedName) {
+          db.exec('ROLLBACK');
+          inTransaction = false;
+          lastError = `MBTiles display-name verify failed: name='${gotName}' (wanted '${wantedName}')`;
+          log(lastError);
+          continue;
+        }
+        if (wantedDescription !== undefined && gotDescription !== wantedDescription) {
+          db.exec('ROLLBACK');
+          inTransaction = false;
+          lastError = `MBTiles display-name verify failed: description mismatch`;
+          log(lastError);
+          continue;
+        }
+
+        db.exec('COMMIT');
+        inTransaction = false;
+        const message =
+          attempt === 1
+            ? `Set MBTiles name='${wantedName}'`
+            : `Set MBTiles name='${wantedName}' on retry`;
+        log(message);
+        return {
+          ok: true,
+          name: gotName,
+          description: gotDescription,
+          attempts: attempt,
+          message
+        };
+      } finally {
+        if (inTransaction) {
+          try {
+            db.exec('ROLLBACK');
+          } catch {
+            /* already committed or no transaction */
+          }
+        }
+        db.close();
+      }
+    } catch (err) {
+      lastError = `MBTiles display-name patch failed (attempt ${attempt}/2): ${
+        err instanceof Error ? err.message : String(err)
+      }`;
+      log(lastError);
+    }
+  }
+
+  return {
+    ok: false,
+    name: null,
+    description: null,
+    attempts: 2,
+    message: lastError || 'MBTiles display-name patch failed (unknown reason)'
+  };
+}

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -11,7 +11,7 @@ import {
 } from './container-runtime';
 import { BAND_MIN_ZOOM, bandClampedMaxzoom, highestBandForFiles } from './s57-band';
 import { detectContainerRuntime } from './container-environment';
-import { patchS57Mbtiles } from './mbtiles-metadata';
+import { patchS57Mbtiles, setMbtilesDisplayName } from './mbtiles-metadata';
 import type {
   ConversionProgress,
   ConversionProgressMap,
@@ -767,6 +767,30 @@ export async function processS57Zip(
     if (!patchResult.ok) {
       const banner = `[charts-provider] WARNING: ${patchResult.message} (${outputName})`;
       console.warn(banner);
+    }
+
+    // Optional second patch: when the caller (catalog flow) supplied a
+    // human-friendly label, overwrite the `name` row that
+    // patchS57Mbtiles just wrote with the cleaned catalog title, and set
+    // `description` to the full original title for provenance. Manual
+    // uploads leave displayName undefined and keep the patcher's
+    // `S-57 <chartNumber>` default.
+    if (options.displayName) {
+      const dnResult = await setMbtilesDisplayName(
+        outputPath,
+        options.displayName,
+        options.displayDescription,
+        {
+          onMessage: (msg) => {
+            debug(msg);
+            appendLog(chartNumber, msg);
+          }
+        }
+      );
+      if (!dnResult.ok) {
+        const banner = `[charts-provider] WARNING: ${dnResult.message} (${outputName})`;
+        console.warn(banner);
+      }
     }
 
     const size = (fs.statSync(outputPath).size / (1024 * 1024)).toFixed(1);

--- a/test/catalog-title.test.js
+++ b/test/catalog-title.test.js
@@ -1,0 +1,83 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { cleanCatalogTitle } = require('../dist/utils/catalog-title');
+
+describe('cleanCatalogTitle', () => {
+  it('strips trailing size + index from a hyphen-separated NL IENC title', () => {
+    assert.strictEqual(
+      cleanCatalogTitle('Zeeland met Diepte - 2026 - Week 19 - 47 MB (0)'),
+      'Zeeland met Diepte - 2026 - Week 19'
+    );
+  });
+
+  it('strips an en-dash size suffix glued to the previous word', () => {
+    // 'Week 18– 25 MB (1)' — en-dash with no leading space.
+    assert.strictEqual(
+      cleanCatalogTitle('Waddenzee met Diepte 2026 - Week 18– 25 MB (1)'),
+      'Waddenzee met Diepte 2026 - Week 18'
+    );
+  });
+
+  it('strips a trailing index when no size suffix is present', () => {
+    assert.strictEqual(
+      cleanCatalogTitle('Port of Rotterdam 2026-04-21 (2)'),
+      'Port of Rotterdam 2026-04-21'
+    );
+  });
+
+  it('preserves mid-title parens (e.g. "excl Zeeland, Waddenzee")', () => {
+    // The trailing (3) gets stripped; the mid-title (excl ...) must stay.
+    assert.strictEqual(
+      cleanCatalogTitle('Nederland (excl Zeeland, Waddenzee) 2026-02-19 - 46MB (3)'),
+      'Nederland (excl Zeeland, Waddenzee) 2026-02-19'
+    );
+  });
+
+  it('strips a no-space size suffix like "46MB"', () => {
+    assert.strictEqual(
+      cleanCatalogTitle('Nederland 2026-02-19 - 46MB (3)'),
+      'Nederland 2026-02-19'
+    );
+  });
+
+  it('strips just the trailing index when title has no size suffix', () => {
+    assert.strictEqual(
+      cleanCatalogTitle('20260216_U7Inland_Closed Edition_NL (4)'),
+      '20260216_U7Inland_Closed Edition_NL'
+    );
+  });
+
+  it('handles em-dash size separator', () => {
+    assert.strictEqual(cleanCatalogTitle('Some Chart 2026 — 25 MB (5)'), 'Some Chart 2026');
+  });
+
+  it('returns the input unchanged when it has no recognised suffix', () => {
+    assert.strictEqual(cleanCatalogTitle('Pure Chart Name 2026'), 'Pure Chart Name 2026');
+  });
+
+  it('preserves year/week identity markers', () => {
+    // The cleaner must NOT strip "2026 - Week 19" — that's part of the chart.
+    const result = cleanCatalogTitle('Foo 2026 - Week 19 - 10 MB (0)');
+    assert.ok(result.includes('2026'));
+    assert.ok(result.includes('Week 19'));
+  });
+
+  it('returns empty string for empty/whitespace input', () => {
+    assert.strictEqual(cleanCatalogTitle(''), '');
+    assert.strictEqual(cleanCatalogTitle('   '), '');
+  });
+
+  it('returns empty string for non-string input (defensive)', () => {
+    assert.strictEqual(cleanCatalogTitle(undefined), '');
+    assert.strictEqual(cleanCatalogTitle(null), '');
+    assert.strictEqual(cleanCatalogTitle(42), '');
+  });
+
+  it('does not strip a (N) that appears mid-title', () => {
+    assert.strictEqual(
+      cleanCatalogTitle('Chart (special edition) 2026'),
+      'Chart (special edition) 2026'
+    );
+  });
+});

--- a/test/mbtiles-metadata.test.js
+++ b/test/mbtiles-metadata.test.js
@@ -4,7 +4,11 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { patchS57Mbtiles, setMbtilesType } = require('../dist/utils/mbtiles-metadata');
+const {
+  patchS57Mbtiles,
+  setMbtilesType,
+  setMbtilesDisplayName
+} = require('../dist/utils/mbtiles-metadata');
 
 // Build a synthetic MBTiles file shaped like tippecanoe's output: empty
 // metadata table with the columns the patcher writes. We don't need actual
@@ -371,6 +375,92 @@ describe('setMbtilesType', () => {
     await setMbtilesType(file, 'tilelayer', { onMessage: (m) => messages.push(m) });
     assert.ok(
       messages.some((m) => m.includes('Set MBTiles type=tilelayer')),
+      'logs the success message'
+    );
+  });
+});
+
+describe('setMbtilesDisplayName', () => {
+  let tmp;
+
+  before(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-charts-displayname-'));
+  });
+
+  after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("replaces tippecanoe's `/output/0.mbtiles` name with the supplied label", async () => {
+    const file = path.join(tmp, 'rename.mbtiles');
+    makeFakeMbtiles(file, { name: '/output/0.mbtiles' });
+    const result = await setMbtilesDisplayName(file, 'Waddenzee 2026 Week 18', undefined);
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.name, 'Waddenzee 2026 Week 18');
+    assert.strictEqual(readMetadata(file).name, 'Waddenzee 2026 Week 18');
+  });
+
+  it('also writes description when supplied', async () => {
+    const file = path.join(tmp, 'desc.mbtiles');
+    makeFakeMbtiles(file, {});
+    const result = await setMbtilesDisplayName(
+      file,
+      'Cleaned title',
+      'Full original title with size – 25 MB (1)'
+    );
+    assert.strictEqual(result.ok, true);
+    const md = readMetadata(file);
+    assert.strictEqual(md.name, 'Cleaned title');
+    assert.strictEqual(md.description, 'Full original title with size – 25 MB (1)');
+  });
+
+  it('leaves an existing description in place when description is undefined', async () => {
+    const file = path.join(tmp, 'preserve-desc.mbtiles');
+    makeFakeMbtiles(file, {
+      name: 'old name',
+      description: 'pre-existing description'
+    });
+    const result = await setMbtilesDisplayName(file, 'new name', undefined);
+    assert.strictEqual(result.ok, true);
+    const md = readMetadata(file);
+    assert.strictEqual(md.name, 'new name');
+    assert.strictEqual(md.description, 'pre-existing description');
+  });
+
+  it('does not duplicate the name row on repeated calls', async () => {
+    // Same DELETE+INSERT idempotency we rely on for type. Repeat the call
+    // and check there's still exactly one name row, not two.
+    const file = path.join(tmp, 'dup.mbtiles');
+    makeFakeMbtiles(file, {});
+    await setMbtilesDisplayName(file, 'A', undefined);
+    await setMbtilesDisplayName(file, 'B', undefined);
+    const { DatabaseSync } = require('node:sqlite');
+    const db = new DatabaseSync(file);
+    try {
+      const rows = db.prepare("SELECT value FROM metadata WHERE name = 'name'").all();
+      assert.strictEqual(rows.length, 1, 'no duplicate name rows');
+      assert.strictEqual(rows[0].value, 'B');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('returns ok=false (not throw) when the file is missing', async () => {
+    const result = await setMbtilesDisplayName(path.join(tmp, 'nope.mbtiles'), 'X', undefined);
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.attempts, 0);
+    assert.match(result.message, /does not exist/);
+  });
+
+  it('forwards progress messages via onMessage', async () => {
+    const file = path.join(tmp, 'logged.mbtiles');
+    makeFakeMbtiles(file, {});
+    const messages = [];
+    await setMbtilesDisplayName(file, 'logged-name', undefined, {
+      onMessage: (m) => messages.push(m)
+    });
+    assert.ok(
+      messages.some((m) => m.includes("Set MBTiles name='logged-name'")),
       'logs the success message'
     );
   });


### PR DESCRIPTION
## Why

Converted charts ship with `metadata.name = "/output/0.mbtiles"` (tippecanoe's default) or `"S-57 <chartNumber>"` (our patcher's default). Neither is what users want to see when picking charts in Freeboard-SK or other consumers. They want **"Waddenzee met Diepte 2026 - Week 18"** — the catalog's own title.

## What changes

- **`cleanCatalogTitle`** (new) strips the noisy size/index suffixes catalog vendors add (`– 25 MB (1)`, `(0)`, `46MB`, …) while preserving the chart's identity (year, week, mid-title parens, etc.). Pure helper, 12 unit tests covering all dash variants, no-suffix titles, defensive non-string input.
- **`setMbtilesDisplayName`** (new) writes `metadata.name` and (optionally) `metadata.description` with the same DELETE+INSERT+verify-in-transaction pattern `patchS57Mbtiles` already uses. Best-effort, retried once, never throws. 6 new tests.
- **Catalog flow**: `/catalog/download` looks up the chart's catalog title server-side (from `getCachedCatalog`), passes the cleaned form as `displayName` and the full original as `displayDescription` through `S57ConversionOptions` to `processS57Zip`.
- **`processS57Zip`** runs `setMbtilesDisplayName` after the existing `patchS57Mbtiles` whenever `displayName` is supplied. Manual uploads stay on the old `S-57 <chartNumber>` default.
- **`/rename-chart`** now patches `metadata.name` to match the new filename in addition to the existing on-disk rename. Closes the same UX gap from the rename side.

## Tested

178 unit tests pass (was 160). Format/build/lint clean. RNC path skipped — catalog has no working RNC links.

## Release

`1.14.0-beta.1` for field testing. Promote to stable `1.14.0` once Marcel and others confirm the chart names look right in their setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S-57 catalog downloads now properly utilize catalog titles for chart naming.
  * Chart rename functionality now updates associated metadata.

* **Tests**
  * Added comprehensive test coverage for catalog title normalization and metadata updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->