### PR TITLE
fix(ui): incremental catalog poll — no more shimmer/scrollbar/progress-bar reset

### DIFF
--- a/public/css/chart-catalog.css
+++ b/public/css/chart-catalog.css
@@ -443,8 +443,12 @@ select.catalog-folder-select:hover {
     font-size: 14px;
 }
 
-/* Inline download progress */
-.catalog-download-progress {
+/* Inline download / conversion progress.  Same flex/typography for both
+ * pills; conversion has no progress bar (just spinner + message), download
+ * has a thin bar.  Two separate classes so pollConversions can update the
+ * conversion pill without touching the download pill.  */
+.catalog-download-progress,
+.catalog-conversion-progress {
     display: flex;
     align-items: center;
     gap: var(--md-sys-spacing-2);

--- a/public/js/chart-catalog.js
+++ b/public/js/chart-catalog.js
@@ -306,8 +306,12 @@ function renderChartList(catalogFile) {
       } else if (isConverting) {
         const progress = catalogConversionProgress[chart.number];
         const progressMsg = progress ? progress.message : 'Converting S-57 to vector tiles...';
+        // Stable ID so pollConversions can update the message text in
+        // place without re-rendering the surrounding row each tick (the
+        // re-render kills CSS animation continuity, scroll position, and
+        // the spinner's transform state).
         actionHtml = `
-          <div class="catalog-download-progress">
+          <div class="catalog-conversion-progress" id="catalog-conversion-${escapeId(chart.number)}">
             <div class="spinner" style="width:16px;height:16px;border-width:2px;"></div>
             <span>${escapeHtml(progressMsg)}</span>
             <button class="btn-catalog-log" onclick="showConversionLog('${escapeAttr(chart.number)}')">Logs</button>
@@ -502,6 +506,37 @@ async function pollCatalogDownloads() {
   }
 }
 
+/** Helper: serialize the current converting+error key set so we can
+ *  cheaply detect whether it changed since the last poll tick.  Sorted
+ *  to make {a,b} and {b,a} compare equal. */
+function catalogActiveStateKey() {
+  const conv = Object.keys(catalogConverting).sort().join(',');
+  const err = Object.keys(catalogConversionErrors).sort().join(',');
+  return `c=${conv}|e=${err}`;
+}
+
+let catalogPrevActiveStateKey = '';
+
+/** Walk currently-rendered conversion pills and update their message
+ *  text in place, without touching the surrounding DOM.  Avoids
+ *  destroying scroll position / spinner animation / progress-bar
+ *  state on every 3-second poll tick.  Only call when the
+ *  converting+error key set has not changed (the action-column shape
+ *  is the same; only the message inside it differs). */
+function updateConversionMessagesInPlace() {
+  for (const chartNumber of Object.keys(catalogConverting)) {
+    const pill = document.getElementById(`catalog-conversion-${escapeId(chartNumber)}`);
+    if (!pill) continue;
+    const span = pill.querySelector('span');
+    if (!span) continue;
+    const progress = catalogConversionProgress[chartNumber];
+    const msg = progress ? progress.message : 'Converting S-57 to vector tiles...';
+    if (span.textContent !== msg) {
+      span.textContent = msg;
+    }
+  }
+}
+
 async function pollConversions() {
   // Declared at function scope: the previous version had it inside the
   // `if (regResp.ok)` block, then referenced it on the outer-scope
@@ -552,11 +587,31 @@ async function pollConversions() {
       }
     }
 
-    const hasActive = Object.keys(catalogConverting).length > 0 ||
+    // Decide between full re-render (action-column shape changed:
+    // conversion started, finished, errored, or was dismissed) and
+    // in-place message update (same set of charts converting; only
+    // their progress message text differs).
+    //
+    // Doing a full innerHTML replace every 3 s during a long
+    // conversion was the root cause of three UX complaints: the
+    // shimmer animation restarted, the scrollbar flickered as the
+    // table re-laid-out, and the progress bar's CSS state got reset.
+    const activeStateKey = catalogActiveStateKey();
+    const stateChanged =
+      activeStateKey !== catalogPrevActiveStateKey || justFinished.length > 0;
+    catalogPrevActiveStateKey = activeStateKey;
+
+    const hasActive =
+      Object.keys(catalogConverting).length > 0 ||
       Object.keys(catalogConversionErrors).length > 0 ||
       justFinished.length > 0;
-    if (hasActive) {
+    if (!hasActive) {
+      return;
+    }
+    if (stateChanged) {
       renderCatalogList();
+    } else {
+      updateConversionMessagesInPlace();
     }
   } catch (_e) {
     // ignore


### PR DESCRIPTION
## Summary

Stops the Chart Catalog tab from destroying its DOM on every 3-second poll tick during a conversion. Fixes three UX annoyances reported by Dirk SV MOIN:

1. The shimmer animation restarted every poll cycle.
2. The scrollbar flickered as the table re-laid-out.
3. The progress bar reset to 0% / re-glowed every second.

All three are the same root cause: \`pollConversions\` called \`renderCatalogList()\` (full \`innerHTML\` replacement) every tick while any chart was converting, even when nothing changed except the progress message text inside an already-rendered "Converting…" pill.

## Fix

- **Track the active state across ticks** — the sorted set of converting + errored chart numbers. Full re-render fires only when that set genuinely changes (conversion started, finished, errored, or got dismissed; the action-column shape really differs). Otherwise the new \`updateConversionMessagesInPlace\` helper walks the existing pills and patches just \`<span>.textContent\`.
- **Stable id on the converting pill** (\`catalog-conversion-<chartNumber>\`) so the in-place updater can find it without query-by-content. The download pill already had a stable id and was already updating correctly.
- **Wrapper class rename** from \`catalog-download-progress\` → \`catalog-conversion-progress\` for the converting variant. The CSS file gets both classes on the existing flex/typography rules so the visual is unchanged.

## Out of scope

The same destructive-render pattern *could* exist on the manage-charts tab, but [\`manage-charts-enhanced.js\`](public/js/manage-charts-enhanced.js#L66-L92) already does smart-render (only on length / downloading / converting flips). No fix needed there.

The download pill (\`pollCatalogDownloads\`) was already updating in place. Only the conversion poll was destructive.

## Tested

- \`npm run format && npm run build && npm run lint && npm test\` locally — 179/179 green.
- \`cr review --plain\` locally on the diff: no findings.
- Manual: re-ran a Waddenzee conversion against the live SignalK; conversion progresses smoothly, scroll position is preserved, no flicker, progress text updates in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Unified styling for download and conversion progress indicators.

* **Refactor**
  * Enhanced chart conversion progress display to preserve scroll position and animation continuity during status updates, eliminating unnecessary full-interface refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->