### PR TITLE
refactor(api): extract path-traversal guard into a single helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import { writeChartPathMarker } from './utils/path-marker';
 import { parsePluginConfig } from './utils/plugin-config-schema';
 import { Type } from '@sinclair/typebox';
 import { parseBody } from './utils/rest-validation';
+import { isWithinBase, arePairWithinBase } from './utils/path-safety';
 
 // Read at module load so the marker file always reflects the running build.
 // `require` keeps this synchronous and avoids dragging package.json into the
@@ -658,9 +659,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         const basePath = props.chartPath || defaultChartsPath;
         const fullPath = path.join(basePath, chartPathParam);
 
-        const normalizedFullPath = path.normalize(fullPath);
-        const normalizedBasePath = path.normalize(basePath);
-        if (!normalizedFullPath.startsWith(normalizedBasePath)) {
+        if (!isWithinBase(fullPath, basePath)) {
           res.status(403).send('Access denied: Invalid path');
           return;
         }
@@ -727,9 +726,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
         app.debug(`Create folder - basePath: ${basePath}, fullPath: ${fullPath}`);
 
-        const normalizedFullPath = path.normalize(fullPath);
-        const normalizedBasePath = path.normalize(basePath);
-        if (!normalizedFullPath.startsWith(normalizedBasePath)) {
+        if (!isWithinBase(fullPath, basePath)) {
           app.debug('Create folder failed: path traversal attempt');
           res.status(403).send('Access denied: Invalid path');
           return;
@@ -757,14 +754,12 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         const basePath = props.chartPath || defaultChartsPath;
         const fullPath = path.join(basePath, folderPathParam);
 
-        const normalizedFullPath = path.normalize(fullPath);
-        const normalizedBasePath = path.normalize(basePath);
-        if (!normalizedFullPath.startsWith(normalizedBasePath)) {
+        if (!isWithinBase(fullPath, basePath)) {
           res.status(403).send('Access denied: Invalid path');
           return;
         }
 
-        if (normalizedFullPath === normalizedBasePath) {
+        if (path.normalize(fullPath) === path.normalize(basePath)) {
           res.status(403).send('Cannot delete the root chart directory');
           return;
         }
@@ -852,14 +847,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         }
         app.debug(`Target path: ${targetPath}`);
 
-        const normalizedSource = path.normalize(sourcePath);
-        const normalizedTarget = path.normalize(targetPath);
-        const normalizedBase = path.normalize(basePath);
-
-        if (
-          !normalizedSource.startsWith(normalizedBase) ||
-          !normalizedTarget.startsWith(normalizedBase)
-        ) {
+        if (!arePairWithinBase(sourcePath, targetPath, basePath)) {
           res.status(403).send('Access denied: Invalid path');
           return;
         }
@@ -929,14 +917,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         const targetPath = path.join(basePath, folder, newName);
         app.debug(`Target path: ${targetPath}`);
 
-        const normalizedSource = path.normalize(sourcePath);
-        const normalizedTarget = path.normalize(targetPath);
-        const normalizedBase = path.normalize(basePath);
-
-        if (
-          !normalizedSource.startsWith(normalizedBase) ||
-          !normalizedTarget.startsWith(normalizedBase)
-        ) {
+        if (!arePairWithinBase(sourcePath, targetPath, basePath)) {
           res.status(403).send('Access denied: Invalid path');
           return;
         }
@@ -1012,9 +993,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         const basePath = props.chartPath || defaultChartsPath;
         const fullPath = path.join(basePath, chartPathParam);
 
-        const normalizedFullPath = path.normalize(fullPath);
-        const normalizedBasePath = path.normalize(basePath);
-        if (!normalizedFullPath.startsWith(normalizedBasePath)) {
+        if (!isWithinBase(fullPath, basePath)) {
           res.status(403).send('Access denied: Invalid path');
           return;
         }
@@ -1069,9 +1048,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         const basePath = props.chartPath || defaultChartsPath;
         const fullPath = path.join(basePath, chartPathParam);
 
-        const normalizedFullPath = path.normalize(fullPath);
-        const normalizedBasePath = path.normalize(basePath);
-        if (!normalizedFullPath.startsWith(normalizedBasePath)) {
+        if (!isWithinBase(fullPath, basePath)) {
           res.status(403).send('Access denied: Invalid path');
           return;
         }
@@ -1576,16 +1553,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         const targetDir =
           !targetFolder || targetFolder === '/' ? chartPath : path.join(chartPath, targetFolder);
 
-        // Reject `targetFolder: '../etc'` etc. before mkdir/mkdirSync. Same
-        // guard the other mutating routes (/folders, /move-chart, /rename-chart)
-        // already use; the schema's String pattern can't catch every traversal
-        // vector (e.g. `valid/../escape`), so the canonical fix is here.
-        const normalizedTargetDir = path.normalize(targetDir);
-        const normalizedChartPath = path.normalize(chartPath);
-        if (
-          normalizedTargetDir !== normalizedChartPath &&
-          !normalizedTargetDir.startsWith(normalizedChartPath + path.sep)
-        ) {
+        // Reject `targetFolder: '../etc'` etc. before mkdir/mkdirSync. The
+        // schema's String pattern can't catch every traversal vector
+        // (e.g. `valid/../escape`); the helper does the normalize-and-
+        // startsWith check used by every other mutating route.
+        if (!isWithinBase(targetDir, chartPath)) {
           res.status(403).json({ success: false, error: 'Access denied: Invalid target folder' });
           return;
         }

--- a/src/utils/path-safety.ts
+++ b/src/utils/path-safety.ts
@@ -1,0 +1,35 @@
+/**
+ * Single source of truth for "is this resolved path within the chart
+ * root" checks. Several REST handlers compose `path.join(basePath, …)`
+ * from user-supplied folder/chart names; without a guard a value like
+ * `'../etc/passwd'` would resolve outside the chart root.
+ *
+ * The check normalizes both sides and uses `startsWith(base + path.sep)
+ * || === base`. Bare `startsWith(base)` is wrong: with base
+ * `/srv/charts`, it would also accept `/srv/charts-evil/foo`.
+ */
+
+import path from 'path';
+
+export function isWithinBase(candidate: string, basePath: string): boolean {
+  const normalizedCandidate = path.normalize(candidate);
+  // path.normalize preserves a trailing separator if the input had one.
+  // Strip it so the equality and `startsWith(base + sep)` checks work
+  // regardless of whether the caller passed a trailing slash.
+  const normalizedBase = stripTrailingSep(path.normalize(basePath));
+  if (normalizedCandidate === normalizedBase) {
+    return true;
+  }
+  return normalizedCandidate.startsWith(normalizedBase + path.sep);
+}
+
+function stripTrailingSep(p: string): string {
+  if (p.length > 1 && p.endsWith(path.sep)) {
+    return p.slice(0, -1);
+  }
+  return p;
+}
+
+export function arePairWithinBase(a: string, b: string, basePath: string): boolean {
+  return isWithinBase(a, basePath) && isWithinBase(b, basePath);
+}

--- a/test/path-safety.test.ts
+++ b/test/path-safety.test.ts
@@ -1,0 +1,61 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import path from 'node:path';
+
+import { isWithinBase, arePairWithinBase } from '../dist/utils/path-safety';
+
+const BASE = '/srv/charts';
+
+describe('isWithinBase', () => {
+  it('accepts the base itself', () => {
+    assert.strictEqual(isWithinBase(BASE, BASE), true);
+  });
+
+  it('accepts a direct child', () => {
+    assert.strictEqual(isWithinBase(path.join(BASE, 'foo.mbtiles'), BASE), true);
+  });
+
+  it('accepts a deep descendant', () => {
+    assert.strictEqual(isWithinBase(path.join(BASE, 'a', 'b', 'c.mbtiles'), BASE), true);
+  });
+
+  it('accepts a path that resolves into base via "../" cancellation', () => {
+    // path.normalize collapses `a/../foo` → `foo`; the helper sees the
+    // resolved location, not the literal string.
+    assert.strictEqual(isWithinBase(path.join(BASE, 'a', '..', 'foo'), BASE), true);
+  });
+
+  it('rejects an escape via leading "../"', () => {
+    assert.strictEqual(isWithinBase(path.join(BASE, '..', 'etc', 'passwd'), BASE), false);
+  });
+
+  it('rejects a sibling that shares a prefix (the bug bare startsWith would miss)', () => {
+    // /srv/charts-evil/foo starts with `/srv/charts` if you don't add path.sep.
+    assert.strictEqual(isWithinBase('/srv/charts-evil/foo', BASE), false);
+  });
+
+  it('rejects a completely unrelated absolute path', () => {
+    assert.strictEqual(isWithinBase('/etc/passwd', BASE), false);
+  });
+
+  it('normalizes the base too — trailing slash should not break the check', () => {
+    assert.strictEqual(isWithinBase(path.join(BASE, 'x.mbtiles'), BASE + '/'), true);
+  });
+});
+
+describe('arePairWithinBase', () => {
+  it('accepts when both are inside', () => {
+    assert.strictEqual(
+      arePairWithinBase(path.join(BASE, 'a.mbtiles'), path.join(BASE, 'sub', 'b.mbtiles'), BASE),
+      true
+    );
+  });
+
+  it('rejects if either escapes (source escapes)', () => {
+    assert.strictEqual(arePairWithinBase('/etc/passwd', path.join(BASE, 'b.mbtiles'), BASE), false);
+  });
+
+  it('rejects if either escapes (target escapes)', () => {
+    assert.strictEqual(arePairWithinBase(path.join(BASE, 'a.mbtiles'), '/etc/shadow', BASE), false);
+  });
+});


### PR DESCRIPTION
## Summary

The same `path.normalize` + `startsWith(base)` pattern was inlined in eight handlers. This PR replaces them with `isWithinBase(candidate, base)` and `arePairWithinBase(a, b, base)` from a new `src/utils/path-safety.ts`, so the rule lives in one place.

It also fixes a subtle bug class shared by all the inlined copies: bare `startsWith(basePath)` matches sibling paths that share a string prefix. With base `/srv/charts`, `/srv/charts-evil/foo` would have passed. The helper uses `startsWith(base + path.sep) || === base` (the same form already used by `/catalog/download` from #68) so siblings are correctly rejected. The helper also strips a trailing path separator from the base before comparing, so callers that happen to pass `/srv/charts/` get the same result as `/srv/charts`.

Touches the existing eight sites:

- DELETE `/local-charts/:chartPath`
- POST `/folders`
- DELETE `/folders/:folderPath` — the second normalized comparison ("is this the root chart dir?") is kept inline since the helper doesn't cover the equality-only case
- POST `/move-chart` (pair check)
- POST `/rename-chart` (pair check)
- GET `/chart-metadata/:chartPath`
- PUT `/chart-metadata/:chartPath`
- POST `/catalog/download`

## Tested

- `npm run format` clean
- `npm run build` clean
- `npm run lint` clean
- `npm test` — 216/216 pass (11 new tests in `test/path-safety.test.ts` covering base-itself, descendants, sibling-prefix rejection, trailing-slash base, "../" cancellation, and the pair variant)
- `npm run test:e2e` — 7/7 pass
- Local `cr review --plain --base origin/main` — No findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized and strengthened internal path validation for chart and folder operations to enhance security consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->