### PR TITLE
fix(downloads): show indeterminate barberpole when server omits Content-Length

### DIFF
--- a/public/css/manage-charts.css
+++ b/public/css/manage-charts.css
@@ -1334,6 +1334,21 @@
     transition: width 0.3s ease;
 }
 
+/* Indeterminate progress: server didn't report Content-Length, so we
+ * don't know the total. A barberpole moving across an empty track is
+ * the standard cue for "something is happening, don't know how much
+ * is left." Used by the catalog row pill and the download-jobs card. */
+.progress-fill-indeterminate {
+    width: 30% !important;
+    transition: none !important;
+    animation: progress-indeterminate 1.5s linear infinite;
+}
+
+@keyframes progress-indeterminate {
+    0%   { transform: translateX(-100%); }
+    100% { transform: translateX(400%); }
+}
+
 .progress-text {
     text-align: center;
     font-size: 0.9rem;

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -64,6 +64,7 @@ interface DownloadJobLite {
   status: 'queued' | 'downloading' | 'extracting' | 'completed' | 'failed';
   progress?: number;
   downloadedBytes?: number;
+  totalBytes?: number;
   url?: string;
   error?: string;
 }
@@ -789,13 +790,24 @@ async function pollCatalogDownloads(): Promise<void> {
         const safeProgress = Number.isFinite(job.progress)
           ? Math.max(0, Math.min(100, job.progress ?? 0))
           : 0;
+        // No Content-Length from the server → switch the fill into the
+        // animated barberpole (CSS class), drop the explicit width.
+        // Otherwise drive width by progress and clear the modifier.
+        const totalKnown =
+          Number.isFinite(job.totalBytes) && (job.totalBytes ?? 0) > 0;
         if (fillEl) {
-          fillEl.style.width = `${safeProgress}%`;
+          if (totalKnown) {
+            fillEl.classList.remove('progress-fill-indeterminate');
+            fillEl.style.width = `${safeProgress}%`;
+          } else {
+            fillEl.classList.add('progress-fill-indeterminate');
+            fillEl.style.width = '';
+          }
         }
         if (textEl) {
           if (job.status === 'extracting') {
             textEl.textContent = 'Extracting...';
-          } else if (safeProgress > 0) {
+          } else if (totalKnown && safeProgress > 0) {
             textEl.textContent = `Downloading ${safeProgress}%`;
           } else if ((job.downloadedBytes ?? 0) > 0) {
             const mb = ((job.downloadedBytes ?? 0) / (1024 * 1024)).toFixed(1);

--- a/public/js/download-simple.ts
+++ b/public/js/download-simple.ts
@@ -320,12 +320,23 @@ function renderDownloadJob(job: DownloadJob): string {
     ? Math.max(0, Math.min(100, job.progress))
     : 0;
 
+  // Some servers (e.g. vaarweginformatie.nl) don't report Content-Length
+  // so totalBytes stays 0 and the percentage can't be computed. Switch
+  // to an indeterminate barberpole and show just the downloaded byte
+  // count instead of "0% - X MB / 0 B".
+  const totalKnown = Number.isFinite(job.totalBytes) && job.totalBytes > 0;
+  const fillClass = totalKnown ? 'progress-fill' : 'progress-fill progress-fill-indeterminate';
+  const fillStyle = totalKnown ? `style="width: ${safeProgress}%"` : '';
+  const progressText = totalKnown
+    ? `${safeProgress}% - ${formatBytes(job.downloadedBytes)} / ${formatBytes(job.totalBytes)}`
+    : `${formatBytes(job.downloadedBytes)} downloaded`;
+
   const progressBar =
     job.status === 'downloading' || job.status === 'extracting'
       ? `<div class="progress-bar">
-         <div class="progress-fill" style="width: ${safeProgress}%"></div>
+         <div class="${fillClass}" ${fillStyle}></div>
        </div>
-       <div class="progress-text">${safeProgress}% - ${formatBytes(job.downloadedBytes)} / ${formatBytes(job.totalBytes)}</div>`
+       <div class="progress-text">${progressText}</div>`
       : '';
 
   const errorMessage = job.error


### PR DESCRIPTION
## Summary

Reported: progress bars stay at 0% during a download even though MB are clearly being received. Two screenshots:

- **Catalog row:** "Downloading 18.7 MB..." — text increments, bar stuck at 0%.
- **Download tab card:** "0% - 4.16 MB / 0 B" — percentage wrong, total wrong, bar empty.

### Root cause

`vaarweginformatie.nl` (and any server using chunked transfer without `Content-Length`) doesn't tell us the total. `download-manager` reads `response.headers['content-length']`, parses it, gets 0, and stops updating `job.progress` — so the percentage stays 0 forever even though `downloadedBytes` increments.

### Fix

Switch to an **indeterminate progress** display when `totalBytes <= 0` — a sliding band animation across an empty track. Standard browser/OS cue for "something's happening but the total is unknown."

- New `.progress-fill-indeterminate` modifier class in `manage-charts.css`. Fixed 30% width fill, animated left-to-right via a 1.5s linear keyframe (`translateX(-100%) → 400%`).
- `download-simple.ts` `renderDownloadJob` picks the modifier and drops the explicit width when `totalBytes <= 0`. Text reads "<n> MB downloaded" instead of "0% - X / 0 B".
- `chart-catalog.ts` `pollCatalogDownloads` toggles the modifier on the existing fill element and clears the inline width when total is unknown. Pill text uses MB count instead of "Downloading 0%".
- `DownloadJobLite` gains an optional `totalBytes` field.

Server-side `download-manager` already sets `totalBytes` from `Content-Length` when the server provides one — no change there. This is a frontend-only fix for the missing-header case.

## Tested

- 221/221 unit + 7/7 e2e green
- Local `cr review --plain --base origin/main` — No findings
- Manual test on the linked plugin pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Download progress bars now intelligently adapt to server-provided information: displays percentage-based progress when total file size is available, and automatically switches to an animated indeterminate progress bar showing downloaded bytes when size is unavailable. This ensures users remain fully informed during all file transfer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->