### PR TITLE
fix(catalog): keep card expanded after a conversion finishes

### DIFF
--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -878,16 +878,39 @@ async function pollConversions(): Promise<void> {
       }
       catalogInstalled = regData.installed ?? {};
 
-      // If any conversion just finished, invalidate cached catalog data and refresh
+      // If any conversion just finished, invalidate cached catalog
+      // data and refresh. For catalogs the user already has expanded
+      // we re-fetch so the card stays open with the new "Installed"
+      // badge — without this the card body's empty (cached data was
+      // dropped) but the .expanded class is still on, so the arrow
+      // points down with nothing visible underneath.
       justFinished = Object.keys(prevConverting).filter((k) => !catalogConverting[k]);
       if (justFinished.length > 0) {
+        const affectedCatalogs = new Set<string>();
         for (const chartNum of justFinished) {
           const install = catalogInstalled[chartNum];
           if (install?.catalogFile) {
             delete catalogChartData[install.catalogFile];
+            if (expandedCatalogs.has(install.catalogFile)) {
+              affectedCatalogs.add(install.catalogFile);
+            }
           }
         }
         await loadFolders();
+        await Promise.all(
+          [...affectedCatalogs].map(async (catalogFile) => {
+            try {
+              const resp = await fetch(
+                `${CATALOG_API_BASE}/catalog/${encodeURIComponent(catalogFile)}`
+              );
+              if (resp.ok) {
+                catalogChartData[catalogFile] = (await resp.json()) as CatalogData;
+              }
+            } catch {
+              // Network blip — the next user expand/collapse will retry.
+            }
+          })
+        );
       }
     }
 


### PR DESCRIPTION
## Summary

Reported: after a catalog-driven conversion finishes successfully, the card visually collapses but the expand arrow stays rotated as if it were still expanded. Confusing — looks like a stuck arrow on a collapsed card.

### Root cause

`pollConversions` runs every 3s. When it sees a chart move from converting → finished, it currently:

1. Deletes `catalogChartData[catalogFile]` (so the next render fetches fresh chart data with the new "Installed" state).
2. Calls `renderCatalogList()`.

But the catalog's entry in `expandedCatalogs` is **not** touched. The renderer reads:

```ts
const isExpanded = expandedCatalogs.has(catalog.file);
// …
class="catalog-card ${isExpanded ? 'expanded' : ''}"
${isExpanded && catalogChartData[catalog.file] ? renderChartList(catalog.file) : ''}
```

So the card emits `class="catalog-card expanded"` (which the CSS uses to rotate the arrow and keep the body visible) but its body falls through to `''` because `catalogChartData[file]` is gone. End state: arrow says "expanded", body is empty → looks collapsed but the arrow's wrong.

### Fix

Snapshot which expanded catalogs are affected by a just-finished conversion, re-fetch their chart data in parallel after dropping the cache, then `renderCatalogList()` proceeds. The user's card stays expanded with fresh content (now showing "Installed" on the chart that just converted) without any manual collapse/expand.

Same pattern as the `charts-changed` handler from PR #82 — that one fired on delete/move/rename in Manage Charts; this one fires on the polling loop's "conversion just finished" branch.

## Tested

- 221/221 unit + 7/7 e2e green
- Local `cr review --plain --base origin/main` — No findings
- Manual test on the linked plugin pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvement**
  * Optimized chart catalog refresh when conversions complete to update only affected catalogs instead of all catalogs, resulting in faster and more responsive catalog updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->