### PR TITLE
feat(api): TypeBox-validate busboy/header multipart handlers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ import { getCpuBudget, setCpuBudget } from './utils/concurrency';
 import { writeChartPathMarker } from './utils/path-marker';
 import { parsePluginConfig } from './utils/plugin-config-schema';
 import { Type } from '@sinclair/typebox';
-import { parseBody } from './utils/rest-validation';
+import { parseBody, parseShape } from './utils/rest-validation';
 import { isWithinBase, arePairWithinBase } from './utils/path-safety';
 
 // Read at module load so the marker file always reflects the running build.
@@ -425,6 +425,33 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     name: Type.String({ minLength: 1 })
   });
 
+  // Multipart/header field schemas. Same domain rules as the JSON-body
+  // counterparts: zoom bounds, https?:// URL floor, non-empty chart
+  // names. parseShape (via Value.Convert) handles the busboy-string-only
+  // wire format so `'9'` validates as the integer 9.
+  const DownloadChartLockerFields = Type.Object({
+    url: Type.String({ minLength: 1, pattern: '^https?://' }),
+    targetFolder: Type.String({ minLength: 1 }),
+    chartName: Type.String({ minLength: 1 })
+  });
+
+  const UploadFields = Type.Object({
+    targetFolder: Type.Optional(Type.String())
+  });
+
+  const UploadChunkHeaders = Type.Object({
+    'x-upload-filename': Type.String({ minLength: 1, pattern: '\\.mbtiles$' }),
+    'x-chunk-index': Type.Integer({ minimum: 0 }),
+    'x-total-chunks': Type.Integer({ minimum: 1 }),
+    'x-target-folder': Type.Optional(Type.String())
+  });
+
+  const ConvertUploadFields = Type.Object({
+    type: Type.Union([Type.Literal('s57'), Type.Literal('rnc')]),
+    minzoom: Type.Optional(ZoomLevel),
+    maxzoom: Type.Optional(ZoomLevel)
+  });
+
   const registerRoutes = (router: IRouter): void => {
     app.debug('** Registering API paths via registerWithRouter **');
 
@@ -455,29 +482,29 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       const Busboy = require('busboy') as typeof import('busboy');
       const bb = Busboy({ headers: req.headers });
 
-      let downloadUrl = '';
-      let targetFolder = '';
-      let chartName = '';
-
+      const fields: Record<string, string> = {};
       bb.on('field', (name: string, value: string) => {
-        if (name === 'url') {
-          downloadUrl = value;
-        }
-        if (name === 'targetFolder') {
-          targetFolder = value;
-        }
-        if (name === 'chartName') {
-          chartName = value;
-        }
+        fields[name] = value;
       });
 
       bb.on('finish', () => {
+        const parsed = parseShape(DownloadChartLockerFields, fields, res);
+        if (!parsed) {
+          return;
+        }
+        const { url: downloadUrl, targetFolder, chartName } = parsed;
+
         try {
           console.log(`Creating download job for: ${downloadUrl}`);
           console.log(`Target folder: ${targetFolder}`);
 
-          const targetDir =
-            targetFolder === '/' ? props.chartPath : path.join(props.chartPath, targetFolder);
+          const basePath = props.chartPath || defaultChartsPath;
+          const targetDir = targetFolder === '/' ? basePath : path.join(basePath, targetFolder);
+
+          if (!isWithinBase(targetDir, basePath)) {
+            res.status(403).json({ success: false, error: 'Access denied: Invalid target folder' });
+            return;
+          }
 
           if (!fs.existsSync(targetDir)) {
             fs.mkdirSync(targetDir, { recursive: true });
@@ -1114,12 +1141,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         const basePath = props.chartPath || defaultChartsPath;
         const uploadedFiles: string[] = [];
         const writePromises: Promise<void>[] = [];
-        let targetFolder = '';
+        const fields: Record<string, string> = {};
+        let traversalRejected = false;
 
         bb.on('field', (fieldname: string, value: string) => {
-          if (fieldname === 'targetFolder') {
-            targetFolder = value;
-          }
+          fields[fieldname] = value;
         });
 
         bb.on(
@@ -1132,12 +1158,22 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
               return;
             }
 
+            const targetFolder = fields.targetFolder ?? '';
             let uploadPath = basePath;
             if (targetFolder && targetFolder !== '/') {
               uploadPath = path.join(basePath, targetFolder);
             }
 
             const filepath = path.join(uploadPath, filename);
+
+            // Reject path-traversal in either the targetFolder or the
+            // upload's own filename (`filename: '../etc/passwd'`).
+            if (!isWithinBase(filepath, basePath)) {
+              traversalRejected = true;
+              (file as NodeJS.ReadableStream & { resume(): void }).resume();
+              return;
+            }
+
             app.debug(`Uploading chart file: ${filename} to ${filepath}`);
 
             const writeStream = fs.createWriteStream(filepath);
@@ -1162,6 +1198,21 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
         bb.on('finish', () => {
           void (async () => {
+            // Validate fields here (after busboy has handed every one to
+            // us). The 'file' handler already used `fields.targetFolder`
+            // to decide upload paths; doing the schema check on `finish`
+            // also lets us include 'targetFolder' rules in the validator.
+            const parsed = parseShape(UploadFields, fields, res);
+            if (!parsed) {
+              return;
+            }
+            const { targetFolder = '' } = parsed;
+
+            if (traversalRejected) {
+              res.status(403).json({ success: false, error: 'Access denied: Invalid upload path' });
+              return;
+            }
+
             try {
               await Promise.all(writePromises);
 
@@ -1199,20 +1250,24 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     // stays well within Node's server.requestTimeout (default 300s in Node 18+).
     router.put('/upload-chunk', (req: Request, res: Response) => {
       try {
-        const filename = req.headers['x-upload-filename'] as string;
-        const chunkIndex = parseInt(req.headers['x-chunk-index'] as string, 10);
-        const totalChunks = parseInt(req.headers['x-total-chunks'] as string, 10);
-        const targetFolder = (req.headers['x-target-folder'] as string) || '/';
-
-        if (
-          !filename ||
-          !filename.endsWith('.mbtiles') ||
-          isNaN(chunkIndex) ||
-          isNaN(totalChunks)
-        ) {
-          res.status(400).json({ error: 'Missing or invalid chunk upload headers' });
+        // Headers are pulled from req.headers as a plain object; node
+        // already lowercases the names, so picking the four we care
+        // about by-name is safe. parseShape coerces the numeric ones
+        // (`x-chunk-index`, `x-total-chunks`) from string to integer.
+        const headerFields = {
+          'x-upload-filename': req.headers['x-upload-filename'],
+          'x-chunk-index': req.headers['x-chunk-index'],
+          'x-total-chunks': req.headers['x-total-chunks'],
+          'x-target-folder': req.headers['x-target-folder']
+        };
+        const parsed = parseShape(UploadChunkHeaders, headerFields, res);
+        if (!parsed) {
           return;
         }
+        const filename = parsed['x-upload-filename'];
+        const chunkIndex = parsed['x-chunk-index'];
+        const totalChunks = parsed['x-total-chunks'];
+        const targetFolder = parsed['x-target-folder'] ?? '/';
 
         const basePath = props.chartPath || defaultChartsPath;
         let uploadPath = basePath;
@@ -1222,6 +1277,14 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
         const partialPath = path.join(uploadPath, filename + '.partial');
         const finalPath = path.join(uploadPath, filename);
+
+        // Reject path-traversal via either header. Catches `'../foo.mbtiles'`
+        // as a filename and `'../etc'` as a target-folder, both of which
+        // would otherwise resolve outside the chart root.
+        if (!arePairWithinBase(partialPath, finalPath, basePath)) {
+          res.status(403).json({ error: 'Access denied: Invalid upload path' });
+          return;
+        }
 
         const writeStream = fs.createWriteStream(partialPath, {
           flags: chunkIndex === 0 ? 'w' : 'a'
@@ -1379,26 +1442,16 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       const Busboy = require('busboy') as typeof import('busboy');
       const bb = Busboy({ headers: req.headers, limits: { fileSize: 500 * 1024 * 1024 } });
       const chartPath = props.chartPath || defaultChartsPath;
-      let convType = '';
-      let minzoom = 9;
-      let maxzoom = 16;
 
       const tmpDir = path.join(app.getDataDirPath(), `convert-upload-${Date.now()}`);
       fs.mkdirSync(tmpDir, { recursive: true });
 
       let uploadedFile: string | null = null;
       let uploadedFileName = '';
+      const fields: Record<string, string> = {};
 
       bb.on('field', (name: string, value: string) => {
-        if (name === 'type') {
-          convType = value;
-        }
-        if (name === 'minzoom') {
-          minzoom = parseInt(value) || 9;
-        }
-        if (name === 'maxzoom') {
-          maxzoom = parseInt(value) || 16;
-        }
+        fields[name] = value;
       });
 
       bb.on(
@@ -1423,9 +1476,18 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           return;
         }
 
-        if (!convType || !['s57', 'rnc'].includes(convType)) {
+        const parsed = parseShape(ConvertUploadFields, fields, res);
+        if (!parsed) {
           cleanupDir(tmpDir);
-          res.status(400).json({ success: false, error: 'Invalid conversion type' });
+          return;
+        }
+        const convType = parsed.type;
+        const minzoom = parsed.minzoom ?? 9;
+        const maxzoom = parsed.maxzoom ?? 16;
+
+        if (minzoom > maxzoom) {
+          cleanupDir(tmpDir);
+          res.status(400).json({ success: false, error: 'minzoom must be ≤ maxzoom' });
           return;
         }
 

--- a/src/utils/rest-validation.ts
+++ b/src/utils/rest-validation.ts
@@ -40,3 +40,31 @@ export function parseBody<T extends TSchema>(
   });
   return null;
 }
+
+/**
+ * Validate `input` against `schema` and send a single 400 with a
+ * field-level error list on failure. Use when the source of fields is
+ * something other than `req.body` — busboy field collection, headers,
+ * or any other piecemeal-collected map.
+ *
+ * The input is first run through `Value.Convert`, which coerces
+ * compatible primitive types (e.g. the string `"9"` to the number `9`
+ * for `Type.Integer`). This matches the way busboy/header handlers
+ * receive everything as strings.
+ */
+export function parseShape<T extends TSchema>(
+  schema: T,
+  input: unknown,
+  res: Response
+): Static<T> | null {
+  const converted: unknown = Value.Convert(schema, input);
+  if (Value.Check(schema, converted)) {
+    return converted;
+  }
+  res.status(400).json({
+    success: false,
+    error: 'Invalid request fields',
+    details: formatErrors(schema, converted)
+  });
+  return null;
+}

--- a/test/rest-validation.test.ts
+++ b/test/rest-validation.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { Type } from '@sinclair/typebox';
 
-import { parseBody } from '../dist/utils/rest-validation';
+import { parseBody, parseShape } from '../dist/utils/rest-validation';
 
 interface FakeRes {
   statusCode: number;
@@ -93,5 +93,64 @@ describe('parseBody', () => {
     parseBody(Big, { body: {} } as never, res as never);
     const payload = res.body as { details: string[] };
     assert.ok(payload.details.length <= 5);
+  });
+});
+
+describe('parseShape', () => {
+  // Mirrors the busboy/header use case: every input arrives as a string
+  // (or is undefined). parseShape uses Value.Convert so numeric schemas
+  // accept stringified numbers.
+  const Fields = Type.Object({
+    type: Type.Union([Type.Literal('s57'), Type.Literal('rnc')]),
+    minzoom: Type.Optional(Type.Integer({ minimum: 0, maximum: 22 })),
+    maxzoom: Type.Optional(Type.Integer({ minimum: 0, maximum: 22 }))
+  });
+
+  it('returns the typed shape with numeric coercion from strings', () => {
+    const res = fakeRes();
+    const result = parseShape(Fields, { type: 's57', minzoom: '9', maxzoom: '16' }, res as never);
+    assert.deepStrictEqual(result, { type: 's57', minzoom: 9, maxzoom: 16 });
+    assert.strictEqual(res.statusCode, 200);
+  });
+
+  it('rejects an unknown literal value', () => {
+    const res = fakeRes();
+    const result = parseShape(Fields, { type: 'turbo' }, res as never);
+    assert.strictEqual(result, null);
+    assert.strictEqual(res.statusCode, 400);
+    const payload = res.body as { details: string[] };
+    assert.ok(payload.details.some((d) => /type/.test(d)));
+  });
+
+  it('rejects a stringified integer that is out of range', () => {
+    const res = fakeRes();
+    const result = parseShape(Fields, { type: 's57', minzoom: '99' }, res as never);
+    assert.strictEqual(result, null);
+    assert.strictEqual(res.statusCode, 400);
+  });
+
+  it('rejects when a required header is missing', () => {
+    const Headers = Type.Object({
+      'x-upload-filename': Type.String({ minLength: 1, pattern: '\\.mbtiles$' }),
+      'x-chunk-index': Type.Integer({ minimum: 0 })
+    });
+    const res = fakeRes();
+    const result = parseShape(
+      Headers,
+      { 'x-upload-filename': undefined, 'x-chunk-index': '0' },
+      res as never
+    );
+    assert.strictEqual(result, null);
+    assert.strictEqual(res.statusCode, 400);
+  });
+
+  it('rejects a filename without the .mbtiles suffix', () => {
+    const Headers = Type.Object({
+      'x-upload-filename': Type.String({ minLength: 1, pattern: '\\.mbtiles$' })
+    });
+    const res = fakeRes();
+    const result = parseShape(Headers, { 'x-upload-filename': 'evil.exe' }, res as never);
+    assert.strictEqual(result, null);
+    assert.strictEqual(res.statusCode, 400);
   });
 });


### PR DESCRIPTION
## Summary

Extends the `parseBody` pattern from the JSON-body PRs to the four remaining mutating routes that take multipart bodies or upload-related headers. busboy hands fields piecemeal, so input is collected into a `Record<string, string>` and validated at the `'finish'` event. `/upload-chunk` reads the same kind of untrusted strings out of `req.headers`; same idea.

A new `parseShape` helper in `rest-validation.ts` does the work — same contract as `parseBody`, but takes any unknown input. Runs the value through `Value.Convert` first so a TypeBox `Integer` accepts the string `"9"` that busboy/headers actually deliver.

| Route | Schema | Bug class closed |
|---|---|---|
| POST `/download-chart-locker` | `{ url(https?://), targetFolder(min 1), chartName(min 1) }` | Accepted any url string (file://, gopher://). targetFolder traversal was unguarded. |
| POST `/upload` | `{ targetFolder? }` | Malicious upload filename (`'../etc/passwd.mbtiles'`) — busboy doesn't sanitize these. Now path-checked per file. |
| PUT `/upload-chunk` | header schema with int coercion + `\\.mbtiles$` pattern | `parseInt(undefined)` quietly produced NaN. Pair-traversal guard for `partialPath` and `finalPath`. |
| POST `/convert-upload` | `{ type: 's57' \| 'rnc', minzoom?, maxzoom? }` | Unparseable zoom strings silently coerced to 9/16, hiding typos. Now bounds-checked to `[0, 22]` and `minzoom <= maxzoom`. |

This closes the TypeBox sweep across every mutating REST handler in the plugin.

## Tested

- `npm run format` clean
- `npm run build` clean
- `npm run lint` clean
- `npm test` — 221/221 pass (5 new tests covering numeric coercion, unknown literal, out-of-range coerced int, missing required header, filename pattern rejection)
- `npm run test:e2e` — 7/7 pass
- Local `cr review --plain --base origin/main` — No findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened validation for chart downloads, file uploads, and chunk uploads
  * Enhanced security checks to prevent unauthorized file access patterns
  * Improved validation for conversion parameters and configurations
  * Added explicit error handling for invalid operations

* **Tests**
  * Added comprehensive test coverage for request validation including edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->