### PR TITLE
docs(toolbox): document the standalone charts-toolbox image for third-party use

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ The plugin uses standard images that `signalk-container` pulls automatically on 
 
 Conversion concurrency is configurable — see the [CPU budget](#cpu-budget-for-chart-conversion) section. MBTiles charts (display only, no conversion) work without any container runtime, and without `signalk-container`.
 
+### Standalone container image (third-party use)
+
+This repository also publishes a self-contained `charts-toolbox` image bundling GDAL + tippecanoe + tile-join in a single image. It's available for anyone who wants to run the same converter outside Signal K — overnight NOAA region pipelines, ad-hoc shell-script automation, GitHub Actions workflows under your own account, etc.
+
+Pull it directly from GHCR:
+
+```bash
+docker pull ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox:1.0.0
+```
+
+See [docs/charts-toolbox-image.md](docs/charts-toolbox-image.md) for a quickstart, the `--user` / `--userns=keep-id` flag forms per runtime, and reproducibility notes.
+
 ## Legal Notice
 
 ### Chart Metadata Editing

--- a/docs/charts-toolbox-image.md
+++ b/docs/charts-toolbox-image.md
@@ -51,16 +51,22 @@ docker run --rm \
         done
     '
 
-# 2. tippecanoe — band-aware ranges per the IHO/IENC scale system
+# 2. tippecanoe — band-aware ranges per the IHO/IENC scale system.
+# Wrap in sh -c so the /data/*.geojsonl glob expands inside the
+# container; passed as a bare argv arg, the runtime would hand
+# tippecanoe a literal "*.geojsonl" string and it would error with
+# "No such file or directory".
 docker run --rm \
     -v "$PWD:/data" \
     --user "$(id -u):$(id -g)" \
     ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox:1.0.0 \
-    tippecanoe \
-        -o /data/MyChart.mbtiles \
-        -Z 9 -z 14 \
-        --layer=enc \
-        /data/*.geojsonl
+    sh -c '
+        tippecanoe \
+            -o /data/MyChart.mbtiles \
+            -Z 9 -z 14 \
+            --layer=enc \
+            /data/*.geojsonl
+    '
 ```
 
 Result: `/tmp/charts/MyChart.mbtiles`, ready to drop into a Signal K chart directory or serve directly.

--- a/docs/charts-toolbox-image.md
+++ b/docs/charts-toolbox-image.md
@@ -2,18 +2,18 @@
 
 This repository publishes a self-contained container image with **GDAL** and **tippecanoe** preinstalled, for use outside the Signal K plugin context — overnight conversion pipelines, ad-hoc CLI experiments, third-party automation, etc.
 
-The image is the same one this plugin's converter uses internally (or will use, once the plugin is migrated to it — track [PR #93](https://github.com/dirkwa/signalk-charts-provider-simple/pull/93) for that), so behaviour stays in lockstep with what the plugin produces.
+This is also the image the plugin's converter is being migrated to use internally, so behaviour will stay in lockstep with what the plugin produces.
 
 ## Image reference
 
-```
+```text
 ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox:1.0.0
 ```
 
 Tags:
 - `:latest` — rolls automatically with each `main` build. Fine for dev. Don't pin scripts to it.
-- `:1.0.0` — version-pinned, content-addressable, never re-pushed (the build workflow refuses to overwrite an existing version tag). Use this for any reproducible script.
-- `:<commit-sha>` — also published, for absolute pinning.
+- `:1.0.0` — **policy-immutable**: the build workflow refuses to overwrite an existing version tag, so once a `:VERSION` is published it never moves. Use this for any reproducible script. For absolute reproducibility — i.e. content-addressable, byte-identical-on-pull — pin to the digest form `…@sha256:<hash>` instead, which you can read off the GHCR UI or via `docker manifest inspect`.
+- `:<commit-sha>` — also published, for pinning to a specific build of this repo.
 
 Multi-arch (`linux/amd64` + `linux/arm64`).
 
@@ -43,7 +43,7 @@ docker run --rm \
     --user "$(id -u):$(id -g)" \
     ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox:1.0.0 \
     sh -c '
-        for cell in $(find /data/ENC_ROOT -name "*.000"); do
+        find /data/ENC_ROOT -name "*.000" -print0 | while IFS= read -r -d "" cell; do
             name=$(basename "$cell" .000)
             ogr2ogr -f GeoJSONSeq -skipfailures \
                 -mapFieldType DateTime=String \

--- a/docs/charts-toolbox-image.md
+++ b/docs/charts-toolbox-image.md
@@ -1,0 +1,124 @@
+# charts-toolbox container image
+
+This repository publishes a self-contained container image with **GDAL** and **tippecanoe** preinstalled, for use outside the Signal K plugin context — overnight conversion pipelines, ad-hoc CLI experiments, third-party automation, etc.
+
+The image is the same one this plugin's converter uses internally (or will use, once the plugin is migrated to it — track [PR #93](https://github.com/dirkwa/signalk-charts-provider-simple/pull/93) for that), so behaviour stays in lockstep with what the plugin produces.
+
+## Image reference
+
+```
+ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox:1.0.0
+```
+
+Tags:
+- `:latest` — rolls automatically with each `main` build. Fine for dev. Don't pin scripts to it.
+- `:1.0.0` — version-pinned, content-addressable, never re-pushed (the build workflow refuses to overwrite an existing version tag). Use this for any reproducible script.
+- `:<commit-sha>` — also published, for absolute pinning.
+
+Multi-arch (`linux/amd64` + `linux/arm64`).
+
+## What's inside
+
+- **GDAL 3.13.0** — `ogrinfo`, `ogr2ogr`, `gdalinfo`, `gdal_translate`, `gdaladdo`, `gdal_rasterize`, etc. From the upstream `osgeo/gdal:ubuntu-small-3.13.0` image (Ubuntu 26.04 / glibc).
+- **tippecanoe 2.79.0** — `tippecanoe`, `tile-join`, `tippecanoe-decode`, `tippecanoe-overzoom`, `tippecanoe-enumerate`, `tippecanoe-json-tool`. Compiled from `felt/tippecanoe`.
+- **GDAL's bundled S-57 catalogue** with **IEHG inland additions** (classes 17xxx — Waterway axis, Distance mark with `wtwdis`, Berth berths, Fairway, etc.). Picked up automatically via `S57_CSV` defaulting to `/usr/share/gdal`. No need to vendor IEHG CSVs separately.
+- **`LANG=C.UTF-8` / `LC_ALL=C.UTF-8`** — accented OBJNAM strings (Dutch, German, French) round-trip cleanly.
+- **Non-root by default** — runs as `toolbox` (UID 1001). See "File ownership" below.
+
+Image size: ~400 MB (compressed: ~140 MB amd64).
+
+## Quickstart: convert one S-57 ENC zip to vector MBTiles
+
+```bash
+mkdir -p /tmp/charts
+cd /tmp/charts
+
+# Drop your ENC zip here, then unzip
+cp ~/Downloads/MyChart.zip .
+unzip -q MyChart.zip                     # creates ENC_ROOT/ etc.
+
+# 1. ogr2ogr each .000 cell to GeoJSON
+docker run --rm \
+    -v "$PWD:/data" \
+    --user "$(id -u):$(id -g)" \
+    ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox:1.0.0 \
+    sh -c '
+        for cell in $(find /data/ENC_ROOT -name "*.000"); do
+            name=$(basename "$cell" .000)
+            ogr2ogr -f GeoJSONSeq -skipfailures \
+                -mapFieldType DateTime=String \
+                "/data/$name.geojsonl" "$cell"
+        done
+    '
+
+# 2. tippecanoe — band-aware ranges per the IHO/IENC scale system
+docker run --rm \
+    -v "$PWD:/data" \
+    --user "$(id -u):$(id -g)" \
+    ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox:1.0.0 \
+    tippecanoe \
+        -o /data/MyChart.mbtiles \
+        -Z 9 -z 14 \
+        --layer=enc \
+        /data/*.geojsonl
+```
+
+Result: `/tmp/charts/MyChart.mbtiles`, ready to drop into a Signal K chart directory or serve directly.
+
+## File ownership: the `--user` flag
+
+The image runs as a non-root user by default (`toolbox`, UID 1001). When you bind-mount a host directory, files written into that directory will be owned by **that** UID, not the host user — which usually means the host user can't read them afterwards.
+
+Pass `--user $(id -u):$(id -g)` to align the in-container UID with your host UID. **All examples in this doc do that.**
+
+### Docker (and Docker Desktop)
+
+```bash
+docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    -v "$PWD:/data" \
+    ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox:1.0.0 \
+    <command>
+```
+
+### Rootless Podman
+
+`--user` works the same way under rootless Podman, but a more robust approach uses `--userns=keep-id`:
+
+```bash
+podman run --rm \
+    --userns=keep-id:uid=1001,gid=1001 \
+    -v "$PWD:/data:Z" \
+    ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox:1.0.0 \
+    <command>
+```
+
+The `:Z` SELinux relabel suffix on the volume is needed on Fedora / RHEL / Rocky hosts; harmless elsewhere.
+
+### Rootful Podman / rootful Docker
+
+Same as Docker — use `--user $(id -u):$(id -g)`.
+
+### CI runners (GitHub Actions ubuntu-latest, etc.)
+
+The runner is typically rootful Docker. Add `--user "$(id -u):$(id -g)"` to your `docker run` invocations. The `${{ github.workspace }}` directory and any other paths you need to write are owned by the runner user; the flag aligns the container with that.
+
+## What the image is NOT
+
+- **Not a CLI wrapper** — there's no `convert-noaa` script or "make me an mbtiles" tool. The image is GDAL + tippecanoe; you orchestrate the steps yourself with shell scripts, `make`, GitHub Actions, etc.
+- **Not bundled with the Signal K plugin** — the plugin has its own runtime path through `signalk-container`. This image is for users who want the same converter outside Signal K.
+- **Not a publishing pipeline** — if you want overnight NOAA region conversions published to a GitHub Release, that's your workflow to build, in your repo, against this image. The third-party user pursuing that use case owns the publishing logic; we ship the image they invoke.
+
+## Reproducibility
+
+- Both `FROM` lines in the [Dockerfile](../docker/charts-toolbox/Dockerfile) are pinned by SHA256 digest — never by mutable tag.
+- `tippecanoe` is checked out by exact commit SHA, not by tag.
+- Bumping any of the above is a deliberate edit to the Dockerfile + a bump of [`docker/charts-toolbox/VERSION`](../docker/charts-toolbox/VERSION). The `build-charts-toolbox.yml` workflow refuses to push a duplicate `:VERSION` tag, so digest updates without a VERSION bump fail the build at publish time.
+
+See the "Bumping image digests" comment block at the bottom of the [Dockerfile](../docker/charts-toolbox/Dockerfile) for the maintenance procedure.
+
+## Tippecanoe references
+
+- Repository: <https://github.com/felt/tippecanoe>
+- Tile-size and feature-density tuning: see the upstream `tippecanoe -h` output and [`README.md`](https://github.com/felt/tippecanoe#tippecanoe).
+- IHO/IENC band-aware zoom mapping (what this plugin uses internally): [src/utils/s57-band.ts](../src/utils/s57-band.ts) — `BAND_MIN_ZOOM` / `BAND_MAX_ZOOM` constants.


### PR DESCRIPTION
## Summary

Adds [docs/charts-toolbox-image.md](docs/charts-toolbox-image.md) — a standalone reference for the `charts-toolbox` image published from this repo (introduced in #92, available now at `ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox:1.0.0`).

Audience: third-party users who want to run the same converter the plugin uses internally, but **outside** Signal K — overnight NOAA region pipelines, ad-hoc shell-script automation, GitHub Actions workflows under their own account.

## What's covered

- Image reference + tag policy (`:1.0.0` immutable, `:latest` rolls, `:<sha>` for absolute pinning)
- What's inside: GDAL 3.13.0 (with IEHG inland classes 17xxx already merged into its bundled catalogue), tippecanoe 2.79.0, tile-join + helpers, C.UTF-8 locale, runs as non-root `toolbox` (UID 1001)
- Quickstart: `ogr2ogr` per cell + `tippecanoe` to one mbtiles
- File-ownership flag forms per runtime — Docker `--user $(id -u):$(id -g)`, rootless Podman `--userns=keep-id:uid=1001,gid=1001`, CI runners, etc.
- What the image is NOT (no CLI wrapper, no publishing pipeline)
- Reproducibility — digest pins, commit-SHA pin on tippecanoe, `VERSION` bump procedure

## Plugin-runtime images section unchanged

The README's existing "uses these images at conversion time" block still points at the legacy two-image setup (`osgeo/gdal:alpine-small-latest` + the legacy tippecanoe image). That's accurate today — the plugin hasn't migrated yet. When PR 2 (the converter migration) lands, those lines will be updated. This PR adds a distinct "Standalone container image (third-party use)" subsection that's deliberately phrased as "this image is also available for non-plugin use" so the two stories don't collide.

## Tested

- format / build / lint clean (no source changes)
- `npm test`: 247/247 pass
- cr review: 1 finding declined as factually incorrect (cr's training data appears to predate GDAL 3.13.0's 2026-05-04 release; verified the published image actually contains GDAL 3.13.0 by `podman run … gdalinfo --version`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added user-facing docs for a standalone charts-toolbox container image: registry/tagging policy, included tools (GDAL, tippecanoe), supported platforms, non-root behavior, and reproducibility approach.
  * Added a Quickstart converting ENC data to MBTiles, with required mounts and UID/GID guidance for Docker/Podman/CI.
  * Clarified intended uses and limitations and linked upstream references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->