### PR TITLE
fix(catalog): don't flag converting until download completes

### DIFF
--- a/public/css/manage-charts.css
+++ b/public/css/manage-charts.css
@@ -1349,6 +1349,23 @@
     100% { transform: translateX(400%); }
 }
 
+/* Translate-based animations can trigger vestibular discomfort. Users
+ * with prefers-reduced-motion get a slow opacity pulse instead — still
+ * shows the bar is "active" without the panning motion, and not
+ * completely frozen (which would make the UI feel stuck). */
+@keyframes progress-indeterminate-pulse {
+    0%, 100% { opacity: 1; }
+    50%      { opacity: 0.4; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .progress-fill-indeterminate {
+        animation-name: progress-indeterminate-pulse;
+        animation-duration: 2s;
+        transform: none;
+    }
+}
+
 .progress-text {
     text-align: center;
     font-size: 0.9rem;

--- a/public/css/manage-charts.css
+++ b/public/css/manage-charts.css
@@ -1334,6 +1334,21 @@
     transition: width 0.3s ease;
 }
 
+/* Indeterminate progress: server didn't report Content-Length, so we
+ * don't know the total. A barberpole moving across an empty track is
+ * the standard cue for "something is happening, don't know how much
+ * is left." Used by the catalog row pill and the download-jobs card. */
+.progress-fill-indeterminate {
+    width: 30% !important;
+    transition: none !important;
+    animation: progress-indeterminate 1.5s linear infinite;
+}
+
+@keyframes progress-indeterminate {
+    0%   { transform: translateX(-100%); }
+    100% { transform: translateX(400%); }
+}
+
 .progress-text {
     text-align: center;
     font-size: 0.9rem;

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -64,6 +64,7 @@ interface DownloadJobLite {
   status: 'queued' | 'downloading' | 'extracting' | 'completed' | 'failed';
   progress?: number;
   downloadedBytes?: number;
+  totalBytes?: number;
   url?: string;
   error?: string;
 }
@@ -789,13 +790,24 @@ async function pollCatalogDownloads(): Promise<void> {
         const safeProgress = Number.isFinite(job.progress)
           ? Math.max(0, Math.min(100, job.progress ?? 0))
           : 0;
+        // No Content-Length from the server → switch the fill into the
+        // animated barberpole (CSS class), drop the explicit width.
+        // Otherwise drive width by progress and clear the modifier.
+        const totalKnown =
+          Number.isFinite(job.totalBytes) && (job.totalBytes ?? 0) > 0;
         if (fillEl) {
-          fillEl.style.width = `${safeProgress}%`;
+          if (totalKnown) {
+            fillEl.classList.remove('progress-fill-indeterminate');
+            fillEl.style.width = `${safeProgress}%`;
+          } else {
+            fillEl.classList.add('progress-fill-indeterminate');
+            fillEl.style.width = '';
+          }
         }
         if (textEl) {
           if (job.status === 'extracting') {
             textEl.textContent = 'Extracting...';
-          } else if (safeProgress > 0) {
+          } else if (totalKnown && safeProgress > 0) {
             textEl.textContent = `Downloading ${safeProgress}%`;
           } else if ((job.downloadedBytes ?? 0) > 0) {
             const mb = ((job.downloadedBytes ?? 0) / (1024 * 1024)).toFixed(1);

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -61,6 +61,10 @@ interface CatalogUpdate {
 
 interface DownloadJobLite {
   id: string;
+  // chartName on the server side is the chartNumber the catalog
+  // download flow passes through createJob(). Used here to re-seed
+  // catalogDownloadJobs after a page reload.
+  chartName?: string;
   status: 'queued' | 'downloading' | 'extracting' | 'completed' | 'failed';
   progress?: number;
   downloadedBytes?: number;
@@ -188,6 +192,17 @@ async function initCatalogTab(): Promise<void> {
   await loadFolders();
   await checkS57Status();
   await refreshUpdateBadge();
+  // Re-seed catalogDownloadJobs from any in-flight server-side jobs.
+  // Without this, a page reload during download loses the local
+  // mapping and the catalog row renders the chart as "Download &
+  // Convert" again (or — once the server finally flips converting
+  // — as "Converting…" while the download is still running).
+  await seedCatalogDownloadJobs();
+  // Re-render now: loadCatalogRegistry rendered earlier when
+  // catalogDownloadJobs was still empty, so without this call the
+  // user briefly sees "Download & Convert" on actively-downloading
+  // rows until the first pollCatalogDownloads tick (~2s later).
+  renderCatalogList();
 
   // Wire delegated click handlers — every action that previously used
   // inline `onclick="X('${catalogEscapeAttr(value)}')"` now reads a data-*
@@ -700,6 +715,36 @@ async function downloadCatalogChart(
   } catch (error) {
     console.error('Failed to start catalog download:', error);
     alert('Failed to start download. Check your network connection.');
+  }
+}
+
+/**
+ * On tab init / page reload, fetch the server's current download jobs
+ * and rebuild `catalogDownloadJobs` from anything that's still in
+ * flight (queued / downloading / extracting). Without this the catalog
+ * loses its local mapping and the row re-renders without a download
+ * pill until the next user action.
+ */
+async function seedCatalogDownloadJobs(): Promise<void> {
+  try {
+    const response = await fetch(`${CATALOG_API_BASE}/download-jobs`);
+    if (!response.ok) {
+      return;
+    }
+    const jobs = (await response.json()) as DownloadJobLite[];
+    for (const job of jobs) {
+      if (
+        job.chartName &&
+        (job.status === 'queued' ||
+          job.status === 'downloading' ||
+          job.status === 'extracting')
+      ) {
+        catalogDownloadJobs[job.chartName] = job.id;
+      }
+    }
+  } catch {
+    // Network blip — first poll cycle will do the right thing once
+    // the user clicks something or 2s elapses.
   }
 }
 

--- a/public/js/download-simple.ts
+++ b/public/js/download-simple.ts
@@ -320,12 +320,23 @@ function renderDownloadJob(job: DownloadJob): string {
     ? Math.max(0, Math.min(100, job.progress))
     : 0;
 
+  // Some servers (e.g. vaarweginformatie.nl) don't report Content-Length
+  // so totalBytes stays 0 and the percentage can't be computed. Switch
+  // to an indeterminate barberpole and show just the downloaded byte
+  // count instead of "0% - X MB / 0 B".
+  const totalKnown = Number.isFinite(job.totalBytes) && job.totalBytes > 0;
+  const fillClass = totalKnown ? 'progress-fill' : 'progress-fill progress-fill-indeterminate';
+  const fillStyle = totalKnown ? `style="width: ${safeProgress}%"` : '';
+  const progressText = totalKnown
+    ? `${safeProgress}% - ${formatBytes(job.downloadedBytes)} / ${formatBytes(job.totalBytes)}`
+    : `${formatBytes(job.downloadedBytes)} downloaded`;
+
   const progressBar =
     job.status === 'downloading' || job.status === 'extracting'
       ? `<div class="progress-bar">
-         <div class="progress-fill" style="width: ${safeProgress}%"></div>
+         <div class="${fillClass}" ${fillStyle}></div>
        </div>
-       <div class="progress-text">${safeProgress}% - ${formatBytes(job.downloadedBytes)} / ${formatBytes(job.totalBytes)}</div>`
+       <div class="progress-text">${progressText}</div>`
       : '';
 
   const errorMessage = job.error

--- a/public/js/download-simple.ts
+++ b/public/js/download-simple.ts
@@ -327,9 +327,15 @@ function renderDownloadJob(job: DownloadJob): string {
   const totalKnown = Number.isFinite(job.totalBytes) && job.totalBytes > 0;
   const fillClass = totalKnown ? 'progress-fill' : 'progress-fill progress-fill-indeterminate';
   const fillStyle = totalKnown ? `style="width: ${safeProgress}%"` : '';
-  const progressText = totalKnown
-    ? `${safeProgress}% - ${formatBytes(job.downloadedBytes)} / ${formatBytes(job.totalBytes)}`
-    : `${formatBytes(job.downloadedBytes)} downloaded`;
+  // 'extracting' uses the same indeterminate bar but its byte count is
+  // the now-stale download total — show an explicit label instead so
+  // we don't display "142 MB downloaded" while the bar spins on extract.
+  const progressText =
+    job.status === 'extracting'
+      ? 'Extracting...'
+      : totalKnown
+        ? `${safeProgress}% - ${formatBytes(job.downloadedBytes)} / ${formatBytes(job.totalBytes)}`
+        : `${formatBytes(job.downloadedBytes)} downloaded`;
 
   const progressBar =
     job.status === 'downloading' || job.status === 'extracting'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1822,7 +1822,10 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     const jobId = downloadManager.createJob(url, tmpDownloadDir, chartNumber, { saveRaw: true });
 
     trackInstall(chartNumber, catalogFile, zipfileDatetime ?? '', url);
-    setConvertingState(chartNumber, true);
+    // Don't flag converting yet — the download still has to finish.
+    // Setting it here made the catalog UI report "Converting…" all
+    // through the (slow!) download phase. Flip it to true inside the
+    // listener once the ZIP is on disk and processS57Zip is about to run.
 
     const s57Listener = async (job: DownloadJob): Promise<void> => {
       if (job.id !== jobId) {
@@ -1837,10 +1840,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       if (!zipPath || !fs.existsSync(zipPath)) {
         app.debug(`S-57: no ZIP file found after download for ${chartNumber}`);
         removeInstall(chartNumber);
-        setConvertingState(chartNumber, false);
         cleanupDir(tmpDownloadDir);
         return;
       }
+
+      setConvertingState(chartNumber, true);
 
       try {
         const displayName = chartTitle ? cleanCatalogTitle(chartTitle) : undefined;
@@ -1921,7 +1925,8 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     const jobId = downloadManager.createJob(url, tmpDownloadDir, chartNumber, { saveRaw: true });
 
     trackInstall(chartNumber, catalogFile, zipfileDatetime ?? '', url);
-    setConvertingState(chartNumber, true);
+    // Set converting state inside the listener once the download has
+    // finished — see the comment on the s57 path; same fix.
 
     const rncListener = async (job: DownloadJob): Promise<void> => {
       if (job.id !== jobId) {
@@ -1936,10 +1941,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       if (!zipPath || !fs.existsSync(zipPath)) {
         app.debug(`RNC: no file found after download for ${chartNumber}`);
         removeInstall(chartNumber);
-        setConvertingState(chartNumber, false);
         cleanupDir(tmpDownloadDir);
         return;
       }
+
+      setConvertingState(chartNumber, true);
 
       app.debug(`Starting RNC conversion for ${chartNumber}: ${zipPath}`);
 
@@ -2019,7 +2025,8 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     const jobId = downloadManager.createJob(url, tmpDownloadDir, chartNumber, { saveRaw: true });
 
     trackInstall(chartNumber, catalogFile, zipfileDatetime ?? '', url);
-    setConvertingState(chartNumber, true);
+    // Set converting state inside the listener once the download has
+    // finished — see the comment on the s57 path; same fix.
 
     const pilotListener = async (job: DownloadJob): Promise<void> => {
       if (job.id !== jobId) {
@@ -2033,10 +2040,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
       if (!dlPath || !fs.existsSync(dlPath)) {
         removeInstall(chartNumber);
-        setConvertingState(chartNumber, false);
         cleanupDir(tmpDownloadDir);
         return;
       }
+
+      setConvertingState(chartNumber, true);
 
       try {
         const result = await processPilotTar(dlPath, targetDir, chartNumber, (status, message) => {
@@ -2104,7 +2112,8 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     const jobId = downloadManager.createJob(url, tmpDownloadDir, chartNumber, { saveRaw: true });
 
     trackInstall(chartNumber, catalogFile, zipfileDatetime ?? '', url);
-    setConvertingState(chartNumber, true);
+    // Set converting state inside the listener once the download has
+    // finished — see the comment on the s57 path; same fix.
 
     const shpListener = async (job: DownloadJob): Promise<void> => {
       if (job.id !== jobId) {
@@ -2118,10 +2127,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
       if (!dlPath || !fs.existsSync(dlPath)) {
         removeInstall(chartNumber);
-        setConvertingState(chartNumber, false);
         cleanupDir(tmpDownloadDir);
         return;
       }
+
+      setConvertingState(chartNumber, true);
 
       try {
         const result = await processShpBasemap(


### PR DESCRIPTION
## Summary

Reported: clicking Download & Convert on an S-57 catalog chart immediately makes the catalog row show "Converting S-57 to vector tiles…" — but no conversion has started, the download is still going. Worse on hard reload: the Download tab correctly shows the download in flight (with the indeterminate bar from #84) while the catalog jumps straight to the converting label.

### Root cause

Server: every catalog-driven download path called `setConvertingState(chartNumber, true)` **immediately after `createJob`** — before the bytes had moved. The flag stuck through the entire (slow) download. Conversion only actually started inside the job-completed listener, when `processS57Zip` / `processRncZip` / etc. ran.

Frontend: a page reload lost `catalogDownloadJobs` (client-only state), so the catalog couldn't tell the row was actively downloading. Combined with the server's eager `converting` flag, the row jumped straight to "Converting…".

### Fix

**Server** (5 catalog-driven paths in `src/index.ts`):
- S-57, RNC, Pilot, Shp basemap: move `setConvertingState(chartNumber, true)` from the eager position right after `createJob` to **inside** each download-completion listener, after the file-existence check passes — i.e. right before `processS57Zip` / `processRncZip` / `processPilotTar` / `processShpBasemap` is about to run.
- The existing `setConvertingState(false)` calls on download failure become defensive no-ops; left in place for clarity in the catch path.
- GSHHG is unchanged: it has no separate download phase (`processGshhg` fetches and converts in one call), so the eager flag matches reality there.
- The manual `/convert-upload` flow is unchanged: conversion truly starts immediately after the upload completes.

**Frontend** (`public/js/chart-catalog.ts`):
- New `seedCatalogDownloadJobs()` in `initCatalogTab`: fetches `/download-jobs` and re-populates `catalogDownloadJobs` by matching `job.chartName` (the chartNumber the catalog flow passes through `createJob`) against in-flight jobs.
- `renderCatalogList()` immediately after seeding so the user sees the download pill right away on reload.
- `DownloadJobLite` gains a `chartName` field.

### CR follow-ups in the same change

1. **download-simple.ts progress text**: explicit "Extracting..." label when `status === 'extracting'`, instead of the now-stale download byte count from the indeterminate-bar branch.
2. **chart-catalog.ts**: `renderCatalogList()` after `seedCatalogDownloadJobs()` so the in-flight pill appears immediately on reload (not after the first 2s poll tick).
3. **manage-charts.css**: `prefers-reduced-motion` override for the indeterminate barberpole — translate-based animations can trigger vestibular discomfort. Users with the OS preference get a slow opacity pulse instead (still active-looking, no panning motion).

## Tested

- 221/221 unit + 7/7 e2e green
- Local `cr review --plain --base origin/main` — No findings (after addressing 3 findings across 2 review rounds)
- Manual test on the linked plugin pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Download progress bar now displays an animated state when the server cannot determine the total file size
  * Improved download handling with automatic cleanup of temporary files when downloads fail
  * Enhanced feedback during file extraction operations

* **Style**
  * Added smooth progress bar animations with accessibility support for reduced-motion preferences

* **Bug Fixes**
  * Better error handling and recovery during download and extraction operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->