### PR TITLE
feat(convert): recognise IENC inland bands 7..9 in the per-band pipeline

### DIFF
--- a/src/utils/s57-band.ts
+++ b/src/utils/s57-band.ts
@@ -5,50 +5,77 @@ import path from 'path';
  * IHO Annex E filename convention `<CC><band><area>` followed by all
  * official national hydrographic offices (NOAA, UKHO, BSH, CHS, AHO, …).
  *
- * Returns 1..6 when the filename conforms, or `null` otherwise (IENC inland
- * charts and ad-hoc files don't follow this convention; callers fall back
- * to the user-requested maxzoom in that case).
+ * Returns 1..6 for maritime ENC bands (Overview..Berthing) and 7..9 for
+ * IENC inland-extension bands (River, River Harbour, River Berth) per
+ * the IEHG Inland ENC Encoding Guide. Returns `null` when the filename
+ * doesn't match the convention — hand-named test files, custom producers
+ * — so callers can fall back to the user-requested zoom range.
+ *
+ * The producer code is two characters of `[A-Z0-9]`. NHOs use letters
+ * (`US`, `GB`, `DE`); IENC producers occasionally lead with a digit
+ * (RWS Dutch IENC `1V`), which is why this isn't restricted to letters.
  */
 export function detectEncBand(filename: string): number | null {
   const base = filename.replace(/\.[^.]+$/, '');
-  const m = base.match(/^[A-Z]{2}(\d)/);
+  // Producer code must be 2 alphanumeric chars *with at least one letter*
+  // among them. Letter-only (`US`, `DE`) is the maritime case; mixed
+  // letter+digit / digit+letter covers IENC producers like RWS `1V`.
+  // Pure-digit prefixes (`12`, `00`) are excluded so a degenerate string
+  // like `001` (which can fall out of the per-chart `extractChartId`
+  // lookup on weird-named files) doesn't get parsed as a band.
+  const m = base.match(/^(?:[A-Z][A-Z0-9]|[A-Z0-9][A-Z])(\d)/);
   if (!m) {
     return null;
   }
   const band = parseInt(m[1], 10);
-  return band >= 1 && band <= 6 ? band : null;
+  return band >= 1 && band <= 9 ? band : null;
 }
 
 /**
- * Sensible tippecanoe maxzoom for each IHO band. Mirrors the documented
- * native chart scales: emitting tiles past these zoom levels produces
- * output that has no underlying feature precision to back it up. Renderers
- * (Freeboard-SK, MapLibre, OpenLayers) handle higher zooms by overzooming
- * the captured top-zoom tile, which is correct for chart data.
+ * Sensible tippecanoe maxzoom for each IHO/IENC band. Mirrors the
+ * documented native chart scales: emitting tiles past these zoom levels
+ * produces output that has no underlying feature precision to back it
+ * up. Renderers (Freeboard-SK, MapLibre, OpenLayers) handle higher
+ * zooms by overzooming the captured top-zoom tile, which is correct
+ * for chart data.
+ *
+ * Bands 7..9 are IENC inland extensions (River / River Harbour / River
+ * Berth) — narrower native scales than maritime bands.
  */
 export const BAND_MAX_ZOOM: Record<number, number> = {
-  1: 8, // Overview  ~1:3,500,000
-  2: 10, // General   ~1:700,000
-  3: 12, // Coastal   ~1:90,000
-  4: 14, // Approach  ~1:22,000
-  5: 16, // Harbour   ~1:8,000
-  6: 18 // Berthing  ~1:3,000   (rare — only major commercial ports)
+  1: 8, // Overview      ~1:3,500,000
+  2: 10, // General       ~1:700,000
+  3: 12, // Coastal       ~1:90,000
+  4: 14, // Approach      ~1:22,000
+  5: 16, // Harbour       ~1:8,000
+  6: 18, // Berthing      ~1:3,000
+  7: 14, // River         ~1:10,000
+  8: 16, // River Harbour ~1:5,000–10,000
+  9: 18 // River Berth   ~1:5,000
 };
 
 /**
- * Sensible tippecanoe minzoom for each IHO band: each band's ceiling minus 4.
- * Band-3 features start emitting at z8 (~150 km tile), band-5 at z12 (~10 km
- * tile), band-6 at z14. Below these zooms the features overplot into
- * illegible blobs anyway, so emitting tiles there only wastes bytes and CPU
- * without adding navigational value.
+ * Sensible tippecanoe minzoom for each band. For maritime bands 1..6
+ * each floor is the ceiling minus 4 — below that, features overplot
+ * into illegible blobs and emitting tiles only wastes bytes and CPU.
+ *
+ * IENC bands 7..9 use a lower floor than the IEHG plan suggests
+ * (z9 / z13 / z15 instead of z11 / z13 / z15) because RWS publishes
+ * the Waddenzee — tidal coastal water with genuine z9 visibility
+ * needs — as IENC band 7. A higher floor would make the chart blank
+ * out at coastal-overview zooms, which matters more than the modest
+ * overplotting cost on actual rivers at z9–z10.
  */
 export const BAND_MIN_ZOOM: Record<number, number> = {
-  1: 4, // Overview  ceiling z8
-  2: 6, // General   ceiling z10
-  3: 8, // Coastal   ceiling z12
-  4: 10, // Approach ceiling z14
-  5: 12, // Harbour  ceiling z16
-  6: 14 // Berthing  ceiling z18
+  1: 4, // Overview       ceiling z8
+  2: 6, // General        ceiling z10
+  3: 8, // Coastal        ceiling z12
+  4: 10, // Approach      ceiling z14
+  5: 12, // Harbour       ceiling z16
+  6: 14, // Berthing      ceiling z18
+  7: 9, // River          ceiling z14
+  8: 13, // River Harbour ceiling z16
+  9: 15 // River Berth    ceiling z18
 };
 
 /**
@@ -139,7 +166,7 @@ export function bandClampedMaxzoom(
  * regressed by the per-band rewrite.
  */
 export interface BandGrouping {
-  /** Map from band number (1..6) to the list of cell paths in that band. */
+  /** Map from band number (1..9, with 7..9 being IENC inland) to the list of cell paths in that band. */
   byBand: Map<number, string[]>;
   /** Cells whose filename didn't yield a band — feed these to the legacy single-pass code path. */
   unbanded: string[];

--- a/test/s57-band.test.ts
+++ b/test/s57-band.test.ts
@@ -36,18 +36,30 @@ describe('detectEncBand (IHO Annex E filename convention)', () => {
     assert.strictEqual(detectEncBand('chart.000'), null);
     assert.strictEqual(detectEncBand('weird-name.000'), null);
     assert.strictEqual(detectEncBand('ENC_AREA1.000'), null);
-    assert.strictEqual(detectEncBand('123ABC.000'), null); // starts with digits
+    assert.strictEqual(detectEncBand('123ABC.000'), null); // pure-digit producer code
+    assert.strictEqual(detectEncBand('001.000'), null); // pure-digit producer code (extractChartId artifact)
+  });
+
+  it('parses IENC inland bands 7..9', () => {
+    // IEHG inland-extension bands. RWS Dutch IENC producer code is `1V`,
+    // which leads with a digit — explicitly supported.
+    assert.strictEqual(detectEncBand('1V7VAR01.000'), 7);
+    assert.strictEqual(detectEncBand('DE7AKxxx.000'), 7);
+    assert.strictEqual(detectEncBand('1V8HARB01.000'), 8);
+    assert.strictEqual(detectEncBand('1V9BERTH1.000'), 9);
   });
 
   it('returns null for out-of-range band digits', () => {
     assert.strictEqual(detectEncBand('US0CO100.000'), null);
-    assert.strictEqual(detectEncBand('US7CO100.000'), null);
-    assert.strictEqual(detectEncBand('US9CO100.000'), null);
+    // Note: bands 7..9 are valid IENC bands now (see test above).
   });
 
-  it('requires uppercase country code (S-57 spec)', () => {
+  it('requires uppercase or numeric producer code (S-57 / IENC)', () => {
+    // S-57 + IENC both spec uppercase letters; IENC additionally allows
+    // a leading digit (RWS `1V`). Lowercase or mixed case is invalid.
     assert.strictEqual(detectEncBand('us3CO100.000'), null);
     assert.strictEqual(detectEncBand('Us3CO100.000'), null);
+    assert.strictEqual(detectEncBand('1v7VAR01.000'), null);
   });
 });
 
@@ -60,10 +72,16 @@ describe('BAND_MAX_ZOOM', () => {
     assert.strictEqual(BAND_MAX_ZOOM[5], 16);
     assert.strictEqual(BAND_MAX_ZOOM[6], 18);
   });
+
+  it('covers IENC inland bands 7..9 with IEHG-tuned ceilings', () => {
+    assert.strictEqual(BAND_MAX_ZOOM[7], 14); // River
+    assert.strictEqual(BAND_MAX_ZOOM[8], 16); // River Harbour
+    assert.strictEqual(BAND_MAX_ZOOM[9], 18); // River Berth
+  });
 });
 
 describe('BAND_MIN_ZOOM', () => {
-  it('uses ceiling-minus-4 for every band', () => {
+  it('uses ceiling-minus-4 for every maritime band', () => {
     assert.strictEqual(BAND_MIN_ZOOM[1], 4);
     assert.strictEqual(BAND_MIN_ZOOM[2], 6);
     assert.strictEqual(BAND_MIN_ZOOM[3], 8);
@@ -72,8 +90,18 @@ describe('BAND_MIN_ZOOM', () => {
     assert.strictEqual(BAND_MIN_ZOOM[6], 14);
   });
 
+  it('uses a lower floor on band 7 than the IEHG plan suggests so Waddenzee renders at coastal-overview zooms', () => {
+    // RWS publishes the Waddenzee — tidal coastal water — as IENC band 7.
+    // A z11 floor (ceiling-minus-3 per IEHG) would blank out the chart at
+    // z9–z10 where users plan coastal navigation; z9 keeps it visible at
+    // a modest overplotting cost on actual rivers.
+    assert.strictEqual(BAND_MIN_ZOOM[7], 9);
+    assert.strictEqual(BAND_MIN_ZOOM[8], 13);
+    assert.strictEqual(BAND_MIN_ZOOM[9], 15);
+  });
+
   it('every band has min < max so tippecanoe gets a non-empty zoom range', () => {
-    for (const band of [1, 2, 3, 4, 5, 6] as const) {
+    for (const band of [1, 2, 3, 4, 5, 6, 7, 8, 9] as const) {
       assert.ok(BAND_MIN_ZOOM[band] < BAND_MAX_ZOOM[band], `band ${band}`);
     }
   });
@@ -192,12 +220,32 @@ describe('groupCellsByBand', () => {
   it('puts non-conforming filenames in the unbanded bucket', () => {
     const g = groupCellsByBand([
       '/tmp/enc/US3CO100.000',
-      '/tmp/enc/1V7VAR01.000', // IENC: producer "1V" doesn't match [A-Z]{2}
+      '/tmp/enc/IENC_PASS_001.000', // hand-named test cell, no convention
       '/tmp/enc/weird-name.000'
     ]);
     assert.deepStrictEqual(g.bands, [3]);
     assert.deepStrictEqual(g.byBand.get(3), ['/tmp/enc/US3CO100.000']);
-    assert.deepStrictEqual(g.unbanded, ['/tmp/enc/1V7VAR01.000', '/tmp/enc/weird-name.000']);
+    assert.deepStrictEqual(g.unbanded, ['/tmp/enc/IENC_PASS_001.000', '/tmp/enc/weird-name.000']);
+  });
+
+  it('routes IENC cells into bands 7..9 (no longer unbanded)', () => {
+    // RWS Dutch IENC and German WSV inland follow the IHO Annex E
+    // convention with bands 7..9 — they belong in their own per-band
+    // buckets, not the legacy unbanded fallback.
+    const g = groupCellsByBand([
+      '/tmp/enc/1V7VAR01.000',
+      '/tmp/enc/1V7WAD05.000',
+      '/tmp/enc/DE7AKxxx.000',
+      '/tmp/enc/1V8HARB01.000'
+    ]);
+    assert.deepStrictEqual(g.bands, [7, 8]);
+    assert.deepStrictEqual(g.byBand.get(7), [
+      '/tmp/enc/1V7VAR01.000',
+      '/tmp/enc/1V7WAD05.000',
+      '/tmp/enc/DE7AKxxx.000'
+    ]);
+    assert.deepStrictEqual(g.byBand.get(8), ['/tmp/enc/1V8HARB01.000']);
+    assert.deepStrictEqual(g.unbanded, []);
   });
 
   it('returns empty bands and one unbanded bucket for a fully non-conforming bundle', () => {


### PR DESCRIPTION
## Summary

- `detectEncBand` now accepts the IENC producer-code shape (mixed letter/digit, e.g. RWS Dutch IENC `1V`, German WSV inland `DE7`). Pure-digit prefixes are still rejected so a degenerate string like `001` (an `extractChartId` artifact on weird-named files) doesn't get parsed as a band.
- Valid band range extended from 1..6 to 1..9 to cover the IEHG inland-extension bands: River (7), River Harbour (8), River Berth (9).
- `BAND_MAX_ZOOM` adds `{7:14, 8:16, 9:18}` per the IEHG plan native chart scales.
- `BAND_MIN_ZOOM` adds `{7:9, 8:13, 9:15}`.

## Why z9 (not z11) for band-7's floor

The IEHG plan suggests z11 for band 7's floor (ceiling-minus-3). We deliberately diverge: RWS publishes the Waddenzee — tidal coastal water with genuine z9 visibility needs — under IENC band 7. A z11 floor would blank out the chart at z9–z10 where users plan coastal navigation. z9 keeps it visible at a modest overplotting cost on actual rivers.

This is the "one fits all" choice: no per-cell or per-producer override, no Waddenzee-specific heuristic. Worst case (river noise at z9–z10) matches the legacy unbanded fallback's existing behaviour for IENC, so nobody is regressed.

## Verified end-to-end on live RWS data

Tested against `NL_IENC_Catalog.xml` → "Waddenzee met Diepte 2026 - Week 19" (`20260508_U7Inland_Waddenzee_week 19_NL.zip`, 14 cells: `1R7EMS01..04`, `1R7WAD01..14`).

- `detectEncBand('1R7EMS01.000')` → 7 ✓
- `groupCellsByBand([...14 cells])` → `{ bands: [7], unbanded: [] }`
- `bucketCount = 1` → falls through to single-pass code path (no fan-out gain when only one bucket).
- `bandClampedMaxzoom` clamps user-requested z16 → z14 (band-7 ceiling).
- Final mbtiles: z9–z14, landed cleanly in chartPath, visible in Freeboard-SK.

## Tested

- format / build / lint clean
- `npm test`: 243/243 pass (4 new tests for IENC parsing, band 7..9 zoom entries, IENC routing, min-max non-empty range across 1..9)
- cr review: no findings
- Real RWS Dutch IENC bundle converted successfully end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Expanded Electronic Navigational Chart band support to include inland navigation variants (bands 7-9) in addition to standard ocean bands (1-6)
- Enhanced chart file recognition with improved naming convention detection

**Improvements**
- Updated zoom level configuration to optimize viewing ranges across all supported chart band types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->