### PR TITLE
fix(s57): name converted .mbtiles after the catalog title, not the chart index

### DIFF
--- a/src/utils/catalog-title.ts
+++ b/src/utils/catalog-title.ts
@@ -39,3 +39,55 @@ export function cleanCatalogTitle(raw: string): string {
 
   return s.trim();
 }
+
+/**
+ * Turn a (cleaned) catalog title into a filesystem-safe basename for the
+ * output `.mbtiles` file, so users see e.g. `Waddenzee_met_Diepte_2026-Week_18.mbtiles`
+ * in their chart directory instead of the catalog's sequential index
+ * (`1.mbtiles`, `2.mbtiles`, …) which is meaningless out of context.
+ *
+ * Rules:
+ *   - All whitespace runs collapse to single underscores (no spaces in filenames).
+ *   - Path separators (/, \) and `.` are replaced with `-` so the result
+ *     can never escape its directory or accidentally trigger an extension
+ *     change.
+ *   - Any control / non-printable character is dropped.
+ *   - Other punctuation is preserved as-is — modern filesystems handle
+ *     dashes, parens, brackets fine.
+ *   - Result is trimmed of leading/trailing dashes, dots, and underscores.
+ *   - Capped at 100 chars to stay well below filesystem limits even after
+ *     `.mbtiles` and any collision suffix the caller appends.
+ *
+ * Returns the empty string when the input is empty / sanitizes to nothing
+ * (caller falls back to chartNumber or another label).
+ */
+export function sanitizeChartFilename(title: string): string {
+  if (typeof title !== 'string') {
+    return '';
+  }
+  let s = title.trim();
+  if (s === '') {
+    return '';
+  }
+
+  // Whitespace runs → single underscore.
+  s = s.replace(/\s+/g, '_');
+
+  // Path separators and dots → dash.  Dots especially must go: an extension
+  // boundary in the middle of a chart name would confuse downstream tools
+  // (and our own /\.mbtiles$/ regex if we ever round-trip through it).
+  s = s.replace(/[/\\.]/g, '-');
+
+  // Drop control / non-printable.
+  // eslint-disable-next-line no-control-regex
+  s = s.replace(/[\x00-\x1f\x7f]/g, '');
+
+  // Trim noisy leading/trailing punctuation.
+  s = s.replace(/^[-._]+|[-._]+$/g, '');
+
+  if (s.length > 100) {
+    s = s.slice(0, 100).replace(/[-._]+$/g, '');
+  }
+
+  return s;
+}

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -11,6 +11,7 @@ import {
 import { getContainerManager } from './container-manager';
 import { BAND_MIN_ZOOM, bandClampedMaxzoom, highestBandForFiles } from './s57-band';
 import { patchS57Mbtiles, setMbtilesDisplayName } from './mbtiles-metadata';
+import { sanitizeChartFilename } from './catalog-title';
 import type {
   ConversionProgress,
   ConversionProgressMap,
@@ -115,6 +116,64 @@ function setProgress(chartNumber: string, status: string, message: string): void
     conversionProgress[chartNumber].status = status;
     conversionProgress[chartNumber].message = message;
   }
+}
+
+/**
+ * Decide the on-disk `.mbtiles` filename for a freshly converted chart.
+ *
+ * Catalogs (NL_IENC, etc.) hand us sequential chart numbers like "1",
+ * "2", "3" — meaningless when the user later sees `1.mbtiles` in their
+ * chart directory.  When the catalog also supplied a human-friendly
+ * `displayName` (cleanCatalogTitle output, e.g. "Waddenzee met Diepte
+ * 2026 - Week 18"), use that as the filename basis instead.
+ *
+ * Falls back to `<chartNumber>.mbtiles` when no displayName is provided
+ * (manual upload path) or sanitizes to nothing.  Suffixes a numeric
+ * counter on collisions so re-running a conversion against the same
+ * catalog entry doesn't overwrite an existing chart silently.
+ */
+export function chooseOutputFilename(opts: {
+  chartsDir: string;
+  displayName: string | undefined;
+  chartNumber: string;
+  fileExists?: (path: string) => boolean;
+}): string {
+  const exists = opts.fileExists ?? fs.existsSync;
+  // Sanitize both inputs up-front: the chartNumber feeds both the base
+  // (when displayName is absent) and the collision suffix.  A malformed
+  // catalog with a chartNumber like "../../evil" would otherwise turn
+  // the candidate into a path-traversal escape and write the .mbtiles
+  // somewhere outside chartsDir.  Catalog values are typically integers
+  // and pass sanitization unchanged, so this is a safety net rather
+  // than a behaviour change.
+  const sanitized = opts.displayName ? sanitizeChartFilename(opts.displayName) : '';
+  const safeChartNumber = sanitizeChartFilename(opts.chartNumber);
+  const base = sanitized || safeChartNumber || 'enc-chart';
+
+  const candidate = `${base}.mbtiles`;
+  if (!exists(path.join(opts.chartsDir, candidate))) {
+    return candidate;
+  }
+
+  // Collision: try chartNumber-suffixed first (informative), then a counter.
+  // Catalog flow re-runs against the same chartNumber are the common case,
+  // so users immediately see "this is from chart entry 1, take 2" via
+  // the suffix instead of getting `Waddenzee_met_Diepte_2026-Week_18-2.mbtiles`.
+  if (sanitized && safeChartNumber && safeChartNumber !== sanitized) {
+    const numbered = `${base}-${safeChartNumber}.mbtiles`;
+    if (!exists(path.join(opts.chartsDir, numbered))) {
+      return numbered;
+    }
+  }
+  for (let i = 2; i < 1000; i += 1) {
+    const counted = `${base}-${i}.mbtiles`;
+    if (!exists(path.join(opts.chartsDir, counted))) {
+      return counted;
+    }
+  }
+  // Pathological: 1000 collisions.  Fall through to a timestamped name
+  // so we never silently overwrite.
+  return `${base}-${Date.now()}.mbtiles`;
 }
 
 interface ExportScriptOptions {
@@ -749,7 +808,11 @@ export async function processS57Zip(
     }
     const effectiveOptions: S57ConversionOptions = { ...options, maxzoom: clamp.effective };
 
-    const outputName = `${chartNumber || 'enc-chart'}.mbtiles`;
+    const outputName = chooseOutputFilename({
+      chartsDir,
+      displayName: options.displayName,
+      chartNumber
+    });
     const outputPath = path.join(chartsDir, outputName);
     await runTippecanoe(geojsonDir, outputPath, chartNumber, effectiveOptions);
 

--- a/test/catalog-title.test.js
+++ b/test/catalog-title.test.js
@@ -1,7 +1,7 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
 
-const { cleanCatalogTitle } = require('../dist/utils/catalog-title');
+const { cleanCatalogTitle, sanitizeChartFilename } = require('../dist/utils/catalog-title');
 
 describe('cleanCatalogTitle', () => {
   it('strips trailing size + index from a hyphen-separated NL IENC title', () => {
@@ -79,5 +79,64 @@ describe('cleanCatalogTitle', () => {
       cleanCatalogTitle('Chart (special edition) 2026'),
       'Chart (special edition) 2026'
     );
+  });
+});
+
+describe('sanitizeChartFilename', () => {
+  it('replaces spaces with underscores', () => {
+    assert.strictEqual(
+      sanitizeChartFilename('Waddenzee met Diepte 2026 - Week 18'),
+      'Waddenzee_met_Diepte_2026_-_Week_18'
+    );
+  });
+
+  it('collapses runs of whitespace', () => {
+    assert.strictEqual(sanitizeChartFilename('Foo   Bar\tBaz'), 'Foo_Bar_Baz');
+  });
+
+  it('replaces path separators with dashes', () => {
+    assert.strictEqual(sanitizeChartFilename('NL/Inland\\Foo'), 'NL-Inland-Foo');
+  });
+
+  it('replaces dots with dashes (no extension confusion mid-name)', () => {
+    assert.strictEqual(
+      sanitizeChartFilename('Port of Rotterdam 2026.04.21'),
+      'Port_of_Rotterdam_2026-04-21'
+    );
+  });
+
+  it('drops control characters', () => {
+    assert.strictEqual(sanitizeChartFilename('Foo\x00Bar\x1fBaz'), 'FooBarBaz');
+  });
+
+  it('preserves common safe punctuation (parens, dashes, brackets)', () => {
+    assert.strictEqual(
+      sanitizeChartFilename('Nederland (excl Zeeland, Waddenzee) 2026'),
+      'Nederland_(excl_Zeeland,_Waddenzee)_2026'
+    );
+  });
+
+  it('trims leading and trailing punctuation', () => {
+    assert.strictEqual(sanitizeChartFilename('  -.--__Foo Bar__--.-  '), 'Foo_Bar');
+  });
+
+  it('caps length at 100 chars and trims trailing punctuation after the cut', () => {
+    const long = 'A'.repeat(120);
+    const got = sanitizeChartFilename(long);
+    assert.strictEqual(got.length, 100);
+    assert.ok(got.endsWith('A'));
+  });
+
+  it('returns empty string for empty / whitespace / non-string', () => {
+    assert.strictEqual(sanitizeChartFilename(''), '');
+    assert.strictEqual(sanitizeChartFilename('   '), '');
+    assert.strictEqual(sanitizeChartFilename(undefined), '');
+    assert.strictEqual(sanitizeChartFilename(null), '');
+    assert.strictEqual(sanitizeChartFilename(42), '');
+  });
+
+  it('returns empty string when only unsafe characters remain after sanitization', () => {
+    // Just whitespace and control chars → nothing left after collapse + trim.
+    assert.strictEqual(sanitizeChartFilename('\x00 \x01\x02\x03'), '');
   });
 });

--- a/test/choose-output-filename.test.js
+++ b/test/choose-output-filename.test.js
@@ -1,0 +1,154 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+
+const { chooseOutputFilename } = require('../dist/utils/s57-converter');
+
+// Build a `fileExists` stub that says "yes" for the listed paths and "no"
+// for everything else.  Lets us drive the collision logic without
+// touching disk.
+function existsIn(paths) {
+  const set = new Set(paths);
+  return (p) => set.has(p);
+}
+
+describe('chooseOutputFilename', () => {
+  const chartsDir = '/charts';
+
+  it('uses the displayName-derived basename when no collision', () => {
+    const got = chooseOutputFilename({
+      chartsDir,
+      displayName: 'Waddenzee met Diepte 2026 - Week 18',
+      chartNumber: '1',
+      fileExists: existsIn([])
+    });
+    assert.strictEqual(got, 'Waddenzee_met_Diepte_2026_-_Week_18.mbtiles');
+  });
+
+  it('falls back to chartNumber when displayName is missing', () => {
+    const got = chooseOutputFilename({
+      chartsDir,
+      displayName: undefined,
+      chartNumber: '1',
+      fileExists: existsIn([])
+    });
+    assert.strictEqual(got, '1.mbtiles');
+  });
+
+  it('falls back to chartNumber when displayName sanitizes to empty', () => {
+    const got = chooseOutputFilename({
+      chartsDir,
+      displayName: '   ',
+      chartNumber: '1',
+      fileExists: existsIn([])
+    });
+    assert.strictEqual(got, '1.mbtiles');
+  });
+
+  it('falls back to "enc-chart" when both displayName and chartNumber are empty', () => {
+    const got = chooseOutputFilename({
+      chartsDir,
+      displayName: '',
+      chartNumber: '',
+      fileExists: existsIn([])
+    });
+    assert.strictEqual(got, 'enc-chart.mbtiles');
+  });
+
+  it('on collision, suffixes with the chartNumber for an informative filename', () => {
+    const taken = path.join(chartsDir, 'Waddenzee_met_Diepte_2026_-_Week_18.mbtiles');
+    const got = chooseOutputFilename({
+      chartsDir,
+      displayName: 'Waddenzee met Diepte 2026 - Week 18',
+      chartNumber: '1',
+      fileExists: existsIn([taken])
+    });
+    assert.strictEqual(got, 'Waddenzee_met_Diepte_2026_-_Week_18-1.mbtiles');
+  });
+
+  it('on chartNumber-suffix collision too, falls through to a counter', () => {
+    const taken = [
+      path.join(chartsDir, 'Waddenzee_met_Diepte_2026_-_Week_18.mbtiles'),
+      path.join(chartsDir, 'Waddenzee_met_Diepte_2026_-_Week_18-1.mbtiles')
+    ];
+    const got = chooseOutputFilename({
+      chartsDir,
+      displayName: 'Waddenzee met Diepte 2026 - Week 18',
+      chartNumber: '1',
+      fileExists: existsIn(taken)
+    });
+    assert.strictEqual(got, 'Waddenzee_met_Diepte_2026_-_Week_18-2.mbtiles');
+  });
+
+  it('counter increments past 2 when -2 is also taken', () => {
+    const taken = [
+      path.join(chartsDir, 'Foo.mbtiles'),
+      path.join(chartsDir, 'Foo-bar.mbtiles'),
+      path.join(chartsDir, 'Foo-2.mbtiles'),
+      path.join(chartsDir, 'Foo-3.mbtiles')
+    ];
+    const got = chooseOutputFilename({
+      chartsDir,
+      displayName: 'Foo',
+      chartNumber: 'bar',
+      fileExists: existsIn(taken)
+    });
+    assert.strictEqual(got, 'Foo-4.mbtiles');
+  });
+
+  it('sanitizes a hostile chartNumber used as the base (no displayName)', () => {
+    // Path-traversal protection: with displayName absent, the base is
+    // derived from chartNumber.  A hostile or malformed catalog with
+    // chartNumber='../../evil' must NOT yield a filename that escapes
+    // chartsDir when path.join'd.
+    const got = chooseOutputFilename({
+      chartsDir,
+      displayName: undefined,
+      chartNumber: '../../evil',
+      fileExists: existsIn([])
+    });
+    assert.ok(!got.includes('/'), `filename leaked separator: ${got}`);
+    assert.ok(!got.includes('\\'), `filename leaked separator: ${got}`);
+    assert.ok(!got.includes('..'), `filename leaked traversal: ${got}`);
+    // sanitizeChartFilename strips the leading '----' (slashes + dots all
+    // become dashes, then leading-dash trim) leaving 'evil'.
+    assert.strictEqual(got, 'evil.mbtiles');
+  });
+
+  it('sanitizes a hostile chartNumber suffix (path separators stripped)', () => {
+    // CR-flagged regression: a malformed chartNumber containing '/' or '\\'
+    // would otherwise embed a directory component into the chosen filename,
+    // and the post-conversion existsSync(outputPath) check would fail with
+    // "tippecanoe completed but output file not found" — confusing diagnostic
+    // for what's actually a chartNumber sanitization issue.
+    const taken = [path.join(chartsDir, 'Foo.mbtiles')];
+    const got = chooseOutputFilename({
+      chartsDir,
+      displayName: 'Foo',
+      chartNumber: 'evil/../bar',
+      fileExists: existsIn(taken)
+    });
+    assert.ok(!got.includes('/'), `filename leaked separator: ${got}`);
+    assert.ok(!got.includes('\\'), `filename leaked separator: ${got}`);
+    // sanitizeChartFilename collapses 'evil/../bar' → 'evil----bar': four
+    // characters match [/\\.] (slash, dot, dot, slash) and each becomes a
+    // dash.  Leading/trailing trim isn't triggered.  The regex below uses
+    // `-+` so it accepts any number of dashes — the assertion is "dash-
+    // joined and safe", not the exact dash count.
+    assert.match(got, /^Foo-evil-+bar\.mbtiles$/);
+  });
+
+  it('manual upload (no displayName, chartNumber-only) still avoids overwrite', () => {
+    const taken = [path.join(chartsDir, 'manual-upload.mbtiles')];
+    const got = chooseOutputFilename({
+      chartsDir,
+      displayName: undefined,
+      chartNumber: 'manual-upload',
+      fileExists: existsIn(taken)
+    });
+    // No displayName → `base` is derived from chartNumber, so `base ===
+    // safeChartNumber` and the chartNumber-suffix branch is skipped.
+    // Counter therefore falls through to `-2`.
+    assert.strictEqual(got, 'manual-upload-2.mbtiles');
+  });
+});


### PR DESCRIPTION
## Summary

Renames converted catalog charts from `1.mbtiles`, `2.mbtiles`, … to filenames derived from the catalog's human-friendly title:

| Before | After |
|---|---|
| `1.mbtiles` | `Waddenzee_met_Diepte_2026_-_Week_18.mbtiles` |
| `0.mbtiles` | `Zeeland_met_Diepte_-_2026_-_Week_19.mbtiles` |
| `4.mbtiles` | `20260216_U7Inland_Closed_Edition_NL.mbtiles` |

## Why

Catalogs (NL_IENC, etc.) hand chart-provider sequential chart numbers like `"1"`, `"2"`, `"3"` — meaningless when the user later sees `1.mbtiles` in their chart directory. The catalog flow already passes a clean `displayName` (cleanCatalogTitle output) which gets written into MBTiles `metadata.name`, but the on-disk filename was still `<chartNumber>.mbtiles`. Now both align.

## What changed

- New `sanitizeChartFilename` helper in [`utils/catalog-title.ts`](src/utils/catalog-title.ts): spaces → `_` (per user request, no spaces in filenames), `/`/`\\`/`.` → `-`, control chars dropped, leading/trailing punctuation trimmed, length capped at 100 chars. Pure helper.
- New `chooseOutputFilename` helper in [`utils/s57-converter.ts`](src/utils/s57-converter.ts): if `displayName` is present, use the sanitized title; otherwise fall back to (sanitized) `chartNumber`. On collision: append `-<chartNumber>` first (informative for catalog re-runs), then `-2`, `-3`, …, then a timestamp at 1000.
- `processS57Zip` now picks the output filename via `chooseOutputFilename` instead of `\`${chartNumber || 'enc-chart'}.mbtiles\``.

## Path-traversal protection

CR caught two related security issues during the local review:

1. The collision suffix used `chartNumber` unsanitized → a `chartNumber` like `evil/../bar` could embed a directory component into the candidate filename.
2. The base derivation used raw `chartNumber` when `displayName` was absent → `chartNumber='../../evil'` would yield `../../evil.mbtiles`, and `path.join(chartsDir, …)` would resolve **outside** `chartsDir`, writing the converted .mbtiles to an unintended location.

Both inputs (`displayName`, `chartNumber`) are now sanitized up-front. Catalog values are typically integers and pass sanitization unchanged, so this is a safety net rather than a behaviour change for normal use.

Two regression tests cover these cases.

## Out of scope (preserved as-is)

- **GSHHG basemaps**: filename stays `gshhg-basemap-<resolution>.mbtiles` (hardcoded; resolution is sufficient).
- **SHP basemaps**: filename stays `osm-basemap-<resolution>.mbtiles` (hardcoded).
- **RNC/BSB/Pilot conversions**: filenames are derived from per-chart KAP basenames already (`<kapbasename>.mbtiles`), which are meaningful — not affected by this change.
- **Manual upload path**: no `displayName` → falls back to `chartNumber` (sanitized) as before.

## Tested

- `npm run format && npm run build && npm run lint && npm test` locally — 179/179 green (was 156, +23 new across `sanitizeChartFilename`, `chooseOutputFilename`, and 2 path-traversal regression tests).
- `cr review --plain` locally on the diff: no findings (after addressing two path-traversal CR catches).

## No release tag yet

Per request — more fixes coming before we tag v2.0.0-beta.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved chart output filename selection using catalog display names when available.
  * Added automatic collision detection and prevention to avoid overwriting existing files.

* **Tests**
  * Added comprehensive test coverage for filename sanitization and collision handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->