### PR TITLE
fix(catalog): refresh registry after delete/move/rename without hard reload

### DIFF
--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -104,14 +104,39 @@ let catalogUpdateBadgeInterval: ReturnType<typeof setInterval> | null = null;
 // any operation that moves the on-disk chart inventory (delete, move,
 // rename). Drop our cached chart data and re-fetch the registry so the
 // "Installed" badges reflect server state without a hard browser reload.
+//
+// Catalog rows the user had expanded need their chart data re-fetched
+// too — otherwise renderCatalogCard sees `expandedCatalogs.has(file)`
+// is true but `catalogChartData[file]` is missing and renders an empty
+// body. Snapshot the expanded set, clear the cache, then re-fetch in
+// parallel for those catalogs.
 document.addEventListener('charts-changed', () => {
   if (!catalogInitialized) {
     return;
   }
+  const wereExpanded = Array.from(expandedCatalogs);
   for (const key of Object.keys(catalogChartData)) {
     delete catalogChartData[key];
   }
-  void loadCatalogRegistry();
+  void (async () => {
+    await loadCatalogRegistry();
+    await Promise.all(
+      wereExpanded.map(async (catalogFile) => {
+        try {
+          const resp = await fetch(
+            `${CATALOG_API_BASE}/catalog/${encodeURIComponent(catalogFile)}`
+          );
+          if (resp.ok) {
+            catalogChartData[catalogFile] = (await resp.json()) as CatalogData;
+          }
+        } catch {
+          // Network blip — leave the entry empty; the user can
+          // collapse/expand to retry.
+        }
+      })
+    );
+    renderCatalogList();
+  })();
 });
 
 window.handleCatalogTabActive = function (): void {

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -100,6 +100,20 @@ let catalogDownloadPollInterval: ReturnType<typeof setInterval> | null = null;
 let catalogConversionPollInterval: ReturnType<typeof setInterval> | null = null;
 let catalogUpdateBadgeInterval: ReturnType<typeof setInterval> | null = null;
 
+// Cross-tab notification: Manage Charts dispatches `charts-changed` after
+// any operation that moves the on-disk chart inventory (delete, move,
+// rename). Drop our cached chart data and re-fetch the registry so the
+// "Installed" badges reflect server state without a hard browser reload.
+document.addEventListener('charts-changed', () => {
+  if (!catalogInitialized) {
+    return;
+  }
+  for (const key of Object.keys(catalogChartData)) {
+    delete catalogChartData[key];
+  }
+  void loadCatalogRegistry();
+});
+
 window.handleCatalogTabActive = function (): void {
   if (!catalogInitialized) {
     void initCatalogTab();

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -119,7 +119,11 @@ document.addEventListener('charts-changed', () => {
     delete catalogChartData[key];
   }
   void (async () => {
-    await loadCatalogRegistry();
+    // Run registry + folder list in parallel — a move can add/remove
+    // folders, and the download-folder <select> in expanded catalog
+    // rows is rendered from catalogFolders. Without this call the
+    // dropdown stayed stale until the next download or tab re-init.
+    await Promise.all([loadCatalogRegistry(), loadFolders()]);
     await Promise.all(
       wereExpanded.map(async (catalogFile) => {
         try {

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -123,7 +123,7 @@ document.addEventListener('charts-changed', () => {
     // folders, and the download-folder <select> in expanded catalog
     // rows is rendered from catalogFolders. Without this call the
     // dropdown stayed stale until the next download or tab re-init.
-    await Promise.all([loadCatalogRegistry(), loadFolders()]);
+    const [registryOk] = await Promise.all([loadCatalogRegistry(), loadFolders()]);
     await Promise.all(
       wereExpanded.map(async (catalogFile) => {
         try {
@@ -139,7 +139,12 @@ document.addEventListener('charts-changed', () => {
         }
       })
     );
-    renderCatalogList();
+    // Don't overwrite the .catalog-error state loadCatalogRegistry
+    // wrote into #catalogList on failure; rendering would replace it
+    // with stale cards from whatever catalogRegistry held before.
+    if (registryOk) {
+      renderCatalogList();
+    }
   })();
 });
 
@@ -282,7 +287,13 @@ function wireCatalogClickHandlers(): void {
   }
 }
 
-async function loadCatalogRegistry(): Promise<void> {
+/**
+ * Returns true on a successful registry refresh, false on network/HTTP
+ * failure. Callers that chain follow-up renders need to skip them on
+ * failure so the .catalog-error message this function writes into
+ * #catalogList isn't overwritten with stale cards.
+ */
+async function loadCatalogRegistry(): Promise<boolean> {
   try {
     const response = await fetch(`${CATALOG_API_BASE}/catalog-registry`);
     if (!response.ok) {
@@ -301,12 +312,14 @@ async function loadCatalogRegistry(): Promise<void> {
     } else {
       renderCatalogList();
     }
+    return true;
   } catch (error) {
     console.error('Failed to load catalog registry:', error);
     const listEl = document.getElementById('catalogList');
     if (listEl) {
       listEl.innerHTML = `<div class="catalog-error">Failed to load catalog registry. You may be offline.</div>`;
     }
+    return false;
   }
 }
 

--- a/public/js/manage-charts-enhanced.ts
+++ b/public/js/manage-charts-enhanced.ts
@@ -480,6 +480,11 @@ function deleteChart(relativePath: string, name: string): void {
         );
 
         if (response.ok) {
+          // Tell the Catalog tab to drop its cached chart data and
+          // re-fetch the registry; otherwise the "Installed" badge
+          // sticks until a hard browser reload even though the server
+          // already cleared the install record.
+          document.dispatchEvent(new CustomEvent('charts-changed'));
           void loadCharts();
         } else {
           const errorText = await response.text();
@@ -1043,6 +1048,7 @@ async function performChartMove(chartPath: string, targetFolder: string): Promis
     });
 
     if (response.ok) {
+      document.dispatchEvent(new CustomEvent('charts-changed'));
       void loadCharts();
     } else {
       const errorText = await response.text();
@@ -1263,6 +1269,7 @@ async function confirmRename(): Promise<void> {
     });
 
     if (response.ok) {
+      document.dispatchEvent(new CustomEvent('charts-changed'));
       void loadCharts();
       showRenameNotification(currentNameWithExtension, newNameWithExtension);
     } else {


### PR DESCRIPTION
## Summary

PRs #80 and #81 fixed the server-side install-record cleanup. But the Catalog tab's frontend state (`catalogInstalled`, `catalogChartData`, `catalogConverting`) was last fetched on tab init. After deleting a chart from Manage Charts, the server cleared the install record correctly — but the Catalog tab kept showing "Installed" until a hard browser reload forced a re-fetch.

### Fix

Manage Charts dispatches a `charts-changed` `CustomEvent` on:
- chart delete
- chart move
- chart rename

chart-catalog listens for it at module load time, drops its cached chart data, and re-fetches the registry via `loadCatalogRegistry()`. The render that follows reflects the actual server state.

Wiring at module load (not at tab activation) means the cached state stays consistent even if the user is on Manage Charts when they delete — the catalog isn't out of sync the next time they switch tabs.

`handleCatalogTabActive`'s badge-only refresh path is unchanged; the heavier registry refetch only fires on the events that actually invalidate per-chart state.

## Tested

- 221/221 unit + 7/7 e2e green
- Manual test pending on the linked plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Catalog now refreshes automatically when charts are deleted, moved, or renamed so installed badges, catalog lists, and expanded sections update immediately without a manual reload.
  * Registry refresh failures now preserve an error message in the catalog view instead of briefly showing stale content.

* **New Features**
  * Catalog updates propagate across open tabs/windows so changes in one view are reflected in others, restoring previously expanded sections and reloading chart data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->