### PR TITLE
feat(config): validate plugin settings with TypeBox

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@signalk/server-api": "^2.0.0",
+    "@sinclair/typebox": "^0.34.49",
     "busboy": "^1.6.0",
     "unzipper": "^0.12.3",
     "xml2js": "^0.6.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import {
 import { processGshhg, processShpBasemap } from './utils/s57-converter';
 import { getCpuBudget, setCpuBudget } from './utils/concurrency';
 import { writeChartPathMarker } from './utils/path-marker';
+import { parsePluginConfig } from './utils/plugin-config-schema';
 
 // Read at module load so the marker file always reflects the running build.
 // `require` keeps this synchronous and avoids dragging package.json into the
@@ -111,10 +112,21 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     }),
     uiSchema: () => ({}),
     start: (settings) => {
+      // Validate the saved config against the TypeBox schema before doing
+      // anything with it. Bad shapes show up as a clear plugin error in
+      // the admin UI instead of crashing several frames into doStartup.
+      let config: PluginConfig;
+      try {
+        config = parsePluginConfig(settings);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        app.setPluginError(msg);
+        return;
+      }
       // Signal K does not await start(); run async init in a self-contained
       // promise that handles its own errors so a setPluginError surfaces
       // anything we couldn't recover from (e.g. signalk-container missing).
-      doStartup(settings as PluginConfig).catch((err: unknown) => {
+      doStartup(config).catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
         app.setPluginError(`Startup failed: ${msg}`);
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,13 +3,10 @@ import type { Request, Response, IRouter } from 'express';
 import type { MBTilesReader } from './utils/mbtiles-reader';
 
 // ---- Plugin Configuration ----
+// Runtime-validated via TypeBox in `utils/plugin-config-schema.ts`.
+// Re-exported here so existing imports (`from './types'`) keep working.
 
-export type CpuBudgetPreset = 'single-core' | 'half' | 'all';
-
-export interface PluginConfig {
-  chartPath: string;
-  cpuBudget?: CpuBudgetPreset;
-}
+export type { CpuBudgetPreset, PluginConfig } from './utils/plugin-config-schema';
 
 // ---- Extended ServerAPI ----
 // ServerAPI from @signalk/server-api does not expose app.config or app.get() for route registration.

--- a/src/utils/plugin-config-schema.ts
+++ b/src/utils/plugin-config-schema.ts
@@ -1,0 +1,39 @@
+import { Type, type Static } from '@sinclair/typebox';
+import { Value } from '@sinclair/typebox/value';
+
+export const CpuBudgetPresetSchema = Type.Union([
+  Type.Literal('single-core'),
+  Type.Literal('half'),
+  Type.Literal('all')
+]);
+
+// `chartPath` is required in the parsed shape so downstream callers can
+// treat it as a definite string. Empty string means "use the computed
+// default": Signal K passes `{}` on auto-enable (the plugin has
+// `signalk-plugin-enabled-by-default: true` and Signal K does not inject
+// JSON-schema defaults at runtime), so the validator normalizes a missing
+// `chartPath` to `''` before checking.
+export const PluginConfigSchema = Type.Object({
+  chartPath: Type.String(),
+  cpuBudget: Type.Optional(CpuBudgetPresetSchema)
+});
+
+export type CpuBudgetPreset = Static<typeof CpuBudgetPresetSchema>;
+export type PluginConfig = Static<typeof PluginConfigSchema>;
+
+export function parsePluginConfig(input: unknown): PluginConfig {
+  // Normalize the auto-enable shape (`{}`) by injecting an empty
+  // chartPath; doStartup() falls back to the computed default for `''`.
+  const normalized =
+    typeof input === 'object' && input !== null && !Array.isArray(input)
+      ? { chartPath: '', ...(input as Record<string, unknown>) }
+      : input;
+  if (Value.Check(PluginConfigSchema, normalized)) {
+    return normalized;
+  }
+  const errors = [...Value.Errors(PluginConfigSchema, normalized)]
+    .slice(0, 3)
+    .map((e) => `${e.path || '<root>'}: ${e.message}`)
+    .join('; ');
+  throw new Error(`Invalid plugin configuration — ${errors}`);
+}

--- a/test/plugin-config-schema.test.ts
+++ b/test/plugin-config-schema.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { parsePluginConfig } from '../dist/utils/plugin-config-schema';
+
+describe('parsePluginConfig', () => {
+  it('accepts a minimal config with just chartPath', () => {
+    const config = parsePluginConfig({ chartPath: '/var/charts' });
+    assert.strictEqual(config.chartPath, '/var/charts');
+    assert.strictEqual(config.cpuBudget, undefined);
+  });
+
+  it('accepts an empty config (Signal K passes {} during auto-enable)', () => {
+    // The plugin sets `signalk-plugin-enabled-by-default: true`, so on a
+    // fresh install Signal K calls start({}) before the user has saved
+    // any settings. The validator normalizes the missing field to '' so
+    // doStartup's `props.chartPath || defaultChartsPath` fallback fires.
+    const config = parsePluginConfig({});
+    assert.strictEqual(config.chartPath, '');
+  });
+
+  it('accepts an empty-string chartPath (user cleared the field)', () => {
+    const config = parsePluginConfig({ chartPath: '' });
+    assert.strictEqual(config.chartPath, '');
+  });
+
+  it('accepts each cpuBudget preset', () => {
+    for (const preset of ['single-core', 'half', 'all'] as const) {
+      const config = parsePluginConfig({ chartPath: '/x', cpuBudget: preset });
+      assert.strictEqual(config.cpuBudget, preset);
+    }
+  });
+
+  it('rejects an unknown cpuBudget value', () => {
+    assert.throws(() => parsePluginConfig({ chartPath: '/x', cpuBudget: 'turbo' }), /cpuBudget/);
+  });
+
+  it('rejects a non-string chartPath', () => {
+    assert.throws(() => parsePluginConfig({ chartPath: 42 }), /chartPath/);
+  });
+
+  it('rejects null', () => {
+    assert.throws(() => parsePluginConfig(null));
+  });
+
+  it('rejects a non-object input (string, array, etc.)', () => {
+    assert.throws(() => parsePluginConfig('hi'));
+    assert.throws(() => parsePluginConfig([]));
+  });
+});


### PR DESCRIPTION
## Summary

Introduces TypeBox runtime validation at the plugin-config boundary. The saved settings Signal K hands to `start()` are now checked against a schema before anything else runs.

- New `src/utils/plugin-config-schema.ts` exports `PluginConfigSchema`, `PluginConfig` (derived via `Static<>`), `CpuBudgetPreset`, and `parsePluginConfig(input)` that returns the typed config or throws with up to three field-level error messages.
- `src/index.ts` `start()` validates the saved config before invoking `doStartup`. A malformed config surfaces as one clear `setPluginError` line instead of crashing several frames into startup with an unhelpful stack.
- The validator normalizes a missing `chartPath` to `''` so the auto-enable shape (`{}`) keeps working: `signalk-plugin-enabled-by-default: true` means Signal K calls `start({})` on first install, and Signal K does not inject JSON-schema defaults at runtime. `doStartup`'s existing `props.chartPath || defaultChartsPath` fallback fires unchanged, and downstream call sites still see `chartPath: string`.
- `src/types.ts` re-exports `PluginConfig` / `CpuBudgetPreset` from the new module so existing imports keep working.

This is part 1 of three TypeBox passes:
1. **Plugin config (this PR)** — smallest, most contained boundary.
2. REST handler bodies / params (especially numeric zoom bounds, busboy fields).
3. Catalog XML and cached-JSON parsing.

## Tested

- `npm run format` clean
- `npm run build` clean
- `npm run lint` clean (now also covers `playwright.config.ts`)
- `npm test` — 187/187 pass (8 new tests in `test/plugin-config-schema.test.ts` covering minimal config, auto-enable `{}`, every `cpuBudget` preset, unknown preset, non-string `chartPath`, `null`, non-object inputs)
- `npm run test:e2e` — 7/7 pass
- Local `cr review --plain --base origin/main` — No findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Plugin configuration is now validated at startup. Invalid configuration settings are caught early and reported with clear error messages to help diagnose issues.

* **Chores**
  * Added dependencies to support runtime configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->