### PR TITLE
feat(api): TypeBox-validate /catalog/download body

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,8 @@ import { processGshhg, processShpBasemap } from './utils/s57-converter';
 import { getCpuBudget, setCpuBudget } from './utils/concurrency';
 import { writeChartPathMarker } from './utils/path-marker';
 import { parsePluginConfig } from './utils/plugin-config-schema';
+import { Type } from '@sinclair/typebox';
+import { parseBody } from './utils/rest-validation';
 
 // Read at module load so the marker file always reflects the running build.
 // `require` keeps this synchronous and avoids dragging package.json into the
@@ -373,6 +375,27 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       }
     }
   };
+
+  // Tippecanoe accepts zooms 0–22 in practice (anything beyond produces
+  // 4×4 pixel tiles per source feature; nothing useful comes out and the
+  // job runs much longer). Bound the inputs to that envelope so a typo
+  // (`minzoom: 100`) is rejected at the boundary instead of silently
+  // turning into a multi-hour conversion that produces unusable output.
+  const ZoomLevel = Type.Integer({ minimum: 0, maximum: 22 });
+
+  const CatalogDownloadBody = Type.Object({
+    // `^https?://` is the floor: rejecting `file://`, `gopher://`, and the
+    // bare-string SSRF case (e.g. supplying `169.254.169.254/...` as a
+    // path-relative URL). Per-host allowlisting is a bigger conversation
+    // — catalog charts come from many community-run hosts.
+    url: Type.String({ minLength: 1, pattern: '^https?://' }),
+    chartNumber: Type.String({ minLength: 1 }),
+    catalogFile: Type.String({ minLength: 1 }),
+    zipfileDatetime: Type.Optional(Type.String()),
+    targetFolder: Type.Optional(Type.String()),
+    minzoom: Type.Optional(ZoomLevel),
+    maxzoom: Type.Optional(ZoomLevel)
+  });
 
   const registerRoutes = (router: IRouter): void => {
     app.debug('** Registering API paths via registerWithRouter **');
@@ -1511,24 +1534,19 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     });
 
     router.post('/catalog/download', (req: Request, res: Response) => {
-      const { url, chartNumber, catalogFile, zipfileDatetime, targetFolder, minzoom, maxzoom } =
-        req.body as {
-          url?: string;
-          chartNumber?: string;
-          catalogFile?: string;
-          zipfileDatetime?: string;
-          targetFolder?: string;
-          minzoom?: number;
-          maxzoom?: number;
-        };
-
-      if (!url || !chartNumber || !catalogFile) {
-        res.status(400).json({
-          success: false,
-          error: 'url, chartNumber, and catalogFile are required'
-        });
+      const body = parseBody(CatalogDownloadBody, req, res);
+      if (!body) {
         return;
       }
+      // TypeBox bounds each field independently; cross-field invariants
+      // (`minzoom <= maxzoom`) need a plain post-parse guard. A typo
+      // here would silently produce empty tile sets after a long run.
+      if (body.minzoom !== undefined && body.maxzoom !== undefined && body.minzoom > body.maxzoom) {
+        res.status(400).json({ success: false, error: 'minzoom must be ≤ maxzoom' });
+        return;
+      }
+      const { url, chartNumber, catalogFile, zipfileDatetime, targetFolder, minzoom, maxzoom } =
+        body;
 
       const registryEntry = getCatalogRegistry().find((r) => r.file === catalogFile);
       const catalogCategory = registryEntry ? registryEntry.category : '';
@@ -1545,6 +1563,20 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         const chartPath = props.chartPath || defaultChartsPath;
         const targetDir =
           !targetFolder || targetFolder === '/' ? chartPath : path.join(chartPath, targetFolder);
+
+        // Reject `targetFolder: '../etc'` etc. before mkdir/mkdirSync. Same
+        // guard the other mutating routes (/folders, /move-chart, /rename-chart)
+        // already use; the schema's String pattern can't catch every traversal
+        // vector (e.g. `valid/../escape`), so the canonical fix is here.
+        const normalizedTargetDir = path.normalize(targetDir);
+        const normalizedChartPath = path.normalize(chartPath);
+        if (
+          normalizedTargetDir !== normalizedChartPath &&
+          !normalizedTargetDir.startsWith(normalizedChartPath + path.sep)
+        ) {
+          res.status(403).json({ success: false, error: 'Access denied: Invalid target folder' });
+          return;
+        }
 
         if (!fs.existsSync(targetDir)) {
           fs.mkdirSync(targetDir, { recursive: true });

--- a/src/utils/rest-validation.ts
+++ b/src/utils/rest-validation.ts
@@ -1,0 +1,42 @@
+/**
+ * Helpers for validating REST request shapes against TypeBox schemas.
+ *
+ * Each handler that adopts this gets:
+ *  - a typed body (no more `as { foo?: string }` casts)
+ *  - a single 400 response with a list of which fields failed and why,
+ *    instead of one ad-hoc `if (!field)` per field
+ *
+ * Usage:
+ *
+ *   const Body = Type.Object({ ... });
+ *   const body = parseBody(Body, req, res);
+ *   if (!body) return; // 400 already sent
+ *   // body is fully typed from here
+ */
+
+import type { Response } from 'express';
+import type { Request } from '../types';
+import { Value } from '@sinclair/typebox/value';
+import type { TSchema, Static } from '@sinclair/typebox';
+
+function formatErrors(schema: TSchema, input: unknown): string[] {
+  return [...Value.Errors(schema, input)]
+    .slice(0, 5)
+    .map((e) => `${e.path || '<root>'}: ${e.message}`);
+}
+
+export function parseBody<T extends TSchema>(
+  schema: T,
+  req: Request,
+  res: Response
+): Static<T> | null {
+  if (Value.Check(schema, req.body)) {
+    return req.body;
+  }
+  res.status(400).json({
+    success: false,
+    error: 'Invalid request body',
+    details: formatErrors(schema, req.body)
+  });
+  return null;
+}

--- a/test/rest-validation.test.ts
+++ b/test/rest-validation.test.ts
@@ -1,0 +1,97 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { Type } from '@sinclair/typebox';
+
+import { parseBody } from '../dist/utils/rest-validation';
+
+interface FakeRes {
+  statusCode: number;
+  body: unknown;
+  status(code: number): FakeRes;
+  json(payload: unknown): FakeRes;
+}
+
+function fakeRes(): FakeRes {
+  const res: FakeRes = {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+  return res;
+}
+
+describe('parseBody', () => {
+  const Body = Type.Object({
+    url: Type.String({ minLength: 1 }),
+    minzoom: Type.Optional(Type.Integer({ minimum: 0, maximum: 22 }))
+  });
+
+  it('returns the typed body when valid', () => {
+    const res = fakeRes();
+    const result = parseBody(
+      Body,
+      { body: { url: 'http://x', minzoom: 5 } } as never,
+      res as never
+    );
+    assert.deepStrictEqual(result, { url: 'http://x', minzoom: 5 });
+    assert.strictEqual(res.statusCode, 200);
+  });
+
+  it('returns null and sends 400 when a required field is missing', () => {
+    const res = fakeRes();
+    const result = parseBody(Body, { body: {} } as never, res as never);
+    assert.strictEqual(result, null);
+    assert.strictEqual(res.statusCode, 400);
+    const payload = res.body as { success: boolean; error: string; details: string[] };
+    assert.strictEqual(payload.success, false);
+    assert.match(payload.error, /Invalid request body/);
+    assert.ok(payload.details.some((d) => /url/.test(d)));
+  });
+
+  it('rejects an out-of-range zoom level', () => {
+    const res = fakeRes();
+    const result = parseBody(
+      Body,
+      { body: { url: 'http://x', minzoom: 99 } } as never,
+      res as never
+    );
+    assert.strictEqual(result, null);
+    assert.strictEqual(res.statusCode, 400);
+    const payload = res.body as { details: string[] };
+    assert.ok(payload.details.some((d) => /minzoom/.test(d)));
+  });
+
+  it('rejects a non-integer zoom level', () => {
+    const res = fakeRes();
+    const result = parseBody(
+      Body,
+      { body: { url: 'http://x', minzoom: 5.5 } } as never,
+      res as never
+    );
+    assert.strictEqual(result, null);
+    assert.strictEqual(res.statusCode, 400);
+  });
+
+  it('caps the details list at five entries even with more failures', () => {
+    const Big = Type.Object({
+      a: Type.String(),
+      b: Type.String(),
+      c: Type.String(),
+      d: Type.String(),
+      e: Type.String(),
+      f: Type.String(),
+      g: Type.String()
+    });
+    const res = fakeRes();
+    parseBody(Big, { body: {} } as never, res as never);
+    const payload = res.body as { details: string[] };
+    assert.ok(payload.details.length <= 5);
+  });
+});


### PR DESCRIPTION
## Summary

Part 2 of three TypeBox passes (after #65 — plugin config). This PR introduces a small request-body validation helper and applies it to one handler so the pattern can be reviewed before it spreads to the other ~6 mutating routes.

- New `src/utils/rest-validation.ts` — `parseBody(schema, req, res)` runs `Value.Check`, returns the typed body on success, or sends a single 400 with up to five field-level error messages.
- POST `/catalog/download` migrated. The new schema covers four bug classes the existence-only checks were missing:
  - **Out-of-range zoom levels** — bounds at `[0, 22]`. Anything above produces 4×4-pixel tiles per source feature; tippecanoe runs much longer for no useful output.
  - **`minzoom > maxzoom`** — rejected with a single 400 right after `parseBody`. TypeBox doesn't model cross-field constraints.
  - **SSRF via `url`** — schema requires `^https?://`. Doesn't replace per-host allowlisting (catalog charts come from many community-run hosts), but rejects `file://`, `gopher://`, and the bare-string metadata-endpoint case.
  - **Path traversal via `targetFolder`** — same `path.normalize` / `startsWith` guard the other mutating routes (`/folders`, `/move-chart`, `/rename-chart`) already use. The String pattern alone can't cover every traversal vector (e.g. `valid/../escape`), so the canonical fix lives in the handler.

Only one handler is migrated here — the helper shape is what wants review before it ships across all the body-taking routes.

## Tested

- `npm run format` clean
- `npm run build` clean
- `npm run lint` clean
- `npm test` — 192/192 pass (5 new tests in `test/rest-validation.test.ts` covering valid body, missing field, out-of-range zoom, non-integer zoom, error-list cap)
- `npm run test:e2e` — 7/7 pass
- Local `cr review --plain --base origin/main` — No findings (after addressing 3 valid findings on first pass: SSRF pattern, cross-field zoom guard, path-traversal handler guard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request validation for the catalog download endpoint with zoom level constraints (0–22) and directory path verification.

* **Bug Fixes**
  * Invalid download requests now return detailed error responses identifying specific validation failures.

* **Tests**
  * Added test coverage for request validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->