### PR TITLE
feat(catalog): TypeBox-validate cache JSON read paths

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -129,49 +129,28 @@ export interface DownloadJob {
 }
 
 // ---- Catalog Manager ----
+// Most catalog types are runtime-validated via TypeBox in
+// `utils/catalog-schemas.ts`. Re-exported here so existing imports
+// (`from './types'`) keep working. `CatalogRegistryInfo` is a UI-only
+// shape (built in-memory after registering, never parsed from JSON), so
+// it stays a plain interface.
 
-export type CatalogCategory = 'mbtiles' | 'ienc' | 'rnc' | 'general';
+export type {
+  CatalogCategory,
+  CatalogRegistryEntry,
+  CatalogChart,
+  CatalogHeader,
+  CatalogData,
+  CatalogInstall,
+  CatalogInstallsMap
+} from './utils/catalog-schemas';
 
-export interface CatalogRegistryEntry {
-  file: string;
-  label: string;
-  category: CatalogCategory;
-}
+import type { CatalogRegistryEntry } from './utils/catalog-schemas';
 
 export interface CatalogRegistryInfo extends CatalogRegistryEntry {
   chartCount: number | null;
   cachedAt: string | null;
 }
-
-export interface CatalogChart {
-  number: string;
-  title: string;
-  format: string;
-  zipfile_location: string;
-  zipfile_datetime_iso8601: string;
-}
-
-export interface CatalogHeader {
-  title: string;
-  dateCreated: string;
-  dateValid: string;
-}
-
-export interface CatalogData {
-  fetchedAt: string;
-  catalogFile: string;
-  header: CatalogHeader;
-  charts: CatalogChart[];
-}
-
-export interface CatalogInstall {
-  catalogFile: string;
-  zipfile_datetime_iso8601: string;
-  installedAt: string;
-  zipfile_location: string;
-}
-
-export type CatalogInstallsMap = Record<string, CatalogInstall>;
 
 export type UrlFormat =
   | 'mbtiles'

--- a/src/utils/catalog-manager.ts
+++ b/src/utils/catalog-manager.ts
@@ -13,6 +13,13 @@ import type {
   CatalogUpdate,
   DebugFunction
 } from '../types';
+import {
+  CatalogDataSchema,
+  CatalogInstallsMapSchema,
+  CatalogRegistryCacheSchema,
+  GithubContentsListingSchema,
+  safeParse
+} from './catalog-schemas';
 
 const CATALOG_BASE_URL = 'https://raw.githubusercontent.com/chartcatalogs/catalogs/master/';
 const CATALOG_GITHUB_API = 'https://api.github.com/repos/chartcatalogs/catalogs/contents/';
@@ -110,10 +117,16 @@ function loadRegistryCache(): void {
   const cachePath = path.join(cacheDir, '_registry.json');
   try {
     if (fs.existsSync(cachePath)) {
-      catalogRegistry = JSON.parse(fs.readFileSync(cachePath, 'utf-8')) as CatalogRegistryEntry[];
+      const raw: unknown = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+      const parsed = safeParse(CatalogRegistryCacheSchema, raw);
+      if (parsed) {
+        catalogRegistry = parsed;
+      } else {
+        debug('Discarding registry cache — shape did not match schema');
+      }
     }
   } catch {
-    // ignore
+    // JSON parse error — file is corrupted, leave registry empty.
   }
 }
 
@@ -130,7 +143,14 @@ function loadInstalls(): void {
   try {
     if (fs.existsSync(installsFilePath)) {
       const data = fs.readFileSync(installsFilePath, 'utf-8');
-      installs = JSON.parse(data) as CatalogInstallsMap;
+      const raw: unknown = JSON.parse(data);
+      const parsed = safeParse(CatalogInstallsMapSchema, raw);
+      if (parsed) {
+        installs = parsed;
+      } else {
+        console.error('Discarding catalog installs file — shape did not match schema');
+        installs = {};
+      }
     }
   } catch (error) {
     console.error('Error loading catalog installs:', error);
@@ -151,7 +171,13 @@ function readCacheFile(catalogFile: string): CatalogData | null {
   try {
     if (fs.existsSync(cachePath)) {
       const data = fs.readFileSync(cachePath, 'utf-8');
-      return JSON.parse(data) as CatalogData;
+      const raw: unknown = JSON.parse(data);
+      const parsed = safeParse(CatalogDataSchema, raw);
+      if (!parsed) {
+        debug(`Discarding cache for ${catalogFile} — shape did not match schema`);
+        return null;
+      }
+      return parsed;
     }
   } catch (error) {
     debug(
@@ -268,7 +294,12 @@ export function fetchCatalogRegistry(): Promise<CatalogRegistryEntry[]> {
 
           response.on('end', () => {
             try {
-              const files = JSON.parse(data) as Array<{ name: string }>;
+              const raw: unknown = JSON.parse(data);
+              const files = safeParse(GithubContentsListingSchema, raw);
+              if (!files) {
+                reject(new Error('GitHub API response did not match expected shape'));
+                return;
+              }
               const xmlFiles: CatalogRegistryEntry[] = files
                 .filter((f) => f.name.endsWith('_Catalog.xml'))
                 .map((f) => ({

--- a/src/utils/catalog-schemas.ts
+++ b/src/utils/catalog-schemas.ts
@@ -1,0 +1,98 @@
+/**
+ * TypeBox schemas + safe-parse helpers for the catalog manager's JSON
+ * read paths (cached catalog files, installs map, registry cache, GitHub
+ * API response).
+ *
+ * Why: every read site previously did `JSON.parse(...) as CatalogData` and
+ * trusted the bytes. A hand-edited or corrupted cache file would put a
+ * malformed shape into memory and surface as a `Cannot read properties of
+ * undefined` later, far from the actual cause. With these schemas a bad
+ * cache is rejected at the read boundary; the manager falls back to
+ * "no cache" / "no installs" and the next refresh writes a clean file.
+ *
+ * The XML parse path is *not* covered here — xml2js's arrays-of-strings
+ * shape is awkward to model in TypeBox and the function already filters
+ * per-entry with a try/catch.
+ */
+
+import { Type, type Static } from '@sinclair/typebox';
+import { Value } from '@sinclair/typebox/value';
+import type { TSchema } from '@sinclair/typebox';
+
+export const CatalogCategorySchema = Type.Union([
+  Type.Literal('mbtiles'),
+  Type.Literal('ienc'),
+  Type.Literal('rnc'),
+  Type.Literal('general')
+]);
+
+export const CatalogRegistryEntrySchema = Type.Object({
+  file: Type.String(),
+  label: Type.String(),
+  category: CatalogCategorySchema
+});
+
+export const CatalogChartSchema = Type.Object({
+  number: Type.String(),
+  title: Type.String(),
+  format: Type.String(),
+  zipfile_location: Type.String(),
+  zipfile_datetime_iso8601: Type.String()
+});
+
+// `dateCreated` and `dateValid` are absent from some real catalog XML
+// headers (and from cached fixtures written by older builds). The
+// parser populates them as `''` when missing; mark optional in the
+// schema so a header without them still validates.
+export const CatalogHeaderSchema = Type.Object({
+  title: Type.String(),
+  dateCreated: Type.Optional(Type.String()),
+  dateValid: Type.Optional(Type.String())
+});
+
+export const CatalogDataSchema = Type.Object({
+  fetchedAt: Type.String(),
+  catalogFile: Type.String(),
+  header: CatalogHeaderSchema,
+  charts: Type.Array(CatalogChartSchema)
+});
+
+export const CatalogInstallSchema = Type.Object({
+  catalogFile: Type.String(),
+  zipfile_datetime_iso8601: Type.String(),
+  installedAt: Type.String(),
+  zipfile_location: Type.String()
+});
+
+export const CatalogInstallsMapSchema = Type.Record(Type.String(), CatalogInstallSchema);
+
+export const CatalogRegistryCacheSchema = Type.Array(CatalogRegistryEntrySchema);
+
+// Shape returned by GitHub's contents API for a directory listing. We
+// only consume `name`; the real response has many more fields, so the
+// schema validates one field by-name and ignores the rest via
+// additionalProperties (TypeBox default).
+export const GithubContentsListingSchema = Type.Array(
+  Type.Object({
+    name: Type.String()
+  })
+);
+
+export type CatalogCategory = Static<typeof CatalogCategorySchema>;
+export type CatalogRegistryEntry = Static<typeof CatalogRegistryEntrySchema>;
+export type CatalogChart = Static<typeof CatalogChartSchema>;
+export type CatalogHeader = Static<typeof CatalogHeaderSchema>;
+export type CatalogData = Static<typeof CatalogDataSchema>;
+export type CatalogInstall = Static<typeof CatalogInstallSchema>;
+export type CatalogInstallsMap = Static<typeof CatalogInstallsMapSchema>;
+export type CatalogRegistryCache = Static<typeof CatalogRegistryCacheSchema>;
+export type GithubContentsListing = Static<typeof GithubContentsListingSchema>;
+
+/**
+ * Validate `input` against `schema`. On success returns the typed value;
+ * on failure returns `null` so the caller can fall back without
+ * try/catching every read site.
+ */
+export function safeParse<T extends TSchema>(schema: T, input: unknown): Static<T> | null {
+  return Value.Check(schema, input) ? input : null;
+}

--- a/test/catalog-manager.test.ts
+++ b/test/catalog-manager.test.ts
@@ -304,7 +304,15 @@ describe('CatalogManager', () => {
         fetchedAt: '2020-01-01T00:00:00Z', // very old
         catalogFile: 'OLD_TEST_Catalog.xml',
         header: { title: 'Old Test' },
-        charts: [{ number: 'old1', title: 'Old Chart' }]
+        charts: [
+          {
+            number: 'old1',
+            title: 'Old Chart',
+            format: '',
+            zipfile_location: '',
+            zipfile_datetime_iso8601: ''
+          }
+        ]
       };
       fs.writeFileSync(
         path.join(cacheDir, 'OLD_TEST_Catalog.json'),

--- a/test/catalog-schemas.test.ts
+++ b/test/catalog-schemas.test.ts
@@ -1,0 +1,114 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  CatalogDataSchema,
+  CatalogInstallsMapSchema,
+  CatalogRegistryCacheSchema,
+  GithubContentsListingSchema,
+  safeParse
+} from '../dist/utils/catalog-schemas';
+
+describe('catalog schemas (cache JSON validation)', () => {
+  describe('CatalogDataSchema', () => {
+    const valid = {
+      fetchedAt: '2026-05-08T00:00:00Z',
+      catalogFile: 'NL_IENC.xml',
+      header: { title: 'NL IENC', dateCreated: '2026-05-01', dateValid: '2027-05-01' },
+      charts: [
+        {
+          number: '1',
+          title: 'Waddenzee',
+          format: 'S-57',
+          zipfile_location: 'https://example.com/wadd.zip',
+          zipfile_datetime_iso8601: '2026-05-01T00:00:00Z'
+        }
+      ]
+    };
+
+    it('accepts a well-formed catalog', () => {
+      assert.deepStrictEqual(safeParse(CatalogDataSchema, valid), valid);
+    });
+
+    it('accepts an empty charts array (catalog with no entries yet)', () => {
+      const empty = { ...valid, charts: [] };
+      assert.deepStrictEqual(safeParse(CatalogDataSchema, empty), empty);
+    });
+
+    it('rejects a missing top-level field', () => {
+      const { header: _h, ...without } = valid;
+      assert.strictEqual(safeParse(CatalogDataSchema, without), null);
+    });
+
+    it('rejects a chart with a non-string zipfile_location', () => {
+      const bad = { ...valid, charts: [{ ...valid.charts[0], zipfile_location: 42 }] };
+      assert.strictEqual(safeParse(CatalogDataSchema, bad), null);
+    });
+
+    it('rejects a non-array charts field', () => {
+      const bad = { ...valid, charts: 'not-an-array' };
+      assert.strictEqual(safeParse(CatalogDataSchema, bad), null);
+    });
+  });
+
+  describe('CatalogInstallsMapSchema', () => {
+    it('accepts an empty map', () => {
+      assert.deepStrictEqual(safeParse(CatalogInstallsMapSchema, {}), {});
+    });
+
+    it('accepts a map keyed by chart number', () => {
+      const m = {
+        '1': {
+          catalogFile: 'NL_IENC.xml',
+          zipfile_datetime_iso8601: '2026-05-01T00:00:00Z',
+          installedAt: '2026-05-08T00:00:00Z',
+          zipfile_location: 'https://example.com/wadd.zip'
+        }
+      };
+      assert.deepStrictEqual(safeParse(CatalogInstallsMapSchema, m), m);
+    });
+
+    it('rejects a value missing zipfile_location', () => {
+      const m = {
+        '1': {
+          catalogFile: 'NL_IENC.xml',
+          zipfile_datetime_iso8601: '2026-05-01T00:00:00Z',
+          installedAt: '2026-05-08T00:00:00Z'
+        }
+      };
+      assert.strictEqual(safeParse(CatalogInstallsMapSchema, m), null);
+    });
+  });
+
+  describe('CatalogRegistryCacheSchema', () => {
+    it('accepts a list of registry entries', () => {
+      const list = [{ file: 'NL_IENC.xml', label: 'NL IENC', category: 'ienc' }];
+      assert.deepStrictEqual(safeParse(CatalogRegistryCacheSchema, list), list);
+    });
+
+    it('rejects an entry with an unknown category', () => {
+      const list = [{ file: 'X.xml', label: 'X', category: 'star-trek' }];
+      assert.strictEqual(safeParse(CatalogRegistryCacheSchema, list), null);
+    });
+  });
+
+  describe('GithubContentsListingSchema', () => {
+    it('accepts a real-shaped GitHub contents response (extra fields ignored)', () => {
+      const list = [
+        { name: 'NL_IENC_Catalog.xml', size: 1234, sha: 'abc' },
+        { name: 'README.md', size: 50 }
+      ];
+      assert.deepStrictEqual(safeParse(GithubContentsListingSchema, list), list);
+    });
+
+    it('rejects when name is missing', () => {
+      assert.strictEqual(safeParse(GithubContentsListingSchema, [{ size: 1 }]), null);
+    });
+  });
+
+  describe('safeParse', () => {
+    it('returns null on null input', () => {
+      assert.strictEqual(safeParse(CatalogInstallsMapSchema, null), null);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Part 3 of three TypeBox passes (after #65 plugin config and #68 REST handlers). This pass tightens the catalog manager's JSON read boundaries.

The catalog manager reads four JSON inputs:
- `catalog-cache/_registry.json` — registry cache, written between starts
- `catalog-installs.json` — charts the user has downloaded
- `catalog-cache/<file>.json` — per-catalog cached parse output
- GitHub contents API listing — used to discover catalog XML files

Each was previously `JSON.parse(...) as CatalogData`. A hand-edited or partially-written file would put a malformed shape into memory and surface as a `Cannot read properties of undefined` later, far from the cause. This PR adds a TypeBox schema for each input and a `safeParse` helper that returns the typed value or `null`. On shape mismatch the manager falls back to the "no cache" / "no installs" / reject-with-clear-error path; the next refresh writes a clean file and recovers.

`CatalogHeader.dateCreated` and `dateValid` are marked `Optional` — real catalog XML headers don't always populate them and the parser already falls back to `''`, so the schema reflects what's actually on disk.

`src/types.ts` re-exports the catalog types from the new schema module so existing imports keep working. The UI-only `CatalogRegistryInfo` stays a plain interface (built in-memory, never JSON-parsed).

The XML parse path is intentionally **not** covered here — xml2js's arrays-of-strings shape is awkward to model in TypeBox and the existing function already filters per-entry with try/catch.

## Tested

- `npm run format` clean
- `npm run build` clean
- `npm run lint` clean
- `npm test` — 205/205 pass (13 new tests in `test/catalog-schemas.test.ts` covering well-formed input, optional header fields, missing required fields, type mismatches, unknown category, GitHub-API extra-fields tolerance, and `safeParse(null)`)
- `npm run test:e2e` — 7/7 pass
- Local `cr review --plain --base origin/main` — No findings

One pre-existing test fixture updated: `getCachedCatalog should return cached data regardless of age` had a minimally-shaped chart entry (`{number, title}`) that bypassed the no-validation old code; now includes all fields the parser actually writes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation of cached catalog and installation data with graceful error recovery when files are corrupted or invalid.
  * Improved handling of external API responses with schema validation before processing.

* **Tests**
  * Added comprehensive test suite for data schema validation and improved existing test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->