### PR TITLE
fix(catalog): clear stale Installed badge after move/rename/legacy delete

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
   classifyUrl,
   trackInstall,
   setInstallFilename,
+  renameInstallFilename,
   removeInstall,
   removeInstallByFilename,
   getInstalledCatalogCharts,
@@ -917,6 +918,12 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         await fs.promises.rename(sourcePath, targetPath);
         app.debug(`Moved chart from ${sourcePath} to ${targetPath}`);
 
+        // Update any catalog-install record that points at the old
+        // path so a later delete still clears the catalog "Installed"
+        // badge by reverse-lookup.
+        const newRelative = path.relative(basePath, targetPath);
+        renameInstallFilename(chartPathBody, newRelative);
+
         await refreshChartProviders();
 
         const chartId = path.basename(chartPathBody).replace(/\.mbtiles$/, '');
@@ -1005,6 +1012,12 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             `rename-chart metadata patch threw: ${mdErr instanceof Error ? mdErr.message : String(mdErr)}`
           );
         }
+
+        // Update any catalog-install record that points at the old
+        // path so a later delete still clears the catalog "Installed"
+        // badge by reverse-lookup.
+        const newRelative = path.relative(basePath, targetPath);
+        renameInstallFilename(chartPathBody, newRelative);
 
         await refreshChartProviders();
 

--- a/src/utils/catalog-manager.ts
+++ b/src/utils/catalog-manager.ts
@@ -528,6 +528,24 @@ export function removeInstallByFilename(filename: string): boolean {
   return false;
 }
 
+/**
+ * Update an install's tracked filename when the user moves or renames
+ * a chart. Matches the prior path's basename to find the right
+ * install record (chartPath-relative comparison). Returns true if an
+ * install was updated.
+ */
+export function renameInstallFilename(oldPath: string, newPath: string): boolean {
+  const oldBase = path.basename(oldPath);
+  for (const install of Object.values(installs)) {
+    if (install.installedFilename && path.basename(install.installedFilename) === oldBase) {
+      install.installedFilename = newPath;
+      saveInstalls();
+      return true;
+    }
+  }
+  return false;
+}
+
 export function setConvertingState(chartNumber: string, isConverting: boolean): void {
   if (isConverting) {
     converting[chartNumber] = true;
@@ -589,13 +607,39 @@ export function pruneStaleInstalls(chartIdentifiers: string[]): void {
   const ids = new Set(chartIdentifiers.map((id) => id.toLowerCase()));
   let pruned = false;
 
-  for (const key of Object.keys(installs)) {
+  for (const [key, install] of Object.entries(installs)) {
+    // Authoritative path: if we recorded the on-disk filename at
+    // conversion/move/rename time, the install key should match the
+    // chart whose chartId is the basename-without-extension. Anything
+    // else means the file is gone (deleted) and the install record
+    // should drop. Skips the legacy fuzzy-match that produced false
+    // positives — install key "2" was kept alive by any chartId
+    // containing the digit "2".
+    if (install.installedFilename) {
+      const expectedId = path
+        .basename(install.installedFilename)
+        .replace(/\.mbtiles$/i, '')
+        .toLowerCase();
+      if (!ids.has(expectedId)) {
+        console.log(
+          `[charts-provider] Pruning catalog install ${key}: file not found (${install.installedFilename})`
+        );
+        delete installs[key];
+        pruned = true;
+      }
+      continue;
+    }
+
     const keyLower = key.toLowerCase();
 
     if (ids.has(keyLower)) {
       continue;
     }
 
+    // Legacy fuzzy match for installs recorded before installedFilename
+    // existed. Kept conservative — substring match has produced false
+    // positives for short numeric chart numbers; the explicit-filename
+    // branch above is the right path going forward.
     let found = false;
     for (const id of ids) {
       if (


### PR DESCRIPTION
## Summary

Follow-up to #80. PR #80 cleared the catalog "Installed" badge when deleting a chart whose install record had `installedFilename` set. Three holes remained, surfaced by manual testing:

### Bugs

1. **Move and rename invalidated the recorded path.** The install record kept pointing at the old location; a later delete saw a path that no longer matched any chart on disk → reverse-lookup missed → badge stuck.
2. **Pre-fix installs (no `installedFilename`)** fell through to the legacy fuzzy match in `pruneStaleInstalls`, which uses `chartId.includes(installKey)`. An install keyed by the short numeric chart number `"2"` was kept alive by **any** chartId containing the digit `2` (basemaps with `2026` in the name, etc.) — every prune cycle saw a "match" and skipped it.
3. The auto-prune ran on every `refreshChartProviders` already, but its filename-aware path didn't exist; only the broken fuzzy matcher was wired in.

### Fixes

- New `renameInstallFilename(oldPath, newPath)` in catalog-manager. Called from both `/move-chart` and `/rename-chart` handlers right after the filesystem rename succeeds. Uses the old path's basename to find the install record, then writes the new `chartPath`-relative path back.
- `pruneStaleInstalls` now takes an **authoritative** path when an install has `installedFilename`: derive the expected chartId from the basename and require exact membership in the chartIdentifiers set. The fuzzy match is kept only as a legacy fallback for records without `installedFilename`. This stops the "install key `2` matches every chartId containing `2`" pattern.

`refreshChartProviders` runs after every move/rename/delete and on plugin start, so stale badges resolve on the first user interaction or restart.

### Migration

Existing installs without `installedFilename` still go through the legacy fuzzy match. They switch to the strict path on the next download (re-download → re-delete clears them properly).

## Tested

- 221/221 unit + 7/7 e2e green