### PR TITLE
chore(release): 1.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.14.0-beta.1",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-charts-provider-simple",
-      "version": "1.14.0-beta.1",
+      "version": "1.14.0",
       "license": "MIT",
       "dependencies": {
         "@signalk/server-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "1.14.0-beta.1",
+  "version": "1.14.0",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Promotes the catalog-title → MBTiles metadata work from `1.14.0-beta.1` to a stable release.

## Includes (since 1.13.2)

- **feat(catalog): cleanCatalogTitle helper** — strip noisy size/index suffixes vendors append to chart titles (`– 25 MB (1)`), preserving year/week markers and mid-title parens.
- **feat(mbtiles): setMbtilesDisplayName** — atomic patch helper for `metadata.name` and (optional) `metadata.description`. Mirrors the patchS57Mbtiles retry pattern.
- **feat(s57): write catalog title into MBTiles on conversion + rename** — `/catalog/download` looks up the chart's catalog title, runs it through cleanCatalogTitle, and passes both cleaned + original through `S57ConversionOptions.displayName`/`displayDescription`. processS57Zip applies them after the existing patchS57Mbtiles. `/rename-chart` now also patches `metadata.name` so renames update what consumers display.

Beta-tested with 1.14.0-beta.1; no regressions reported. Manual uploads continue to use the existing `S-57 <chartNumber>` default since they have no catalog title to source from.

172 unit tests pass; format/build/lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 1.14.0 released as stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->