### PR TITLE
fix(catalog): clear Installed badge when chart is deleted from disk

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,9 @@ import {
   getCachedCatalog,
   classifyUrl,
   trackInstall,
+  setInstallFilename,
   removeInstall,
+  removeInstallByFilename,
   getInstalledCatalogCharts,
   pruneStaleInstalls,
   setConvertingState,
@@ -713,10 +715,20 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           const chartId = path.basename(chartPathParam).replace(/\.mbtiles$/, '');
           emitChartDelta(chartId, null);
 
-          removeInstall(chartId);
-          const chartNumberPart = chartId.replace(/^[A-Z]+-/, '');
-          if (chartNumberPart !== chartId) {
-            removeInstall(chartNumberPart);
+          // Primary path: reverse-lookup by the on-disk filename. The
+          // converter records this in the install record after a
+          // successful conversion, so a chart whose filename was
+          // rewritten by catalog title (chartNumber=2 →
+          // Port_of_Rotterdam_…mbtiles) still gets its catalog
+          // "Installed" badge cleared.
+          if (!removeInstallByFilename(chartPathParam)) {
+            // Fall back to the legacy chartId/chartNumber heuristics
+            // for charts installed before setInstallFilename existed.
+            removeInstall(chartId);
+            const chartNumberPart = chartId.replace(/^[A-Z]+-/, '');
+            if (chartNumberPart !== chartId) {
+              removeInstall(chartNumberPart);
+            }
           }
 
           res.status(200).send('Chart deleted successfully');
@@ -725,10 +737,20 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           const chartId = path.basename(chartPathParam).replace(/\.mbtiles$/, '');
           emitChartDelta(chartId, null);
 
-          removeInstall(chartId);
-          const chartNumberPart = chartId.replace(/^[A-Z]+-/, '');
-          if (chartNumberPart !== chartId) {
-            removeInstall(chartNumberPart);
+          // Primary path: reverse-lookup by the on-disk filename. The
+          // converter records this in the install record after a
+          // successful conversion, so a chart whose filename was
+          // rewritten by catalog title (chartNumber=2 →
+          // Port_of_Rotterdam_…mbtiles) still gets its catalog
+          // "Installed" badge cleared.
+          if (!removeInstallByFilename(chartPathParam)) {
+            // Fall back to the legacy chartId/chartNumber heuristics
+            // for charts installed before setInstallFilename existed.
+            removeInstall(chartId);
+            const chartNumberPart = chartId.replace(/^[A-Z]+-/, '');
+            if (chartNumberPart !== chartId) {
+              removeInstall(chartNumberPart);
+            }
           }
 
           res.status(200).send('Chart deletion processed');
@@ -1726,6 +1748,18 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
               if (!job.extractedFiles || job.extractedFiles.length === 0) {
                 removeInstall(chartNumber);
                 app.debug(`Removed catalog tracking for ${chartNumber}: no .mbtiles extracted`);
+              } else {
+                // Record the produced filename so the delete flow can
+                // clear this install record by reverse-lookup. Same
+                // pattern as the S-57 / RNC conversion completion paths.
+                const firstFile = job.extractedFiles[0];
+                if (firstFile) {
+                  const targetFolderRel = path.relative(chartPath, targetDir);
+                  const relativePath = targetFolderRel
+                    ? path.join(targetFolderRel, firstFile)
+                    : firstFile;
+                  setInstallFilename(chartNumber, relativePath);
+                }
               }
               downloadManager.removeListener('job-failed', cleanupListener);
               downloadManager.removeListener('job-completed', cleanupListener);
@@ -1817,6 +1851,10 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
         const relativePath = path.relative(chartPath, path.join(targetDir, result.mbtilesFile));
         setChartEnabled(relativePath, true);
+        // Record the produced filename so the delete flow can find this
+        // install record even when the converter renamed the file by
+        // catalog title (e.g. chartNumber=2 → Port_of_Rotterdam_….mbtiles).
+        setInstallFilename(chartNumber, relativePath);
         await refreshChartProviders();
 
         const chartId = result.mbtilesFile.replace(/\.mbtiles$/, '');
@@ -1900,9 +1938,19 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         setConvertingState(chartNumber, false);
         cleanupDir(tmpDownloadDir);
 
+        const firstRelative = result.mbtilesFiles[0]
+          ? path.relative(chartPath, path.join(targetDir, result.mbtilesFiles[0]))
+          : null;
         for (const mbtilesFile of result.mbtilesFiles) {
           const relativePath = path.relative(chartPath, path.join(targetDir, mbtilesFile));
           setChartEnabled(relativePath, true);
+        }
+        // Record the produced filename so the delete flow can clear
+        // this install record by matching the filename. RNC catalogs
+        // can produce multiple files per chart number; we track the
+        // first — deleting any one of them clears the catalog badge.
+        if (firstRelative) {
+          setInstallFilename(chartNumber, firstRelative);
         }
         await refreshChartProviders();
         for (const mbtilesFile of result.mbtilesFiles) {

--- a/src/utils/catalog-manager.ts
+++ b/src/utils/catalog-manager.ts
@@ -495,6 +495,39 @@ export function getInstalledCatalogCharts(): CatalogInstallsMap {
   return { ...installs };
 }
 
+/**
+ * Record the on-disk filename produced by a successful conversion.
+ * Lets the delete flow find this install record by the filename the
+ * user actually sees in Manage Charts (which can differ from the
+ * chartNumber when the converter renamed by catalog title).
+ */
+export function setInstallFilename(chartNumber: string, filename: string): void {
+  const install = installs[chartNumber];
+  if (!install) {
+    return;
+  }
+  install.installedFilename = filename;
+  saveInstalls();
+}
+
+/**
+ * Reverse-lookup: clear any install record whose tracked filename
+ * matches `filename` (basename match — chartPath is stripped before
+ * comparison). Returns true if a record was removed. Called from the
+ * chart-delete flow.
+ */
+export function removeInstallByFilename(filename: string): boolean {
+  const base = path.basename(filename);
+  for (const [key, install] of Object.entries(installs)) {
+    if (install.installedFilename && path.basename(install.installedFilename) === base) {
+      delete installs[key];
+      saveInstalls();
+      return true;
+    }
+  }
+  return false;
+}
+
 export function setConvertingState(chartNumber: string, isConverting: boolean): void {
   if (isConverting) {
     converting[chartNumber] = true;

--- a/src/utils/catalog-schemas.ts
+++ b/src/utils/catalog-schemas.ts
@@ -61,7 +61,12 @@ export const CatalogInstallSchema = Type.Object({
   catalogFile: Type.String(),
   zipfile_datetime_iso8601: Type.String(),
   installedAt: Type.String(),
-  zipfile_location: Type.String()
+  zipfile_location: Type.String(),
+  // Relative path of the produced .mbtiles under chartPath. Optional
+  // because the install is recorded before the conversion finishes;
+  // the converter calls setInstallFilename() once the file is on disk
+  // so the delete flow can find this record by filename.
+  installedFilename: Type.Optional(Type.String())
 });
 
 export const CatalogInstallsMapSchema = Type.Record(Type.String(), CatalogInstallSchema);


### PR DESCRIPTION
## Summary

Reported: a chart deleted from Manage Charts kept showing "Installed" on the Chart Catalog tab next to the catalog row.

Root cause: at S-57 conversion time `chooseOutputFilename` rewrites the on-disk filename from the catalog chart number (e.g. `2`) to the catalog title (e.g. `Port_of_Rotterdam_2026-04-21-2.mbtiles`). The delete handler computed `chartId` from the filename → `Port_of_Rotterdam_2026-04-21-2` → never matched the install record stored under chart number `"2"`. `removeInstall()` was a no-op; the catalog still saw the install on next refresh.

### Fix

Track the produced on-disk filename in the install record, then look up by filename at delete time.

- `CatalogInstallSchema` gains an optional `installedFilename` (chartPath-relative).
- New `setInstallFilename(chartNumber, filename)` in catalog-manager, called from each conversion-completion path: S-57 catalog flow, RNC catalog flow, and the direct `.mbtiles` download flow.
- New `removeInstallByFilename(filename)` reverse-lookup helper.
- Chart-delete handler tries the filename lookup first; falls through to the legacy `chartId`/chartNumber heuristics for installs recorded before this change (no schema break).

### Migration note

Existing installs on disk won't have `installedFilename` set. They keep using the old fuzzy match, which is what they had before. They pick up the new field automatically on the next download.

For installs already in the broken state (chart deleted but catalog still shows "Installed"), one-time manual cleanup is needed — either edit `catalog-installs.json` to remove the stale entry, or re-download then delete (which records the filename and the new code path clears it correctly).

## Tested

- 221/221 unit + 7/7 e2e green (`fail 0`)
- Manual test loop to follow on the linked plugin in the running server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Chart deletion is now more reliable with improved installation tracking that better identifies and manages the files associated with installed charts.
  * Catalog downloads have been strengthened to maintain accurate file references throughout the conversion process, improving compatibility and cleanup procedures for S-57 and RNC chart formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->