### PR TITLE
fix(ui): scope progress-bar shimmer to upload context only

### DIFF
--- a/public/css/manage-charts.css
+++ b/public/css/manage-charts.css
@@ -474,7 +474,12 @@
     display: block !important;
 }
 
-.progress-bar::after {
+/* Scoped to upload progress only. The earlier rule fired on every
+ * `.progress-bar` element on the page — the same class is rendered by
+ * download-simple, the catalog "downloading" pill, and chart cards —
+ * so an idle row would still show a shimmer crossing it left-to-right
+ * with nothing actually in flight. */
+.progress-bar-container .progress-bar::after {
     content: '';
     position: absolute;
     top: 0;


### PR DESCRIPTION
## Summary

The `.progress-bar::after` rule was matching **every** `.progress-bar` element on the page. Three different files render that class:

- `download-simple.ts` — download-job rows
- `chart-catalog.ts` — the "downloading" pill on a catalog row
- `manage-charts-enhanced.ts` — upload progress bar

So a shimmer kept animating left-to-right across catalog rows even when nothing was in flight. Reported as a stuck animation at the top of the GEBCO MBTiles row in the Chart Catalog tab — visible in idle state with no active downloads.

Fix: scope the rule to `.progress-bar-container .progress-bar::after`. That container is rendered **only** during an active upload, which is the one place the decorative shimmer is meaningful.

## Tested

- Reproduced locally with the link-installed plugin in the running Signal K instance; shimmer no longer fires on idle rows after a hard refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved unintended styling that caused the upload progress overlay's shimmer animation to affect other progress bars on the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->