### PR TITLE
feat(plugin): consume cleanupOrphanedJobs from signalk-container 1.3.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import {
   setConversionFailed as setS57Failed
 } from './utils/s57-converter.js';
 import { getContainerManager, waitForContainerManager } from './utils/container-manager.js';
+import { PLUGIN_OWNER_ID } from './utils/container-jobs.js';
 import { cleanCatalogTitle } from './utils/catalog-title.js';
 import { setMbtilesDisplayName } from './utils/mbtiles-metadata.js';
 import {
@@ -245,6 +246,39 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       app.debug(
         `signalk-container detected: ${runtime?.runtime ?? 'unknown'} ${runtime?.version ?? ''}`.trim()
       );
+
+      // Reap any helper containers leaked by a previous Signal K
+      // crash mid-conversion. Each reaped orphan clears the
+      // matching install record and converting flag so the catalog
+      // UI doesn't show "Installed" or "Converting…" for a job
+      // that no longer exists. Requires signalk-container >= 1.3.0;
+      // older versions don't have the API and we just skip.
+      if (typeof containerManager.cleanupOrphanedJobs === 'function') {
+        try {
+          const cleanup = await containerManager.cleanupOrphanedJobs({
+            ownerPluginId: PLUGIN_OWNER_ID
+          });
+          for (const orphan of cleanup.reaped) {
+            const chartNumber = orphan.label ? orphan.label.replace(/^[a-z-]+-/, '') : null;
+            app.debug(
+              `Reaped orphan job ${orphan.name} (${orphan.label ?? 'no label'}); ` +
+                `rolling back chart ${chartNumber ?? '<unknown>'}`
+            );
+            if (chartNumber) {
+              setConvertingState(chartNumber, false);
+              removeInstall(chartNumber);
+            }
+          }
+          if (cleanup.reaped.length > 0) {
+            console.log(
+              `[charts-provider] Reaped ${cleanup.reaped.length} orphan job(s) ` +
+                `from a previous Signal K lifecycle`
+            );
+          }
+        } catch (err) {
+          app.debug(`Orphan cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
     }
 
     startCatalogUpdateChecker();

--- a/src/index.ts
+++ b/src/index.ts
@@ -258,8 +258,38 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           const cleanup = await containerManager.cleanupOrphanedJobs({
             ownerPluginId: PLUGIN_OWNER_ID
           });
+          // Labels we set on runJob calls have the form
+          // `<stage>-<chartNumber>`, where <stage> is one of a fixed
+          // set of strings (gdal-export, tippecanoe, gdal-translate,
+          // gdaladdo, tar-extract, gdal-rasterize). The naïve
+          // `replace(/^[a-z-]+-/, '')` was greedy — it would strip
+          // every hyphenated prefix and corrupt chartNumbers that
+          // themselves contain hyphens (e.g. `tippecanoe-abc-def`
+          // would yield `def` instead of `abc-def`). Match the
+          // longest known prefix and take everything after.
+          const STAGES = [
+            'gdal-export',
+            'gdal-translate',
+            'gdal-rasterize',
+            'tar-extract',
+            'tippecanoe',
+            'gdaladdo'
+          ];
+          const extractChartNumber = (label: string | undefined): string | null => {
+            if (!label) {
+              return null;
+            }
+            for (const stage of STAGES) {
+              const prefix = `${stage}-`;
+              if (label.startsWith(prefix)) {
+                return label.slice(prefix.length) || null;
+              }
+            }
+            return null;
+          };
+
           for (const orphan of cleanup.reaped) {
-            const chartNumber = orphan.label ? orphan.label.replace(/^[a-z-]+-/, '') : null;
+            const chartNumber = extractChartNumber(orphan.label);
             app.debug(
               `Reaped orphan job ${orphan.name} (${orphan.label ?? 'no label'}); ` +
                 `rolling back chart ${chartNumber ?? '<unknown>'}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import https from 'https';
 import type { Plugin, Path } from '@signalk/server-api';
+import { SKVersion } from '@signalk/server-api';
 import { findCharts } from './charts-loader.js';
 import { scanChartsRecursively, scanAllFolders } from './utils/file-scanner.js';
 import { initChartState, isChartEnabled, setChartEnabled } from './utils/chart-state.js';
@@ -2436,7 +2437,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             }
           ]
         },
-        2 as unknown as import('@signalk/server-api').SKVersion
+        SKVersion.v2
       );
       app.debug(`Delta emitted for chart: ${chartId}, value: ${chartValue ? 'data' : 'null'}`);
     } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,11 @@ import type {
   DownloadJob
 } from './types.js';
 
-const PLUGIN_ID = 'signalk-charts-provider-simple';
+// Single source of truth lives in container-jobs.ts as PLUGIN_OWNER_ID
+// (used as the `ownerPluginId` label on every runJob call). The plugin
+// id Signal K uses must match exactly so `cleanupOrphanedJobs` reaps
+// the right containers — alias rather than duplicate the literal.
+const PLUGIN_ID = PLUGIN_OWNER_ID;
 const chartTilesPath = `/plugins/${PLUGIN_ID}`;
 
 const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
@@ -2392,12 +2396,12 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
   ): void => {
     try {
       const chartNames = updates.map((u) => u.title ?? u.chartNumber ?? '').join(', ');
-      app.handleMessage('signalk-charts-provider-simple', {
+      app.handleMessage(PLUGIN_ID, {
         updates: [
           {
             values: [
               {
-                path: 'notifications.plugins.signalk-charts-provider-simple.chartCatalogUpdate' as Path,
+                path: `notifications.plugins.${PLUGIN_ID}.chartCatalogUpdate` as Path,
                 value: {
                   state: 'warn',
                   method: ['visual'],
@@ -2419,7 +2423,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
   const emitChartDelta = (chartId: string, chartValue: SanitizedChart | null): void => {
     try {
       app.handleMessage(
-        'signalk-charts-provider-simple',
+        PLUGIN_ID,
         {
           updates: [
             {

--- a/src/utils/container-jobs.ts
+++ b/src/utils/container-jobs.ts
@@ -121,6 +121,8 @@ export async function resolveJobPaths(
  * import the manager type or re-implement exit-code extraction.  Throws
  * when the manager is missing — caller should have checked at startup.
  */
+export const PLUGIN_OWNER_ID = 'signalk-charts-provider-simple';
+
 export async function runJob(opts: JobRunOptions): Promise<JobRunResult> {
   const manager = requireManager();
   const result = await manager.runJob({
@@ -132,7 +134,12 @@ export async function runJob(opts: JobRunOptions): Promise<JobRunResult> {
     label: opts.label,
     onStdoutLine: opts.onStdoutLine,
     onStderrLine: opts.onStderrLine,
-    resources: opts.resources
+    resources: opts.resources,
+    // Required by signalk-container 1.3.0+ for cleanupOrphanedJobs to
+    // find and reap our containers after a Signal K crash. Single
+    // source of truth for the owner id; all of this plugin's helper
+    // jobs go through this wrapper.
+    ownerPluginId: PLUGIN_OWNER_ID
   });
   return {
     exitCode: result.exitCode ?? 1,

--- a/src/utils/container-manager.ts
+++ b/src/utils/container-manager.ts
@@ -57,6 +57,29 @@ export interface ContainerJobConfig {
    */
   resources?: ContainerResourceLimits;
   label?: string;
+  /**
+   * Owning plugin id; tags the container with `sk-job-owner=<id>`
+   * so `cleanupOrphanedJobs` can find and reap it after a Signal K
+   * crash.  Available in signalk-container >= 1.3.0.
+   */
+  ownerPluginId?: string;
+}
+
+/**
+ * One reaped orphan returned by `cleanupOrphanedJobs`.  The `label`
+ * field is whatever the caller passed into `runJob({ label })`; for
+ * this plugin we encode the chartNumber into it so a later rollback
+ * can identify which install record to clear.
+ */
+export interface OrphanJobInfo {
+  name: string;
+  image: string;
+  ownerPluginId: string;
+  label?: string;
+}
+
+export interface CleanupOrphansResult {
+  reaped: OrphanJobInfo[];
 }
 
 export interface ContainerJobResult {
@@ -106,6 +129,15 @@ export interface ContainerManagerApi {
    * mount covers the path.  Available in signalk-container >= 1.1.0.
    */
   resolveHostPath(absPath: string): Promise<ContainerMountResolution | null>;
+  /**
+   * Stop and remove every `sk-job-*` container labelled with the given
+   * `ownerPluginId`. Used at plugin start() to recover from a Signal K
+   * crash that left helpers running with no parent listener. Optional
+   * because we still support signalk-container 1.2.x at runtime — the
+   * plugin guards on `typeof manager.cleanupOrphanedJobs === 'function'`
+   * before calling. Available in signalk-container >= 1.3.0.
+   */
+  cleanupOrphanedJobs?(filter: { ownerPluginId: string }): Promise<CleanupOrphansResult>;
 }
 
 let resolvedManager: ContainerManagerApi | null = null;


### PR DESCRIPTION
## Summary

Consumer-side wiring for the orphan-job recovery API that landed in **signalk-container 1.3.0** (PR https://github.com/dirkwa/signalk-container/pull/18 — released as `signalk-container@1.3.0`).

When Signal K crashed mid-conversion, the helper container kept running but the plugin's listener was lost. The install record written before the conversion ran survived, so the catalog UI showed "Installed" or "Converting…" for a chart that no longer existed. PR #18 added the recovery API; this PR makes the plugin use it.

### Changes

**`src/utils/container-jobs.ts`** — every `runJob` call goes through the local wrapper already, so adding `ownerPluginId: 'signalk-charts-provider-simple'` there covers all 11+ call sites in s57/rnc-converter without threading it through their signatures. Exports `PLUGIN_OWNER_ID` for the start() handler. The existing label format already encodes the chartNumber (`gdal-export-${chartNumber}`, `tippecanoe-${chartNumber}`, etc.) so the cleanup pass can recover which install to roll back from `<stage>-<chartNumber>`.

**`src/utils/container-manager.ts` shim** — `ContainerJobConfig` gains `ownerPluginId?`; `ContainerManagerApi` gains `cleanupOrphanedJobs?` (optional so a 1.2.x runtime degrades gracefully via a `typeof === 'function'` guard at the call site). New `OrphanJobInfo` / `CleanupOrphansResult` types match the surface in signalk-container 1.3.0.

**`src/index.ts`** — after the manager is detected at start(), call `cleanupOrphanedJobs({ ownerPluginId })`. For each reaped orphan, extract the chartNumber from the trailing portion of the label (`gdal-export-2` → `2`), clear converting state, and remove the install record. Emits a single `console.log` line when any reap happens so the user has a breadcrumb in the server log.

### Peer dep

Stays at `>=1.2.1` (per cr feedback on the local review): the plugin gracefully degrades on 1.2.x — it just doesn't get the orphan cleanup, which matches the previous behaviour. Users running 1.3.0 get the fix automatically. Strict bumping to `>=1.3.0` would produce npm warnings for users who have 1.2.x installed without giving them anything they don't already have.

## Tested

- 221/221 unit + 7/7 e2e green
- Local `cr review --plain --base origin/main` — No findings (1 finding addressed: peer dep `>=1.2.1` for graceful degradation)
- Manual end-to-end planned with linked plugin against signalk-container 1.3.0 (released minutes ago).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically detects and cleans up orphaned background conversion jobs during startup.
  * Resets chart converting/install status for interrupted conversions so the catalog UI stays consistent.
  * Cleanup errors are logged without blocking startup, reducing startup failures related to stale jobs.
  * Chart update notifications and delta messages now carry the correct owner ID so updates are attributed consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->