### PR TITLE
feat(convert): quarantine conversions, promote to chartPath only on success

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,12 @@ import {
 } from './utils/s57-converter.js';
 import { getContainerManager, waitForContainerManager } from './utils/container-manager.js';
 import { PLUGIN_OWNER_ID } from './utils/container-jobs.js';
+import {
+  cleanupQuarantineDir,
+  makeQuarantineDir,
+  promoteQuarantine,
+  sweepStaleQuarantineDirs
+} from './utils/quarantine.js';
 import { cleanCatalogTitle } from './utils/catalog-title.js';
 import { setMbtilesDisplayName } from './utils/mbtiles-metadata.js';
 import {
@@ -239,6 +245,24 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     // up.  A missing manager surfaces as setPluginError but does NOT abort
     // startup — chart *display* (serving tiles for already-converted
     // .mbtiles) doesn't need the runtime layer and remains functional.
+    // Wipe any quarantine subdirs left behind by a previous server
+    // lifecycle. Conversions write into <dataDir>/in-progress/<chartNumber>/
+    // and only promote to chartPath on success — if Signal K crashed
+    // mid-conversion the partial .mbtiles is in the quarantine and
+    // safe to drop. Runs unconditionally (independent of whether
+    // signalk-container is reachable) because it only touches our
+    // own filesystem state.
+    try {
+      const swept = sweepStaleQuarantineDirs(app.getDataDirPath());
+      if (swept > 0) {
+        console.log(
+          `[charts-provider] Swept ${swept} stale conversion quarantine dir(s) from a previous lifecycle`
+        );
+      }
+    } catch (err) {
+      app.debug(`Quarantine sweep failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
     const containerManager = await waitForContainerManager({
       onWaitingStatus: () => app.setPluginStatus('Waiting for signalk-container...')
     });
@@ -1623,17 +1647,21 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
           setConvertingState(chartNumber, true);
 
+          const quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+
           try {
             if (convType === 's57') {
               const result = await processS57Zip(
                 validatedFile,
-                chartPath,
+                quarantineDir,
                 chartNumber,
                 (status, message) => {
                   app.debug(`Convert [${chartNumber}] ${status}: ${message}`);
                 },
                 { minzoom, maxzoom }
               );
+
+              await promoteQuarantine(quarantineDir, [result.mbtilesFile], chartPath);
 
               const relativePath = path.relative(
                 chartPath,
@@ -1650,12 +1678,14 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             } else if (convType === 'rnc') {
               const result = await processRncZip(
                 validatedFile,
-                chartPath,
+                quarantineDir,
                 chartNumber,
                 (status, message) => {
                   app.debug(`Convert [${chartNumber}] ${status}: ${message}`);
                 }
               );
+
+              await promoteQuarantine(quarantineDir, result.mbtilesFiles, chartPath);
 
               for (const mbtilesFile of result.mbtilesFiles) {
                 const relativePath = path.relative(chartPath, path.join(chartPath, mbtilesFile));
@@ -1677,6 +1707,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             );
           } finally {
             setConvertingState(chartNumber, false);
+            cleanupQuarantineDir(quarantineDir);
             cleanupDir(tmpDir);
           }
         })();
@@ -1915,11 +1946,20 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
       setConvertingState(chartNumber, true);
 
+      // Convert into a quarantine dir under getDataDirPath() so a
+      // mid-conversion crash leaves a stale .mbtiles there, NOT in
+      // the user's live chart library. Promote to targetDir only
+      // after a successful conversion. trackInstall is already
+      // tracked above (eager — needed so the catalog can show
+      // "Converting…" while we run); the install record gets
+      // cleared on failure or rolled back on next-restart sweep.
+      const quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+
       try {
         const displayName = chartTitle ? cleanCatalogTitle(chartTitle) : undefined;
         const result = await processS57Zip(
           zipPath,
-          targetDir,
+          quarantineDir,
           chartNumber,
           (status, message) => {
             app.debug(`S-57 [${chartNumber}] ${status}: ${message}`);
@@ -1932,7 +1972,14 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           }
         );
 
+        // Atomic move into the live chart library. If this throws
+        // the catch below clears state — the install record gets
+        // dropped and the user sees the catalog row return to
+        // "Download & Convert".
+        await promoteQuarantine(quarantineDir, [result.mbtilesFile], targetDir);
+
         setConvertingState(chartNumber, false);
+        cleanupQuarantineDir(quarantineDir);
         cleanupDir(tmpDownloadDir);
 
         const relativePath = path.relative(chartPath, path.join(targetDir, result.mbtilesFile));
@@ -1955,6 +2002,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         );
         removeInstall(chartNumber);
         setConvertingState(chartNumber, false);
+        cleanupQuarantineDir(quarantineDir);
         cleanupDir(tmpDownloadDir);
       }
     };
@@ -2018,12 +2066,22 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
       app.debug(`Starting RNC conversion for ${chartNumber}: ${zipPath}`);
 
+      const quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+
       try {
-        const result = await processRncZip(zipPath, targetDir, chartNumber, (status, message) => {
-          app.debug(`RNC [${chartNumber}] ${status}: ${message}`);
-        });
+        const result = await processRncZip(
+          zipPath,
+          quarantineDir,
+          chartNumber,
+          (status, message) => {
+            app.debug(`RNC [${chartNumber}] ${status}: ${message}`);
+          }
+        );
+
+        await promoteQuarantine(quarantineDir, result.mbtilesFiles, targetDir);
 
         setConvertingState(chartNumber, false);
+        cleanupQuarantineDir(quarantineDir);
         cleanupDir(tmpDownloadDir);
 
         const firstRelative = result.mbtilesFiles[0]
@@ -2055,6 +2113,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         );
         removeInstall(chartNumber);
         setConvertingState(chartNumber, false);
+        cleanupQuarantineDir(quarantineDir);
         cleanupDir(tmpDownloadDir);
       }
     };
@@ -2115,12 +2174,22 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
       setConvertingState(chartNumber, true);
 
+      const quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+
       try {
-        const result = await processPilotTar(dlPath, targetDir, chartNumber, (status, message) => {
-          app.debug(`Pilot [${chartNumber}] ${status}: ${message}`);
-        });
+        const result = await processPilotTar(
+          dlPath,
+          quarantineDir,
+          chartNumber,
+          (status, message) => {
+            app.debug(`Pilot [${chartNumber}] ${status}: ${message}`);
+          }
+        );
+
+        await promoteQuarantine(quarantineDir, result.mbtilesFiles, targetDir);
 
         setConvertingState(chartNumber, false);
+        cleanupQuarantineDir(quarantineDir);
         cleanupDir(tmpDownloadDir);
 
         for (const mbtilesFile of result.mbtilesFiles) {
@@ -2142,6 +2211,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         );
         removeInstall(chartNumber);
         setConvertingState(chartNumber, false);
+        cleanupQuarantineDir(quarantineDir);
         cleanupDir(tmpDownloadDir);
       }
     };
@@ -2202,17 +2272,22 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
       setConvertingState(chartNumber, true);
 
+      const quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+
       try {
         const result = await processShpBasemap(
           dlPath,
-          targetDir,
+          quarantineDir,
           chartNumber,
           (status, message) => {
             app.debug(`ShpBasemap [${chartNumber}] ${status}: ${message}`);
           }
         );
 
+        await promoteQuarantine(quarantineDir, [result.mbtilesFile], targetDir);
+
         setConvertingState(chartNumber, false);
+        cleanupQuarantineDir(quarantineDir);
         cleanupDir(tmpDownloadDir);
 
         const relativePath = path.relative(chartPath, path.join(targetDir, result.mbtilesFile));
@@ -2231,6 +2306,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         );
         removeInstall(chartNumber);
         setConvertingState(chartNumber, false);
+        cleanupQuarantineDir(quarantineDir);
         cleanupDir(tmpDownloadDir);
       }
     };
@@ -2269,14 +2345,24 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
     const tmpDir = path.join(app.getDataDirPath(), `gshhg-${Date.now()}`);
     fs.mkdirSync(tmpDir, { recursive: true });
+    const quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
 
     void (async () => {
       try {
-        await processGshhg(tmpDir, targetDir, resolution, chartNumber, (status, message) => {
-          app.debug(`GSHHG [${chartNumber}] ${status}: ${message}`);
-        });
+        const result = await processGshhg(
+          tmpDir,
+          quarantineDir,
+          resolution,
+          chartNumber,
+          (status, message) => {
+            app.debug(`GSHHG [${chartNumber}] ${status}: ${message}`);
+          }
+        );
+
+        await promoteQuarantine(quarantineDir, [result.mbtilesFile], targetDir);
 
         setConvertingState(chartNumber, false);
+        cleanupQuarantineDir(quarantineDir);
         await refreshChartProviders();
 
         const chartId = `gshhg-basemap-${resolution}`;
@@ -2291,6 +2377,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         );
         removeInstall(chartNumber);
         setConvertingState(chartNumber, false);
+        cleanupQuarantineDir(quarantineDir);
       } finally {
         cleanupDir(tmpDir);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,7 +218,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     initCatalogManager(dataDir, app.debug.bind(app));
 
     const tempDirPattern =
-      /^(s57-download-|rnc-download-|pilot-download-|shp-download-|gshhg-)\d+$/;
+      /^(s57-download-|rnc-download-|pilot-download-|shp-download-|gshhg-|convert-upload-)\d+$/;
     try {
       const dataDirEntries = fs.readdirSync(dataDir, { withFileTypes: true });
       for (const entry of dataDirEntries) {
@@ -607,7 +607,42 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             fs.mkdirSync(targetDir, { recursive: true });
           }
 
-          const jobId = downloadManager.createJob(downloadUrl, targetDir, chartName);
+          // Stage the download in the quarantine dir; promote on
+          // job-completed so a crash mid-fetch never leaves a partial
+          // .mbtiles in the live chart library.
+          const quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartName);
+          const jobId = downloadManager.createJob(downloadUrl, quarantineDir, chartName);
+
+          const promoteListener = (job: DownloadJob): void => {
+            if (job.id !== jobId) {
+              return;
+            }
+            void (async () => {
+              try {
+                if (
+                  job.status === 'completed' &&
+                  job.extractedFiles &&
+                  job.extractedFiles.length > 0
+                ) {
+                  try {
+                    await promoteQuarantine(quarantineDir, job.extractedFiles, targetDir);
+                  } catch (promoteErr) {
+                    app.error(
+                      `Promotion failed for ${chartName}: ${
+                        promoteErr instanceof Error ? promoteErr.message : String(promoteErr)
+                      }`
+                    );
+                  }
+                }
+              } finally {
+                cleanupQuarantineDir(quarantineDir);
+                downloadManager.removeListener('job-completed', promoteListener);
+                downloadManager.removeListener('job-failed', promoteListener);
+              }
+            })();
+          };
+          downloadManager.on('job-completed', promoteListener);
+          downloadManager.on('job-failed', promoteListener);
 
           res.json({
             success: true,
@@ -1265,6 +1300,14 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       try {
         const bb = Busboy({ headers: req.headers });
         const basePath = props.chartPath || defaultChartsPath;
+        // Per-request quarantine dir: every uploaded `.mbtiles` is
+        // streamed here first, then atomically promoted on `finish`.
+        // A crashed/aborted request leaves the partial files in the
+        // quarantine for the startup sweep to wipe, never in basePath.
+        const quarantineDir = makeQuarantineDir(
+          app.getDataDirPath(),
+          `upload-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+        );
         const uploadedFiles: string[] = [];
         const writePromises: Promise<void>[] = [];
         const fields: Record<string, string> = {};
@@ -1290,30 +1333,35 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
               uploadPath = path.join(basePath, targetFolder);
             }
 
-            const filepath = path.join(uploadPath, filename);
-
             // Reject path-traversal in either the targetFolder or the
             // upload's own filename (`filename: '../etc/passwd'`).
-            if (!isWithinBase(filepath, basePath)) {
+            // Resolve against basePath even though we stage in the
+            // quarantine — the *intended* destination is what matters
+            // for the access-control check.
+            if (
+              !isWithinBase(path.join(uploadPath, filename), basePath) ||
+              path.basename(filename) !== filename
+            ) {
               traversalRejected = true;
               (file as NodeJS.ReadableStream & { resume(): void }).resume();
               return;
             }
 
-            app.debug(`Uploading chart file: ${filename} to ${filepath}`);
+            const stagedPath = path.join(quarantineDir, filename);
+            app.debug(`Staging upload: ${filename} -> ${stagedPath}`);
 
-            const writeStream = fs.createWriteStream(filepath);
+            const writeStream = fs.createWriteStream(stagedPath);
             file.pipe(writeStream);
 
             const writePromise = new Promise<void>((resolve, reject) => {
               writeStream.on('finish', () => {
                 uploadedFiles.push(filename);
-                app.debug(`Chart file uploaded successfully: ${filename}`);
+                app.debug(`Upload staged successfully: ${filename}`);
                 resolve();
               });
 
               writeStream.on('error', (err: Error) => {
-                app.error(`Error writing file ${filename}: ${err.message}`);
+                app.error(`Error staging file ${filename}: ${err.message}`);
                 reject(err);
               });
             });
@@ -1330,11 +1378,13 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             // also lets us include 'targetFolder' rules in the validator.
             const parsed = parseShape(UploadFields, fields, res);
             if (!parsed) {
+              cleanupQuarantineDir(quarantineDir);
               return;
             }
             const { targetFolder = '' } = parsed;
 
             if (traversalRejected) {
+              cleanupQuarantineDir(quarantineDir);
               res.status(403).json({ success: false, error: 'Access denied: Invalid upload path' });
               return;
             }
@@ -1343,6 +1393,12 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
               await Promise.all(writePromises);
 
               if (uploadedFiles.length > 0) {
+                const promoteTarget =
+                  targetFolder && targetFolder !== '/'
+                    ? path.join(basePath, targetFolder)
+                    : basePath;
+                await promoteQuarantine(quarantineDir, uploadedFiles, promoteTarget);
+
                 await finalizeUploadedFiles(uploadedFiles, targetFolder, basePath);
 
                 res.status(200).json({
@@ -1359,6 +1415,8 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
                   (error instanceof Error ? error.message : String(error))
               );
               res.status(500).send('Error completing file uploads');
+            } finally {
+              cleanupQuarantineDir(quarantineDir);
             }
           })();
         });
@@ -1401,18 +1459,32 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           uploadPath = path.join(basePath, targetFolder);
         }
 
-        const partialPath = path.join(uploadPath, filename + '.partial');
         const finalPath = path.join(uploadPath, filename);
 
         // Reject path-traversal via either header. Catches `'../foo.mbtiles'`
         // as a filename and `'../etc'` as a target-folder, both of which
-        // would otherwise resolve outside the chart root.
-        if (!arePairWithinBase(partialPath, finalPath, basePath)) {
+        // would otherwise resolve outside the chart root. Re-check
+        // basename to catch any traversal in the filename header itself
+        // even though arePairWithinBase already handled the resolved
+        // path — defense in depth before we use it as a path segment
+        // inside the quarantine dir.
+        if (
+          !arePairWithinBase(finalPath, finalPath, basePath) ||
+          path.basename(filename) !== filename
+        ) {
           res.status(403).json({ error: 'Access denied: Invalid upload path' });
           return;
         }
 
-        const writeStream = fs.createWriteStream(partialPath, {
+        // Stage chunked uploads in a per-filename quarantine dir.  All
+        // chunks append to a single staged file there; only the final
+        // chunk promotes it to the live `uploadPath`. A crash mid-upload
+        // therefore can never leave a half-built `.mbtiles` in the
+        // chart library — the startup sweep wipes the quarantine.
+        const quarantineDir = makeQuarantineDir(app.getDataDirPath(), `chunk-${filename}`);
+        const stagedPath = path.join(quarantineDir, filename);
+
+        const writeStream = fs.createWriteStream(stagedPath, {
           flags: chunkIndex === 0 ? 'w' : 'a'
         });
 
@@ -1427,17 +1499,19 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
                 return;
               }
 
-              // Final chunk — rename partial to final
+              // Final chunk — promote the staged file out of quarantine.
               app.debug(`Final chunk ${totalChunks}/${totalChunks} for ${filename}, assembling`);
-              fs.renameSync(partialPath, finalPath);
-
-              await finalizeUploadedFiles([filename], targetFolder, basePath);
-
-              res.json({
-                success: true,
-                message: `${filename} uploaded successfully`,
-                files: [filename]
-              });
+              try {
+                await promoteQuarantine(quarantineDir, [filename], uploadPath);
+                await finalizeUploadedFiles([filename], targetFolder, basePath);
+                res.json({
+                  success: true,
+                  message: `${filename} uploaded successfully`,
+                  files: [filename]
+                });
+              } finally {
+                cleanupQuarantineDir(quarantineDir);
+              }
             } catch (error) {
               app.error(
                 `Error finalizing chunked upload: ${error instanceof Error ? error.message : String(error)}`
@@ -1647,9 +1721,15 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
           setConvertingState(chartNumber, true);
 
-          const quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+          // makeQuarantineDir can throw on permission/disk errors;
+          // build it inside the guarded try so a failure goes
+          // through the same converting-flag rollback as a
+          // conversion error. Null until the assignment succeeds
+          // so the finally branch knows whether to clean up.
+          let quarantineDir: string | null = null;
 
           try {
+            quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
             if (convType === 's57') {
               const result = await processS57Zip(
                 validatedFile,
@@ -1707,7 +1787,9 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             );
           } finally {
             setConvertingState(chartNumber, false);
-            cleanupQuarantineDir(quarantineDir);
+            if (quarantineDir !== null) {
+              cleanupQuarantineDir(quarantineDir);
+            }
             cleanupDir(tmpDir);
           }
         })();
@@ -1852,16 +1934,43 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             chartPath
           );
         } else {
-          const jobId = downloadManager.createJob(url, targetDir, chartNumber);
+          // Direct .mbtiles download (or ZIP-of-.mbtiles): stage into the
+          // quarantine dir so a crash mid-download/extract never leaves a
+          // half-built file in the live chart library. Promotion runs on
+          // job-completed; failure / no-files paths drop the quarantine.
+          const quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+          const jobId = downloadManager.createJob(url, quarantineDir, chartNumber);
 
           trackInstall(chartNumber, catalogFile, zipfileDatetime ?? '', url);
 
           const cleanupListener = (job: DownloadJob): void => {
-            if (job.id === jobId) {
-              if (!job.extractedFiles || job.extractedFiles.length === 0) {
-                removeInstall(chartNumber);
-                app.debug(`Removed catalog tracking for ${chartNumber}: no .mbtiles extracted`);
-              } else {
+            if (job.id !== jobId) {
+              return;
+            }
+            void (async () => {
+              try {
+                if (!job.extractedFiles || job.extractedFiles.length === 0) {
+                  removeInstall(chartNumber);
+                  app.debug(`Removed catalog tracking for ${chartNumber}: no .mbtiles extracted`);
+                  return;
+                }
+                if (job.status !== 'completed') {
+                  // Failed downloads leak nothing into the live target;
+                  // the quarantine wipe in `finally` handles cleanup.
+                  removeInstall(chartNumber);
+                  return;
+                }
+                try {
+                  await promoteQuarantine(quarantineDir, job.extractedFiles, targetDir);
+                } catch (promoteErr) {
+                  app.error(
+                    `Promotion failed for ${chartNumber}: ${
+                      promoteErr instanceof Error ? promoteErr.message : String(promoteErr)
+                    }`
+                  );
+                  removeInstall(chartNumber);
+                  return;
+                }
                 // Record the produced filename so the delete flow can
                 // clear this install record by reverse-lookup. Same
                 // pattern as the S-57 / RNC conversion completion paths.
@@ -1873,10 +1982,12 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
                     : firstFile;
                   setInstallFilename(chartNumber, relativePath);
                 }
+              } finally {
+                cleanupQuarantineDir(quarantineDir);
+                downloadManager.removeListener('job-failed', cleanupListener);
+                downloadManager.removeListener('job-completed', cleanupListener);
               }
-              downloadManager.removeListener('job-failed', cleanupListener);
-              downloadManager.removeListener('job-completed', cleanupListener);
-            }
+            })();
           };
           downloadManager.on('job-failed', cleanupListener);
           downloadManager.on('job-completed', cleanupListener);
@@ -1949,13 +2060,13 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       // Convert into a quarantine dir under getDataDirPath() so a
       // mid-conversion crash leaves a stale .mbtiles there, NOT in
       // the user's live chart library. Promote to targetDir only
-      // after a successful conversion. trackInstall is already
-      // tracked above (eager — needed so the catalog can show
-      // "Converting…" while we run); the install record gets
-      // cleared on failure or rolled back on next-restart sweep.
-      const quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+      // after a successful conversion. The mkdir is inside the
+      // guarded try so a sync throw (perms, disk full) goes through
+      // the same cleanup as a conversion failure.
+      let quarantineDir: string | null = null;
 
       try {
+        quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
         const displayName = chartTitle ? cleanCatalogTitle(chartTitle) : undefined;
         const result = await processS57Zip(
           zipPath,
@@ -2002,7 +2113,9 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         );
         removeInstall(chartNumber);
         setConvertingState(chartNumber, false);
-        cleanupQuarantineDir(quarantineDir);
+        if (quarantineDir !== null) {
+          cleanupQuarantineDir(quarantineDir);
+        }
         cleanupDir(tmpDownloadDir);
       }
     };
@@ -2066,9 +2179,10 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
       app.debug(`Starting RNC conversion for ${chartNumber}: ${zipPath}`);
 
-      const quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+      let quarantineDir: string | null = null;
 
       try {
+        quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
         const result = await processRncZip(
           zipPath,
           quarantineDir,
@@ -2113,7 +2227,9 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         );
         removeInstall(chartNumber);
         setConvertingState(chartNumber, false);
-        cleanupQuarantineDir(quarantineDir);
+        if (quarantineDir !== null) {
+          cleanupQuarantineDir(quarantineDir);
+        }
         cleanupDir(tmpDownloadDir);
       }
     };
@@ -2174,9 +2290,10 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
       setConvertingState(chartNumber, true);
 
-      const quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+      let quarantineDir: string | null = null;
 
       try {
+        quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
         const result = await processPilotTar(
           dlPath,
           quarantineDir,
@@ -2211,7 +2328,9 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         );
         removeInstall(chartNumber);
         setConvertingState(chartNumber, false);
-        cleanupQuarantineDir(quarantineDir);
+        if (quarantineDir !== null) {
+          cleanupQuarantineDir(quarantineDir);
+        }
         cleanupDir(tmpDownloadDir);
       }
     };
@@ -2272,9 +2391,10 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
       setConvertingState(chartNumber, true);
 
-      const quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+      let quarantineDir: string | null = null;
 
       try {
+        quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
         const result = await processShpBasemap(
           dlPath,
           quarantineDir,
@@ -2306,7 +2426,9 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         );
         removeInstall(chartNumber);
         setConvertingState(chartNumber, false);
-        cleanupQuarantineDir(quarantineDir);
+        if (quarantineDir !== null) {
+          cleanupQuarantineDir(quarantineDir);
+        }
         cleanupDir(tmpDownloadDir);
       }
     };
@@ -2345,10 +2467,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
     const tmpDir = path.join(app.getDataDirPath(), `gshhg-${Date.now()}`);
     fs.mkdirSync(tmpDir, { recursive: true });
-    const quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
 
     void (async () => {
+      let quarantineDir: string | null = null;
       try {
+        quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
         const result = await processGshhg(
           tmpDir,
           quarantineDir,
@@ -2377,7 +2500,9 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         );
         removeInstall(chartNumber);
         setConvertingState(chartNumber, false);
-        cleanupQuarantineDir(quarantineDir);
+        if (quarantineDir !== null) {
+          cleanupQuarantineDir(quarantineDir);
+        }
       } finally {
         cleanupDir(tmpDir);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -632,6 +632,28 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
                         promoteErr instanceof Error ? promoteErr.message : String(promoteErr)
                       }`
                     );
+                    return;
+                  }
+                  // The global job-completed handler runs against
+                  // job.targetDir (the quarantine), so the chart it
+                  // tried to enable is at a path that no longer
+                  // exists. Re-do enable + refresh against the live
+                  // target so the chart actually shows up.
+                  const basePath = props.chartPath || defaultChartsPath;
+                  const targetFolderRel = path.relative(basePath, targetDir);
+                  for (const fileName of job.extractedFiles) {
+                    const relativePath = targetFolderRel
+                      ? path.join(targetFolderRel, fileName)
+                      : fileName;
+                    setChartEnabled(relativePath, true);
+                  }
+                  await refreshChartProviders();
+                  for (const fileName of job.extractedFiles) {
+                    const chartId = fileName.replace(/\.mbtiles$/, '');
+                    if (chartProviders[chartId]) {
+                      const chartData = sanitizeProvider(chartProviders[chartId], 2);
+                      emitChartDelta(chartId, chartData);
+                    }
                   }
                 }
               } finally {
@@ -1397,6 +1419,21 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
                   targetFolder && targetFolder !== '/'
                     ? path.join(basePath, targetFolder)
                     : basePath;
+                // The earlier per-file `isWithinBase` check ran against
+                // each filename joined with the *raw* `fields.targetFolder`,
+                // before busboy had handed us every field. The actual
+                // promotion target is computed here from the *parsed*
+                // value, so re-check containment before we move staged
+                // files anywhere — a malformed targetFolder mustn't be
+                // able to slip through and direct the promotion outside
+                // basePath.
+                if (!isWithinBase(promoteTarget, basePath)) {
+                  cleanupQuarantineDir(quarantineDir);
+                  res
+                    .status(403)
+                    .json({ success: false, error: 'Access denied: Invalid upload path' });
+                  return;
+                }
                 await promoteQuarantine(quarantineDir, uploadedFiles, promoteTarget);
 
                 await finalizeUploadedFiles(uploadedFiles, targetFolder, basePath);
@@ -1717,19 +1754,27 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             .basename(uploadedFileName, '.zip')
             .replace(/[^a-zA-Z0-9_-]/g, '_');
 
-          res.json({ success: true, chartNumber, message: 'Conversion started' });
-
-          setConvertingState(chartNumber, true);
-
-          // makeQuarantineDir can throw on permission/disk errors;
-          // build it inside the guarded try so a failure goes
-          // through the same converting-flag rollback as a
-          // conversion error. Null until the assignment succeeds
-          // so the finally branch knows whether to clean up.
-          let quarantineDir: string | null = null;
-
+          // Order matters: defer the success response until
+          // makeQuarantineDir has actually returned. A permission /
+          // disk error there used to surface AFTER the client had
+          // already been told the conversion was running, leaving
+          // the UI stuck waiting for status it would never get.
+          let quarantineDir: string;
           try {
             quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+          } catch (err) {
+            res.status(500).json({
+              success: false,
+              error: `Failed to prepare conversion workspace: ${
+                err instanceof Error ? err.message : String(err)
+              }`
+            });
+            return;
+          }
+          setConvertingState(chartNumber, true);
+          res.json({ success: true, chartNumber, message: 'Conversion started' });
+
+          try {
             if (convType === 's57') {
               const result = await processS57Zip(
                 validatedFile,
@@ -1787,9 +1832,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             );
           } finally {
             setConvertingState(chartNumber, false);
-            if (quarantineDir !== null) {
-              cleanupQuarantineDir(quarantineDir);
-            }
+            cleanupQuarantineDir(quarantineDir);
             cleanupDir(tmpDir);
           }
         })();
@@ -1971,12 +2014,34 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
                   removeInstall(chartNumber);
                   return;
                 }
+                // The global `job-completed` handler enables charts and
+                // refreshes providers against `job.targetDir`, but with
+                // quarantine that's the staging dir under
+                // `<dataDir>/in-progress/`, not the live target. So
+                // run the same enable + refresh + delta-emit cycle
+                // ourselves now that the files are actually in place.
+                const targetFolderRel = path.relative(chartPath, targetDir);
+                for (const fileName of job.extractedFiles) {
+                  const relativePath = targetFolderRel
+                    ? path.join(targetFolderRel, fileName)
+                    : fileName;
+                  setChartEnabled(relativePath, true);
+                  app.debug(`Enabled promoted chart: ${relativePath}`);
+                }
+                await refreshChartProviders();
+                for (const fileName of job.extractedFiles) {
+                  const chartId = fileName.replace(/\.mbtiles$/, '');
+                  if (chartProviders[chartId]) {
+                    const chartData = sanitizeProvider(chartProviders[chartId], 2);
+                    emitChartDelta(chartId, chartData);
+                    app.debug(`Delta emitted for promoted chart: ${chartId}`);
+                  }
+                }
                 // Record the produced filename so the delete flow can
                 // clear this install record by reverse-lookup. Same
                 // pattern as the S-57 / RNC conversion completion paths.
                 const firstFile = job.extractedFiles[0];
                 if (firstFile) {
-                  const targetFolderRel = path.relative(chartPath, targetDir);
                   const relativePath = targetFolderRel
                     ? path.join(targetFolderRel, firstFile)
                     : firstFile;

--- a/src/utils/quarantine.ts
+++ b/src/utils/quarantine.ts
@@ -44,9 +44,18 @@ export function makeQuarantineDir(dataDir: string, chartNumber: string): string 
  * dir into `targetDir` (subfolder under chartPath). Failure is
  * **all-or-nothing**: if any file fails to move, every file that
  * was already moved this call is rolled back to the quarantine and
- * the error propagates. Without that, a multi-file RNC/Pilot batch
- * could end up half-promoted — a partial chart set in chartPath
- * defeats the quarantine guarantee.
+ * any pre-existing live file we displaced is restored. Without that,
+ * a multi-file RNC/Pilot batch could end up half-promoted — a
+ * partial chart set in chartPath defeats the quarantine guarantee.
+ *
+ * Pre-existing files in `targetDir` whose names collide with a
+ * promoted filename are preserved by moving the original aside to a
+ * sibling `<filename>.replaced-<ts>` first; on success those backups
+ * are removed, on failure they're moved back into place. Without
+ * this step, a failed multi-file promotion could leave the user's
+ * previously working chart deleted with no replacement (the new file
+ * was rolled back to quarantine, but the old file we overwrote en
+ * route is gone).
  *
  * Each `filename` must be a plain basename (no `..`, no separators,
  * not absolute). The helper is the trust boundary between converter
@@ -72,6 +81,28 @@ export async function promoteQuarantine(
 
   await fs.promises.mkdir(targetDir, { recursive: true });
 
+  // Phase 1: for any target filename that already exists, move the
+  // current live file aside to a backup path in the same dir. Same-dir
+  // keeps the rename atomic (no EXDEV), and on success we just rm the
+  // backup; on failure we rename it back into place.
+  const backupSuffix = `.replaced-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const backups: { live: string; backup: string }[] = [];
+  for (const filename of filenames) {
+    const livePath = path.join(targetDir, filename);
+    let exists = false;
+    try {
+      await fs.promises.access(livePath, fs.constants.F_OK);
+      exists = true;
+    } catch {
+      exists = false;
+    }
+    if (exists) {
+      const backupPath = `${livePath}${backupSuffix}`;
+      await fs.promises.rename(livePath, backupPath);
+      backups.push({ live: livePath, backup: backupPath });
+    }
+  }
+
   const moved: { from: string; to: string }[] = [];
   try {
     for (const filename of filenames) {
@@ -91,11 +122,15 @@ export async function promoteQuarantine(
       moved.push({ from, to });
     }
   } catch (err) {
-    // Roll back: move every successfully promoted file back to the
-    // quarantine dir so the live chart library doesn't keep a
-    // partial set. Best-effort — a rollback failure is logged but
-    // we still throw the original error so the caller knows the
-    // promotion didn't succeed.
+    // Roll back in two phases:
+    //   1) Move each successfully promoted file back to the quarantine
+    //      dir so the live chart library doesn't keep a partial set.
+    //   2) Restore any pre-existing originals from `backups` so an
+    //      attempted upgrade that failed doesn't take out the working
+    //      chart the user had before.
+    // Best-effort throughout — a rollback failure is logged but we
+    // still throw the original error so the caller knows the promotion
+    // didn't succeed.
     for (const { from, to } of moved) {
       try {
         await fs.promises.rename(to, from);
@@ -112,7 +147,33 @@ export async function promoteQuarantine(
         }
       }
     }
+    for (const { live, backup } of backups) {
+      try {
+        await fs.promises.rename(backup, live);
+      } catch (restoreErr) {
+        console.warn(
+          `[charts-provider] promoteQuarantine could not restore pre-existing ${live} from ${backup}: ${
+            restoreErr instanceof Error ? restoreErr.message : String(restoreErr)
+          }`
+        );
+      }
+    }
     throw err;
+  }
+
+  // Promotion succeeded — drop the backups of replaced originals.
+  // Best-effort: a leftover .replaced-* file is cosmetic, never
+  // load-bearing for the live chart library.
+  for (const { backup } of backups) {
+    try {
+      await fs.promises.unlink(backup);
+    } catch (cleanupErr) {
+      console.warn(
+        `[charts-provider] promoteQuarantine could not delete backup ${backup}: ${
+          cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)
+        }`
+      );
+    }
   }
 }
 

--- a/src/utils/quarantine.ts
+++ b/src/utils/quarantine.ts
@@ -1,0 +1,129 @@
+/**
+ * Conversion quarantine: helpers that let a conversion write into a
+ * scratch directory and atomically promote the result(s) to the live
+ * `chartPath`. A Signal K crash during conversion leaves a stale dir
+ * inside `<dataDir>/in-progress/`; `sweepStaleQuarantineDirs()` wipes
+ * any leftover at startup so the user's chart library is never
+ * polluted with half-built `.mbtiles` files.
+ *
+ * Design notes:
+ *
+ * - One subdir per chart number (`<dataDir>/in-progress/<chartNumber>/`).
+ *   Multiple concurrent conversions of the same chartNumber can't
+ *   collide because `cpuBudget.maxConcurrentConversions` is 1, but the
+ *   subdir layout still keeps things tidy under inspection.
+ *
+ * - `promote()` uses `fs.promises.rename` first (atomic when both
+ *   sides are on the same filesystem) and falls back to copy+unlink
+ *   when the user has set `chartPath` to a different mount (USB/NFS).
+ *
+ * - The promotion target dir (subfolder under chartPath) is created
+ *   recursively; the converter itself doesn't need to know how the
+ *   final landing location is shaped.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const QUARANTINE_ROOT_NAME = 'in-progress';
+
+/**
+ * Resolve `<dataDir>/in-progress/<chartNumber>/` and create it. Idempotent.
+ * Returns the absolute path so the caller can pass it as the converter's
+ * `chartsDir` argument and the converter writes there instead of into the
+ * live chart library.
+ */
+export function makeQuarantineDir(dataDir: string, chartNumber: string): string {
+  const dir = path.join(dataDir, QUARANTINE_ROOT_NAME, sanitizeIdSegment(chartNumber));
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * Atomically move every file the converter produced from the quarantine
+ * dir into `targetDir` (subfolder under chartPath). Returns the array of
+ * absolute paths the files now live at — converters that report a
+ * `mbtilesFile` / `mbtilesFiles[]` field can map back through this.
+ *
+ * On promotion failure (rename + copy both fail), the quarantine is
+ * left in place — the next startup sweep cleans it up. The error
+ * propagates so the catalog flow records the conversion as failed.
+ */
+export async function promoteQuarantine(
+  quarantineDir: string,
+  filenames: string[],
+  targetDir: string
+): Promise<void> {
+  await fs.promises.mkdir(targetDir, { recursive: true });
+  for (const filename of filenames) {
+    const from = path.join(quarantineDir, filename);
+    const to = path.join(targetDir, filename);
+    try {
+      await fs.promises.rename(from, to);
+    } catch (err) {
+      // EXDEV = cross-device link. Different filesystems → copy+unlink.
+      // Other errors (EBUSY, EACCES) re-raise; the caller turns it
+      // into a conversion failure.
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'EXDEV') {
+        throw err;
+      }
+      await fs.promises.copyFile(from, to);
+      await fs.promises.unlink(from);
+    }
+  }
+}
+
+/**
+ * Best-effort cleanup of the quarantine subdir. Called whether the
+ * conversion succeeded or failed — on success any non-promoted
+ * leftovers (intermediate files, logs) get cleaned up; on failure
+ * the half-built artifacts are dropped before they can pollute
+ * anything.
+ */
+export function cleanupQuarantineDir(quarantineDir: string): void {
+  try {
+    fs.rmSync(quarantineDir, { recursive: true, force: true });
+  } catch {
+    // Quarantine may have already been swept by the startup
+    // pass (concurrent conversion + restart edge case); not an
+    // error worth surfacing.
+  }
+}
+
+/**
+ * Wipe every subdir under `<dataDir>/in-progress/` at startup.
+ * Anything in there is from a prior server lifecycle that didn't
+ * complete, so the contents are by definition stale and unsafe to
+ * promote.
+ *
+ * Returns the count of dirs swept so callers can log it.
+ */
+export function sweepStaleQuarantineDirs(dataDir: string): number {
+  const root = path.join(dataDir, QUARANTINE_ROOT_NAME);
+  if (!fs.existsSync(root)) {
+    return 0;
+  }
+  let swept = 0;
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      try {
+        fs.rmSync(path.join(root, entry.name), { recursive: true, force: true });
+        swept += 1;
+      } catch {
+        // Best-effort. Permissions / locked file shouldn't block
+        // plugin start; the user can clean up by hand if needed.
+      }
+    }
+  }
+  return swept;
+}
+
+/**
+ * Sanitize a chartNumber for use as a path segment. Catalog chart
+ * numbers are typically integers or short alphanumerics; this is a
+ * defensive guard against anything weird in user-uploaded ZIPs.
+ */
+function sanitizeIdSegment(s: string): string {
+  return s.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64) || 'unnamed';
+}

--- a/src/utils/quarantine.ts
+++ b/src/utils/quarantine.ts
@@ -40,37 +40,79 @@ export function makeQuarantineDir(dataDir: string, chartNumber: string): string 
 }
 
 /**
- * Atomically move every file the converter produced from the quarantine
- * dir into `targetDir` (subfolder under chartPath). Returns the array of
- * absolute paths the files now live at — converters that report a
- * `mbtilesFile` / `mbtilesFiles[]` field can map back through this.
+ * Promote every file the converter produced from the quarantine
+ * dir into `targetDir` (subfolder under chartPath). Failure is
+ * **all-or-nothing**: if any file fails to move, every file that
+ * was already moved this call is rolled back to the quarantine and
+ * the error propagates. Without that, a multi-file RNC/Pilot batch
+ * could end up half-promoted — a partial chart set in chartPath
+ * defeats the quarantine guarantee.
  *
- * On promotion failure (rename + copy both fail), the quarantine is
- * left in place — the next startup sweep cleans it up. The error
- * propagates so the catalog flow records the conversion as failed.
+ * Each `filename` must be a plain basename (no `..`, no separators,
+ * not absolute). The helper is the trust boundary between converter
+ * output and the live chart directory; a converter that returns
+ * `../foo.mbtiles` would otherwise write outside `targetDir`.
  */
 export async function promoteQuarantine(
   quarantineDir: string,
   filenames: string[],
   targetDir: string
 ): Promise<void> {
-  await fs.promises.mkdir(targetDir, { recursive: true });
+  // Validate first: refuse to start any moves if any name is unsafe.
   for (const filename of filenames) {
-    const from = path.join(quarantineDir, filename);
-    const to = path.join(targetDir, filename);
-    try {
-      await fs.promises.rename(from, to);
-    } catch (err) {
-      // EXDEV = cross-device link. Different filesystems → copy+unlink.
-      // Other errors (EBUSY, EACCES) re-raise; the caller turns it
-      // into a conversion failure.
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code !== 'EXDEV') {
-        throw err;
-      }
-      await fs.promises.copyFile(from, to);
-      await fs.promises.unlink(from);
+    if (
+      filename === '' ||
+      path.basename(filename) !== filename ||
+      filename.includes('..') ||
+      path.isAbsolute(filename)
+    ) {
+      throw new Error(`Invalid promoted filename: ${JSON.stringify(filename)}`);
     }
+  }
+
+  await fs.promises.mkdir(targetDir, { recursive: true });
+
+  const moved: { from: string; to: string }[] = [];
+  try {
+    for (const filename of filenames) {
+      const from = path.join(quarantineDir, filename);
+      const to = path.join(targetDir, filename);
+      try {
+        await fs.promises.rename(from, to);
+      } catch (err) {
+        // EXDEV = cross-device link. Different filesystems → copy+unlink.
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== 'EXDEV') {
+          throw err;
+        }
+        await fs.promises.copyFile(from, to);
+        await fs.promises.unlink(from);
+      }
+      moved.push({ from, to });
+    }
+  } catch (err) {
+    // Roll back: move every successfully promoted file back to the
+    // quarantine dir so the live chart library doesn't keep a
+    // partial set. Best-effort — a rollback failure is logged but
+    // we still throw the original error so the caller knows the
+    // promotion didn't succeed.
+    for (const { from, to } of moved) {
+      try {
+        await fs.promises.rename(to, from);
+      } catch {
+        try {
+          await fs.promises.copyFile(to, from);
+          await fs.promises.unlink(to);
+        } catch (rollbackErr) {
+          console.warn(
+            `[charts-provider] promoteQuarantine rollback failed for ${to}: ${
+              rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)
+            }`
+          );
+        }
+      }
+    }
+    throw err;
   }
 }
 

--- a/test/quarantine.test.ts
+++ b/test/quarantine.test.ts
@@ -103,6 +103,44 @@ describe('quarantine helpers', () => {
     assert.strictEqual(fs.readFileSync(path.join(q, 'second.mbtiles'), 'utf8'), 'B');
   });
 
+  it('promoteQuarantine overwrites a pre-existing live file on success and removes the backup', async () => {
+    const q = makeQuarantineDir(dataDir, 'overwrite-1');
+    fs.writeFileSync(path.join(q, 'chart.mbtiles'), 'NEW');
+
+    const subTarget = path.join(chartPath, 'overwrite-target');
+    fs.mkdirSync(subTarget, { recursive: true });
+    fs.writeFileSync(path.join(subTarget, 'chart.mbtiles'), 'OLD');
+
+    await promoteQuarantine(q, ['chart.mbtiles'], subTarget);
+
+    assert.strictEqual(fs.readFileSync(path.join(subTarget, 'chart.mbtiles'), 'utf8'), 'NEW');
+    // No backup left behind once the promotion succeeded.
+    const leftover = fs.readdirSync(subTarget).filter((f) => f.includes('.replaced-'));
+    assert.deepStrictEqual(leftover, []);
+  });
+
+  it('promoteQuarantine restores a pre-existing live file when a later promotion fails', async () => {
+    const q = makeQuarantineDir(dataDir, 'restore-1');
+    fs.writeFileSync(path.join(q, 'first.mbtiles'), 'NEW1');
+    // 'second.mbtiles' missing → second move will fail with ENOENT,
+    // triggering rollback after first.mbtiles has already overwritten
+    // a pre-existing live file.
+
+    const subTarget = path.join(chartPath, 'restore-target');
+    fs.mkdirSync(subTarget, { recursive: true });
+    fs.writeFileSync(path.join(subTarget, 'first.mbtiles'), 'OLD1');
+
+    await assert.rejects(promoteQuarantine(q, ['first.mbtiles', 'second.mbtiles'], subTarget));
+
+    // Pre-existing file restored from backup.
+    assert.strictEqual(fs.readFileSync(path.join(subTarget, 'first.mbtiles'), 'utf8'), 'OLD1');
+    // New file rolled back to quarantine.
+    assert.strictEqual(fs.readFileSync(path.join(q, 'first.mbtiles'), 'utf8'), 'NEW1');
+    // No leftover backup entries.
+    const leftover = fs.readdirSync(subTarget).filter((f) => f.includes('.replaced-'));
+    assert.deepStrictEqual(leftover, []);
+  });
+
   it('promoteQuarantine creates the target dir recursively', async () => {
     const q = makeQuarantineDir(dataDir, 'promote-2');
     fs.writeFileSync(path.join(q, 'x.mbtiles'), 'xxx');

--- a/test/quarantine.test.ts
+++ b/test/quarantine.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import {
+  cleanupQuarantineDir,
+  makeQuarantineDir,
+  promoteQuarantine,
+  sweepStaleQuarantineDirs
+} from '../dist/utils/quarantine.js';
+
+describe('quarantine helpers', () => {
+  let dataDir: string;
+  let chartPath: string;
+
+  before(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-quarantine-test-'));
+    chartPath = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-charts-test-'));
+  });
+
+  after(() => {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+    fs.rmSync(chartPath, { recursive: true, force: true });
+  });
+
+  it('makeQuarantineDir creates <dataDir>/in-progress/<chartNumber>/', () => {
+    const dir = makeQuarantineDir(dataDir, '42');
+    assert.strictEqual(dir, path.join(dataDir, 'in-progress', '42'));
+    assert.strictEqual(fs.existsSync(dir), true);
+  });
+
+  it('makeQuarantineDir is idempotent on existing dir', () => {
+    const dir = makeQuarantineDir(dataDir, '42');
+    fs.writeFileSync(path.join(dir, 'sentinel'), 'first call');
+    const again = makeQuarantineDir(dataDir, '42');
+    assert.strictEqual(dir, again);
+    assert.strictEqual(fs.readFileSync(path.join(again, 'sentinel'), 'utf8'), 'first call');
+  });
+
+  it('makeQuarantineDir sanitizes weird chartNumbers (no path traversal)', () => {
+    // A malicious or malformed chartNumber must not escape the quarantine root.
+    const dir = makeQuarantineDir(dataDir, '../../../etc/passwd');
+    assert.ok(dir.startsWith(path.join(dataDir, 'in-progress')));
+    assert.ok(!dir.includes('..'));
+  });
+
+  it('promoteQuarantine moves named files to the target dir', async () => {
+    const q = makeQuarantineDir(dataDir, 'promote-1');
+    fs.writeFileSync(path.join(q, 'a.mbtiles'), 'aaa');
+    fs.writeFileSync(path.join(q, 'b.mbtiles'), 'bbb');
+
+    const subTarget = path.join(chartPath, 'sub');
+    await promoteQuarantine(q, ['a.mbtiles', 'b.mbtiles'], subTarget);
+
+    assert.strictEqual(fs.readFileSync(path.join(subTarget, 'a.mbtiles'), 'utf8'), 'aaa');
+    assert.strictEqual(fs.readFileSync(path.join(subTarget, 'b.mbtiles'), 'utf8'), 'bbb');
+    // Originals should be gone after the rename.
+    assert.strictEqual(fs.existsSync(path.join(q, 'a.mbtiles')), false);
+    assert.strictEqual(fs.existsSync(path.join(q, 'b.mbtiles')), false);
+  });
+
+  it('promoteQuarantine creates the target dir recursively', async () => {
+    const q = makeQuarantineDir(dataDir, 'promote-2');
+    fs.writeFileSync(path.join(q, 'x.mbtiles'), 'xxx');
+
+    const deepTarget = path.join(chartPath, 'deep', 'a', 'b');
+    assert.strictEqual(fs.existsSync(deepTarget), false);
+    await promoteQuarantine(q, ['x.mbtiles'], deepTarget);
+    assert.strictEqual(fs.readFileSync(path.join(deepTarget, 'x.mbtiles'), 'utf8'), 'xxx');
+  });
+
+  it('cleanupQuarantineDir removes the entire dir', () => {
+    const q = makeQuarantineDir(dataDir, 'cleanup-1');
+    fs.writeFileSync(path.join(q, 'leftover'), 'data');
+    assert.strictEqual(fs.existsSync(q), true);
+    cleanupQuarantineDir(q);
+    assert.strictEqual(fs.existsSync(q), false);
+  });
+
+  it('cleanupQuarantineDir is a no-op when the dir is already gone', () => {
+    const q = path.join(dataDir, 'in-progress', 'never-existed');
+    // Must not throw.
+    cleanupQuarantineDir(q);
+    assert.strictEqual(fs.existsSync(q), false);
+  });
+
+  it('sweepStaleQuarantineDirs wipes every subdir under in-progress/', () => {
+    // Use a fresh dataDir so prior test cases' leftover subdirs don't
+    // get counted into this test's swept total.
+    const sweepDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-quarantine-sweep-'));
+    try {
+      const a = makeQuarantineDir(sweepDir, 'stale-a');
+      const b = makeQuarantineDir(sweepDir, 'stale-b');
+      const c = makeQuarantineDir(sweepDir, 'stale-c');
+      fs.writeFileSync(path.join(a, 'half-built.mbtiles'), 'aaa');
+      fs.writeFileSync(path.join(b, 'half-built.mbtiles'), 'bbb');
+      fs.writeFileSync(path.join(c, 'half-built.mbtiles'), 'ccc');
+
+      const swept = sweepStaleQuarantineDirs(sweepDir);
+      assert.strictEqual(swept, 3);
+      assert.strictEqual(fs.existsSync(a), false);
+      assert.strictEqual(fs.existsSync(b), false);
+      assert.strictEqual(fs.existsSync(c), false);
+      // Root in-progress/ dir itself is preserved (recreated lazily
+      // by makeQuarantineDir on the next conversion).
+      assert.strictEqual(fs.existsSync(path.join(sweepDir, 'in-progress')), true);
+    } finally {
+      fs.rmSync(sweepDir, { recursive: true, force: true });
+    }
+  });
+
+  it('sweepStaleQuarantineDirs returns 0 when there is no in-progress root', () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-quarantine-empty-'));
+    try {
+      assert.strictEqual(sweepStaleQuarantineDirs(empty), 0);
+    } finally {
+      fs.rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/quarantine.test.ts
+++ b/test/quarantine.test.ts
@@ -61,6 +61,48 @@ describe('quarantine helpers', () => {
     assert.strictEqual(fs.existsSync(path.join(q, 'b.mbtiles')), false);
   });
 
+  it('promoteQuarantine rejects path-traversal filenames', async () => {
+    const q = makeQuarantineDir(dataDir, 'reject-1');
+    fs.writeFileSync(path.join(q, 'ok.mbtiles'), 'ok');
+
+    await assert.rejects(
+      promoteQuarantine(q, ['../escape.mbtiles'], chartPath),
+      /Invalid promoted filename/
+    );
+    await assert.rejects(
+      promoteQuarantine(q, ['nested/foo.mbtiles'], chartPath),
+      /Invalid promoted filename/
+    );
+    await assert.rejects(
+      promoteQuarantine(q, ['/abs/path.mbtiles'], chartPath),
+      /Invalid promoted filename/
+    );
+    // Empty string also rejected.
+    await assert.rejects(promoteQuarantine(q, [''], chartPath), /Invalid promoted filename/);
+    // Source file is still there because the guard runs before any move.
+    assert.strictEqual(fs.existsSync(path.join(q, 'ok.mbtiles')), true);
+  });
+
+  it('promoteQuarantine rolls back successfully-moved files when a later one fails', async () => {
+    const q = makeQuarantineDir(dataDir, 'rollback-1');
+    fs.writeFileSync(path.join(q, 'first.mbtiles'), 'A');
+    fs.writeFileSync(path.join(q, 'second.mbtiles'), 'B');
+    // 'missing.mbtiles' is referenced but doesn't exist — third move
+    // will fail with ENOENT.
+
+    const subTarget = path.join(chartPath, 'rollback-target');
+    await assert.rejects(
+      promoteQuarantine(q, ['first.mbtiles', 'second.mbtiles', 'missing.mbtiles'], subTarget)
+    );
+
+    // No partial chart set in the live target.
+    assert.strictEqual(fs.existsSync(path.join(subTarget, 'first.mbtiles')), false);
+    assert.strictEqual(fs.existsSync(path.join(subTarget, 'second.mbtiles')), false);
+    // The quarantine still has the originals (rolled back).
+    assert.strictEqual(fs.readFileSync(path.join(q, 'first.mbtiles'), 'utf8'), 'A');
+    assert.strictEqual(fs.readFileSync(path.join(q, 'second.mbtiles'), 'utf8'), 'B');
+  });
+
   it('promoteQuarantine creates the target dir recursively', async () => {
     const q = makeQuarantineDir(dataDir, 'promote-2');
     fs.writeFileSync(path.join(q, 'x.mbtiles'), 'xxx');


### PR DESCRIPTION
## Summary

Conversions used to write tippecanoe / GDAL output **directly into the user's live chart directory**. A Signal K crash mid-conversion left a half-built `.mbtiles` polluting Manage Charts — the file scanner picked it up and the user saw a malformed chart with no clear way to clean it.

This PR moves every conversion into a quarantine subdir (`<dataDir>/in-progress/<chartNumber>/`) and atomically renames the result(s) to chartPath only when the conversion has fully succeeded. A crash now leaves the partial output safely outside the chart library; the next-startup sweep wipes leftover quarantine subdirs unconditionally — there's never anything in there worth keeping.

Pairs with the orphan-job reaping from PR #86 / signalk-container 1.3.0 (PR #18): the container is killed on restart, the quarantine is wiped on restart, the install record is rolled back via `cleanupOrphanedJobs`. Three independent recovery layers.

### New helper: `src/utils/quarantine.ts`

| function | what it does |
|---|---|
| `makeQuarantineDir(dataDir, chartNumber)` | Resolve and mkdir the per-chart subdir. Sanitizes chartNumber against path traversal. |
| `promoteQuarantine(dir, files, targetDir)` | Atomic `fs.rename` per file. Falls back to `copyFile + unlink` on `EXDEV` (chartPath on a different mount — USB/NFS). |
| `cleanupQuarantineDir(dir)` | Best-effort `rm -rf` of the per-chart dir, called whether the conversion succeeded or failed. |
| `sweepStaleQuarantineDirs(dataDir)` | Wipe every subdir under `in-progress/` at start. Anything in there is from a previous lifecycle that didn't complete. Returns the count for logging. |

### Wiring in `src/index.ts`

- `start()` calls `sweepStaleQuarantineDirs(getDataDirPath())` before signalk-container is even discovered (the sweep only touches our own filesystem state, no runtime needed). Logs `[charts-provider] Swept N stale conversion quarantine dir(s)…` via `console.log` if any were swept.
- All five catalog-driven conversion handlers (S-57, RNC, Pilot, Shp basemap, GSHHG) plus the manual `/convert-upload` flow create a quarantine dir, pass it as the converter's `chartsDir` argument, and call `promoteQuarantine` on success. Every error and finally path cleans up the quarantine.
- `processGshhg` (which fetches its own download) also gets a quarantine dir for its `.mbtiles` output.

### Tested

- 9 new unit cases in `test/quarantine.test.ts` covering dir creation, idempotency, path-traversal sanitization, single- and multi-file promotion, target-dir auto-creation, double-cleanup no-op, and the sweep semantics.
- `npm run format`, `npm run build`, `npm run lint` clean
- `npm test` — 230/230 (was 221, +9)
- `npm run test:e2e` — 7/7 pass
- Local `cr review --plain --base origin/main` — No findings
- Manual end-to-end (kill server mid-conversion → restart → verify quarantine swept and chart not corrupted) pending on the linked plugin.

## Backwards compatibility

Behavior unchanged for successful conversions — they still land at the same path under `chartPath`, just via an atomic rename instead of an in-place tippecanoe write. A user upgrading mid-conversion would see the in-progress dir wiped on the next restart, which is the correct outcome (the helper container was reaped by signalk-container's `cleanupOrphanedJobs` anyway in 1.3.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-job per-chart quarantine staging for uploads, downloads, and conversions so outputs are written and verified before becoming live.

* **Bug Fixes**
  * Prevents partially-written chart and upload files from reaching the live library by atomically promoting only successful outputs and always cleaning up on failure.
  * Sweeps stale in-progress files at startup to remove leftover artifacts.

* **Tests**
  * Added tests covering quarantine staging, promotion, rollback, cleanup, and stale-sweep behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->