### PR TITLE
refactor(converter): use the single charts-toolbox image

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,9 @@ sudo dnf install podman
 systemctl --user enable --now podman.socket
 ```
 
-The plugin uses standard images that `signalk-container` pulls automatically on first use:
+The plugin uses one combined image that `signalk-container` pulls automatically on first conversion:
 
-- `ghcr.io/osgeo/gdal:alpine-small-latest` — GDAL for format conversion
-- `ghcr.io/dirkwa/signalk-charts-provider-simple/tippecanoe` — tippecanoe for vector tile generation (multi-arch: amd64 + arm64)
+- `ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox` — GDAL + tippecanoe + tile-join + helpers in a single image (multi-arch: amd64 + arm64).
 
 **Why `signalk-container`?** It transparently handles the three deployment topologies that 1.x got wrong:
 
@@ -140,7 +139,7 @@ Conversion concurrency is configurable — see the [CPU budget](#cpu-budget-for-
 
 ### Standalone container image (third-party use)
 
-This repository also publishes a self-contained `charts-toolbox` image bundling GDAL + tippecanoe + tile-join in a single image. It's available for anyone who wants to run the same converter outside Signal K — overnight NOAA region pipelines, ad-hoc shell-script automation, GitHub Actions workflows under your own account, etc.
+The same `charts-toolbox` image the plugin uses internally is also available for use **outside** Signal K — overnight NOAA region pipelines, ad-hoc shell-script automation, GitHub Actions workflows under your own account, etc.
 
 Pull it directly from GHCR:
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ systemctl --user enable --now podman.socket
 
 The plugin uses one combined image that `signalk-container` pulls automatically on first conversion:
 
-- `ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox` — GDAL + tippecanoe + tile-join + helpers in a single image (multi-arch: amd64 + arm64).
+- `ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox:1.0.0` — GDAL + tippecanoe + tile-join + helpers in a single image (multi-arch: amd64 + arm64). The plugin pins to a specific `:VERSION` tag rather than `:latest` so a published image tag is permanent for any host that pulled it; bumping the toolbox image is a co-ordinated edit of `docker/charts-toolbox/VERSION` and the matching constant in `src/utils/container-images.ts`.
 
 **Why `signalk-container`?** It transparently handles the three deployment topologies that 1.x got wrong:
 

--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
     "unzipper": "^0.12.3",
     "xml2js": "^0.6.2"
   },
-  "peerDependencies": {
-    "signalk-container": ">=1.2.1"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/dirkwa/signalk-charts-provider-simple"

--- a/src/utils/container-images.ts
+++ b/src/utils/container-images.ts
@@ -1,0 +1,22 @@
+/**
+ * Container images the converters pull through `signalk-container`'s
+ * runtime layer.  Single source of truth — both `s57-converter.ts`
+ * and `rnc-converter.ts` import from here, so bumping the image
+ * version is one edit, not two.
+ *
+ * The toolbox image bundles GDAL + tippecanoe + tile-join + helpers
+ * in a single image, replacing the two upstream-pulled images
+ * (`osgeo/gdal:alpine-small-latest` + the legacy
+ * `ghcr.io/dirkwa/.../tippecanoe`) the converter used before PR #94.
+ * A fresh `signalk-container` host pays one image pull on first
+ * conversion instead of two.
+ *
+ * Pinned to an explicit `:VERSION` tag, not `:latest`.  The
+ * `build-charts-toolbox.yml` workflow refuses to overwrite a
+ * published version tag, so once a `:1.0.0` is in the registry it's
+ * permanent — every host that pulled it has the same content
+ * forever.  Bumping = update `docker/charts-toolbox/VERSION`,
+ * rebuild + push, then update the version in this file.
+ */
+export const CHARTS_TOOLBOX_IMAGE =
+  'ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox:1.0.0';

--- a/src/utils/container-jobs.ts
+++ b/src/utils/container-jobs.ts
@@ -66,6 +66,18 @@ export interface JobRunOptions {
    * signalk-container >= 1.2.0; older versions silently ignore.
    */
   resources?: ContainerResourceLimits;
+  /**
+   * Override the default in-image UID/GID alignment.  Almost no
+   * caller needs to set this — the wrapper hard-codes
+   * `{ inImageUid: 1001, inImageGid: 1001 }` for the charts-toolbox
+   * image's `USER toolbox` (UID/GID 1001), and every job from this
+   * plugin uses that image.  Pass `false` here to opt out (debug
+   * only); pass an object to override for a hypothetical future
+   * non-toolbox image.
+   *
+   * Available in signalk-container >= 1.4.0.
+   */
+  user?: { inImageUid?: number; inImageGid?: number } | false;
 }
 
 export interface JobRunResult {
@@ -123,6 +135,18 @@ export async function resolveJobPaths(
  */
 export const PLUGIN_OWNER_ID = 'signalk-charts-provider-simple';
 
+/**
+ * In-image UID/GID for the charts-toolbox image's `USER toolbox`
+ * directive.  Threaded into every `runJob` call so signalk-container
+ * (>= 1.4.0) emits `--userns=keep-id:uid=1001,gid=1001` on rootless
+ * Podman — without it, the rootless toolbox image's writes into
+ * bind-mounted output dirs would land owned by the wrong UID and the
+ * plugin's `promoteQuarantine` rename would fail with EACCES.  Single
+ * source of truth: bumping the toolbox image's USER directive (rare)
+ * means changing this constant.
+ */
+const TOOLBOX_USER = { inImageUid: 1001, inImageGid: 1001 };
+
 export async function runJob(opts: JobRunOptions): Promise<JobRunResult> {
   const manager = requireManager();
   const result = await manager.runJob({
@@ -139,7 +163,11 @@ export async function runJob(opts: JobRunOptions): Promise<JobRunResult> {
     // find and reap our containers after a Signal K crash. Single
     // source of truth for the owner id; all of this plugin's helper
     // jobs go through this wrapper.
-    ownerPluginId: PLUGIN_OWNER_ID
+    ownerPluginId: PLUGIN_OWNER_ID,
+    // Default to the toolbox image's USER directive; callers can
+    // override with `false` (opt out) or a different `{inImageUid,
+    // inImageGid}` if they ever swap to a non-toolbox image.
+    user: opts.user ?? TOOLBOX_USER
   });
   return {
     exitCode: result.exitCode ?? 1,

--- a/src/utils/container-manager.ts
+++ b/src/utils/container-manager.ts
@@ -63,6 +63,25 @@ export interface ContainerJobConfig {
    * crash.  Available in signalk-container >= 1.3.0.
    */
   ownerPluginId?: string;
+  /**
+   * Align the container's UID/GID with the host caller's so files
+   * written into bind-mounted output dirs land owned by the host
+   * signalk-server process.  signalk-container >= 1.4.0 emits the
+   * right flag form per detected runtime — `--user <hostUID>:<hostGID>`
+   * for Docker / rootful Podman, `--userns=keep-id:uid=<inImageUID>,gid=<inImageGID>`
+   * for rootless Podman.
+   *
+   * - `undefined` (default in signalk-container) auto-aligns assuming
+   *   in-image UID 0; matches every helper image shipped before this
+   *   field existed.
+   * - `{ inImageUid, inImageGid }` for non-root images — chart-provider
+   *   passes `{1001, 1001}` to align with the charts-toolbox image's
+   *   `USER toolbox` (UID/GID 1001).
+   * - `false` opts out entirely (debug only).
+   *
+   * Available in signalk-container >= 1.4.0.
+   */
+  user?: { inImageUid?: number; inImageGid?: number } | false;
 }
 
 /**

--- a/src/utils/rnc-converter.ts
+++ b/src/utils/rnc-converter.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import unzipper from 'unzipper';
+import { CHARTS_TOOLBOX_IMAGE } from './container-images.js';
 import {
   ensureImage as ensureContainerImage,
   resolveJobPaths,
@@ -15,14 +16,6 @@ import type {
   StatusCallback,
   DebugFunction
 } from '../types.js';
-
-// Single combined toolbox image (GDAL + tippecanoe + tile-join +
-// helpers).  RNC conversion only uses GDAL, but sharing the same
-// image with s57-converter means a fresh `signalk-container` host
-// pays one image pull total, not one per converter module.  See
-// `src/utils/s57-converter.ts` for the matching constant — bumping
-// the toolbox version is a single co-ordinated edit.
-const CHARTS_TOOLBOX_IMAGE = 'ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox:1.0.0';
 
 const conversionProgress: ConversionProgressMap = {};
 const MAX_LOG_LINES = 100;

--- a/src/utils/rnc-converter.ts
+++ b/src/utils/rnc-converter.ts
@@ -16,7 +16,13 @@ import type {
   DebugFunction
 } from '../types.js';
 
-const GDAL_IMAGE = 'ghcr.io/osgeo/gdal:alpine-small-latest';
+// Single combined toolbox image (GDAL + tippecanoe + tile-join +
+// helpers).  RNC conversion only uses GDAL, but sharing the same
+// image with s57-converter means a fresh `signalk-container` host
+// pays one image pull total, not one per converter module.  See
+// `src/utils/s57-converter.ts` for the matching constant — bumping
+// the toolbox version is a single co-ordinated edit.
+const CHARTS_TOOLBOX_IMAGE = 'ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox:1.0.0';
 
 const conversionProgress: ConversionProgressMap = {};
 const MAX_LOG_LINES = 100;
@@ -125,7 +131,7 @@ export async function convertKapToMbtiles(
     : '/output';
 
   const result = await runContainerJob({
-    image: GDAL_IMAGE,
+    image: CHARTS_TOOLBOX_IMAGE,
     label: `gdal-translate-${chartNumber || baseName}`,
     command: [
       'gdal_translate',
@@ -172,7 +178,7 @@ async function addOverviews(mbtilesFile: string, chartNumber: string): Promise<v
   const dataPrefix = resolved['/data'].subPath ? `/data/${resolved['/data'].subPath}` : '/data';
 
   const result = await runContainerJob({
-    image: GDAL_IMAGE,
+    image: CHARTS_TOOLBOX_IMAGE,
     label: `gdaladdo-${chartNumber || name}`,
     command: ['gdaladdo', '-r', 'average', `${dataPrefix}/${name}`, '2', '4', '8', '16'],
     outputs: { '/data': resolved['/data'].source },
@@ -218,12 +224,12 @@ export async function processRncZip(
       );
     }
 
-    statusFn('pulling', 'Checking GDAL image...');
+    statusFn('pulling', 'Checking charts-toolbox image...');
     if (chartNumber) {
       conversionProgress[chartNumber].status = 'pulling';
-      conversionProgress[chartNumber].message = 'Checking GDAL image...';
+      conversionProgress[chartNumber].message = 'Checking charts-toolbox image...';
     }
-    await ensureContainerImage(GDAL_IMAGE, (msg) => debug(msg));
+    await ensureContainerImage(CHARTS_TOOLBOX_IMAGE, (msg) => debug(msg));
 
     statusFn('extracting', 'Extracting BSB chart files from ZIP...');
     if (chartNumber) {
@@ -300,7 +306,7 @@ export async function processRncZip(
       }
 
       const translateResult = await runContainerJob({
-        image: GDAL_IMAGE,
+        image: CHARTS_TOOLBOX_IMAGE,
         label: `gdal-translate-${baseName}`,
         command: [
           'gdal_translate',
@@ -324,7 +330,7 @@ export async function processRncZip(
       }
 
       const overviewResult = await runContainerJob({
-        image: GDAL_IMAGE,
+        image: CHARTS_TOOLBOX_IMAGE,
         label: `gdaladdo-${baseName}`,
         command: ['gdaladdo', '-r', 'average', containerOutput, '2', '4', '8', '16'],
         outputs: { '/output': resolved['/output'].source },
@@ -409,8 +415,8 @@ export async function processPilotTar(
       );
     }
 
-    statusFn('pulling', 'Checking GDAL image...');
-    await ensureContainerImage(GDAL_IMAGE, (msg) => debug(msg));
+    statusFn('pulling', 'Checking charts-toolbox image...');
+    await ensureContainerImage(CHARTS_TOOLBOX_IMAGE, (msg) => debug(msg));
 
     statusFn('extracting', 'Extracting pilot chart archive...');
     setConvertProgress(chartNumber, 'extracting', 'Extracting .tar.xz archive...');
@@ -442,7 +448,7 @@ export async function processPilotTar(
       : '/output';
 
     const tarResult = await runContainerJob({
-      image: GDAL_IMAGE,
+      image: CHARTS_TOOLBOX_IMAGE,
       label: `tar-extract-${chartNumber}`,
       command: ['tar', '-xf', `${archivePrefix}/${path.basename(tarPath)}`, '-C', tarOutputPrefix],
       inputs: { '/archive': tarResolved['/archive'].source },
@@ -524,7 +530,7 @@ export async function processPilotTar(
       );
 
       const translateResult = await runContainerJob({
-        image: GDAL_IMAGE,
+        image: CHARTS_TOOLBOX_IMAGE,
         label: `gdal-translate-${baseName}`,
         command: [
           'gdal_translate',
@@ -548,7 +554,7 @@ export async function processPilotTar(
       }
 
       const overviewResult = await runContainerJob({
-        image: GDAL_IMAGE,
+        image: CHARTS_TOOLBOX_IMAGE,
         label: `gdaladdo-${baseName}`,
         command: ['gdaladdo', '-r', 'average', containerOutput, '2', '4', '8', '16'],
         outputs: { '/output': convResolved['/output'].source },

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -912,27 +912,23 @@ async function runPerBandPipeline(
     fs.mkdirSync(bandEncDir, { recursive: true });
     fs.mkdirSync(bandGeojsonDir, { recursive: true });
 
-    // Symlink each cell into the band-scoped dir so the export script
-    // (which walks `find <inDir> -name '*.000'`) only sees this band's
-    // cells. Symlinks keep IO cheap; the per-conversion tmpDir is
-    // wiped in the outer finally regardless.
+    // Hardlink each cell into the band-scoped dir so the export
+    // script (which walks `find <inDir> -name '*.000'`) only sees
+    // this band's cells.  Hardlinks keep IO cheap (no data copy)
+    // and — unlike symlinks — survive being bind-mounted into a
+    // container: a symlink target pointing at an absolute host
+    // path doesn't exist inside the container's filesystem
+    // namespace, so `find` would silently miss every cell.  Copy
+    // is the fallback for the rare case where tmpDir spans
+    // filesystems (e.g. /tmp on tmpfs but the encDir on disk).
     for (const cellPath of cells) {
       const cellRel = path.relative(encDir, cellPath);
       const linkPath = path.join(bandEncDir, cellRel);
       fs.mkdirSync(path.dirname(linkPath), { recursive: true });
       try {
-        fs.symlinkSync(cellPath, linkPath);
-      } catch (err) {
-        // Some filesystems (FAT/exFAT on USB chart drives) don't
-        // support symlinks; fall back to a hardlink, then to a copy.
-        try {
-          fs.linkSync(cellPath, linkPath);
-        } catch {
-          fs.copyFileSync(cellPath, linkPath);
-        }
-        debug(
-          `Symlink unsupported for band ${band}, fell back: ${err instanceof Error ? err.message : String(err)}`
-        );
+        fs.linkSync(cellPath, linkPath);
+      } catch {
+        fs.copyFileSync(cellPath, linkPath);
       }
     }
 
@@ -969,18 +965,17 @@ async function runPerBandPipeline(
     const unbandedGeojsonDir = path.join(tmpDir, 'geojson-unbanded');
     fs.mkdirSync(unbandedEncDir, { recursive: true });
     fs.mkdirSync(unbandedGeojsonDir, { recursive: true });
+    // Hardlink (not symlink) — see the band-loop above for the
+    // why: bind-mounted absolute symlink targets don't resolve
+    // inside the helper container.
     for (const cellPath of grouping.unbanded) {
       const cellRel = path.relative(encDir, cellPath);
       const linkPath = path.join(unbandedEncDir, cellRel);
       fs.mkdirSync(path.dirname(linkPath), { recursive: true });
       try {
-        fs.symlinkSync(cellPath, linkPath);
+        fs.linkSync(cellPath, linkPath);
       } catch {
-        try {
-          fs.linkSync(cellPath, linkPath);
-        } catch {
-          fs.copyFileSync(cellPath, linkPath);
-        }
+        fs.copyFileSync(cellPath, linkPath);
       }
     }
 

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { DatabaseSync } from 'node:sqlite';
 import unzipper from 'unzipper';
 import { getCpuBudget } from './concurrency.js';
+import { CHARTS_TOOLBOX_IMAGE } from './container-images.js';
 import {
   ensureImage as ensureContainerImage,
   resolveJobPaths,
@@ -27,16 +28,6 @@ import type {
   StatusCallback,
   DebugFunction
 } from '../types.js';
-
-// Single combined image: GDAL + tippecanoe + tile-join + helpers.
-// Replaced two upstream-pulled images (`osgeo/gdal:alpine-small-latest`
-// + `ghcr.io/dirkwa/.../tippecanoe`) with one toolbox image so a fresh
-// `signalk-container` host pays one image pull instead of two.  Pinned
-// to an explicit `:VERSION` tag (the toolbox build workflow refuses to
-// overwrite it), so the tag is permanent for any host that pulled it.
-// Bumping = bump `docker/charts-toolbox/VERSION` AND this constant
-// together; one-step refresh.
-const CHARTS_TOOLBOX_IMAGE = 'ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox:1.0.0';
 
 const conversionProgress: ConversionProgressMap = {};
 const MAX_LOG_LINES = 100;

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -347,7 +347,16 @@ async function exportAllLayersToGeoJSON(
   const result = await runContainerJob({
     image: CHARTS_TOOLBOX_IMAGE,
     label: `gdal-export-${chartNumber}`,
-    command: ['sh', '-c', script],
+    // bash, not sh.  The toolbox image's `/bin/sh` is dash on
+    // Ubuntu, which doesn't accept `read -r -d ''` (a bash-ism we
+    // use to consume `find -print0` output safely).  Earlier alpine
+    // images linked `/bin/sh` to BusyBox `ash`, which did accept
+    // `-d` — that's why the script worked there and silently
+    // failed here with `sh: read: Illegal option -d` once the
+    // converter switched to the toolbox image.  The toolbox image
+    // ships bash 5.x at `/usr/bin/bash`; invoking via PATH lookup
+    // works the same way `sh` did.
+    command: ['bash', '-c', script],
     inputs: { '/input': resolved['/input'].source },
     outputs: { '/output': resolved['/output'].source },
     // Cap the helper at the budgeted parallelism — without this the

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -28,8 +28,15 @@ import type {
   DebugFunction
 } from '../types.js';
 
-const GDAL_IMAGE = 'ghcr.io/osgeo/gdal:alpine-small-latest';
-const TIPPECANOE_IMAGE = 'ghcr.io/dirkwa/signalk-charts-provider-simple/tippecanoe';
+// Single combined image: GDAL + tippecanoe + tile-join + helpers.
+// Replaced two upstream-pulled images (`osgeo/gdal:alpine-small-latest`
+// + `ghcr.io/dirkwa/.../tippecanoe`) with one toolbox image so a fresh
+// `signalk-container` host pays one image pull instead of two.  Pinned
+// to an explicit `:VERSION` tag (the toolbox build workflow refuses to
+// overwrite it), so the tag is permanent for any host that pulled it.
+// Bumping = bump `docker/charts-toolbox/VERSION` AND this constant
+// together; one-step refresh.
+const CHARTS_TOOLBOX_IMAGE = 'ghcr.io/dirkwa/signalk-charts-provider-simple/charts-toolbox:1.0.0';
 
 const conversionProgress: ConversionProgressMap = {};
 const MAX_LOG_LINES = 100;
@@ -338,7 +345,7 @@ async function exportAllLayersToGeoJSON(
   });
 
   const result = await runContainerJob({
-    image: GDAL_IMAGE,
+    image: CHARTS_TOOLBOX_IMAGE,
     label: `gdal-export-${chartNumber}`,
     command: ['sh', '-c', script],
     inputs: { '/input': resolved['/input'].source },
@@ -674,7 +681,7 @@ async function runTippecanoe(
   };
 
   const result = await runContainerJob({
-    image: TIPPECANOE_IMAGE,
+    image: CHARTS_TOOLBOX_IMAGE,
     label: `tippecanoe-${chartNumber}`,
     command: [
       'tippecanoe',
@@ -810,7 +817,7 @@ async function runTileJoin(
   };
 
   const result = await runContainerJob({
-    image: TIPPECANOE_IMAGE,
+    image: CHARTS_TOOLBOX_IMAGE,
     label: `tile-join-${chartNumber}`,
     command: [
       'tile-join',
@@ -1045,11 +1052,9 @@ export async function processS57Zip(
       );
     }
 
-    statusFn('pulling', 'Checking container images...');
-    setProgress(chartNumber, 'pulling', 'Checking GDAL image...');
-    await ensureContainerImage(GDAL_IMAGE, (msg) => debug(msg));
-    setProgress(chartNumber, 'pulling', 'Checking tippecanoe image...');
-    await ensureContainerImage(TIPPECANOE_IMAGE, (msg) => debug(msg));
+    statusFn('pulling', 'Checking container image...');
+    setProgress(chartNumber, 'pulling', 'Checking charts-toolbox image...');
+    await ensureContainerImage(CHARTS_TOOLBOX_IMAGE, (msg) => debug(msg));
 
     statusFn('extracting', 'Extracting ENC files...');
     setProgress(chartNumber, 'extracting', 'Extracting ENC files...');
@@ -1242,8 +1247,8 @@ export async function processGshhg(
         'Install it from the App Store and restart Signal K.'
     );
   }
-  setProgress(chartNumber, 'pulling', 'Checking GDAL image...');
-  await ensureContainerImage(GDAL_IMAGE, (msg) => debug(msg));
+  setProgress(chartNumber, 'pulling', 'Checking charts-toolbox image...');
+  await ensureContainerImage(CHARTS_TOOLBOX_IMAGE, (msg) => debug(msg));
 
   setProgress(chartNumber, 'converting', 'Downloading GSHHG shapefiles from NOAA...');
   appendLog(
@@ -1348,7 +1353,7 @@ export async function processGshhg(
 
   appendLog(chartNumber, 'Rasterizing shapefile...');
   const rasterizeResult = await runContainerJob({
-    image: GDAL_IMAGE,
+    image: CHARTS_TOOLBOX_IMAGE,
     label: `gdal-rasterize-${chartNumber}`,
     command: [
       'gdal_rasterize',
@@ -1397,7 +1402,7 @@ export async function processGshhg(
   setProgress(chartNumber, 'converting', 'Creating MBTiles...');
   appendLog(chartNumber, 'Creating MBTiles...');
   const translateResult = await runContainerJob({
-    image: GDAL_IMAGE,
+    image: CHARTS_TOOLBOX_IMAGE,
     label: `gdal-translate-${chartNumber}`,
     command: [
       'gdal_translate',
@@ -1422,7 +1427,7 @@ export async function processGshhg(
   setProgress(chartNumber, 'converting', 'Adding zoom levels...');
   appendLog(chartNumber, 'Adding overview zoom levels...');
   const overviewResult = await runContainerJob({
-    image: GDAL_IMAGE,
+    image: CHARTS_TOOLBOX_IMAGE,
     label: `gdaladdo-${chartNumber}`,
     command: [
       'gdaladdo',
@@ -1500,8 +1505,8 @@ export async function processShpBasemap(
           'Install it from the App Store and restart Signal K.'
       );
     }
-    setProgress(chartNumber, 'pulling', 'Checking GDAL image...');
-    await ensureContainerImage(GDAL_IMAGE, (msg) => debug(msg));
+    setProgress(chartNumber, 'pulling', 'Checking charts-toolbox image...');
+    await ensureContainerImage(CHARTS_TOOLBOX_IMAGE, (msg) => debug(msg));
 
     setProgress(chartNumber, 'extracting', 'Extracting shapefiles...');
     appendLog(chartNumber, 'Extracting .tar.xz archive...');
@@ -1533,7 +1538,7 @@ export async function processShpBasemap(
       : '/output';
 
     const tarResult = await runContainerJob({
-      image: GDAL_IMAGE,
+      image: CHARTS_TOOLBOX_IMAGE,
       label: `tar-extract-${chartNumber}`,
       command: ['tar', '-xf', `${archivePrefix}/${path.basename(tarPath)}`, '-C', tarOutputPrefix],
       inputs: { '/archive': tarResolved['/archive'].source },
@@ -1618,7 +1623,7 @@ export async function processShpBasemap(
 
     appendLog(chartNumber, 'Rasterizing...');
     const rasterizeResult = await runContainerJob({
-      image: GDAL_IMAGE,
+      image: CHARTS_TOOLBOX_IMAGE,
       label: `gdal-rasterize-${chartNumber}`,
       command: [
         'gdal_rasterize',
@@ -1666,7 +1671,7 @@ export async function processShpBasemap(
 
     appendLog(chartNumber, 'Creating MBTiles...');
     const translateResult = await runContainerJob({
-      image: GDAL_IMAGE,
+      image: CHARTS_TOOLBOX_IMAGE,
       label: `gdal-translate-${chartNumber}`,
       command: [
         'gdal_translate',
@@ -1690,7 +1695,7 @@ export async function processShpBasemap(
 
     appendLog(chartNumber, 'Adding zoom levels...');
     const overviewResult = await runContainerJob({
-      image: GDAL_IMAGE,
+      image: CHARTS_TOOLBOX_IMAGE,
       label: `gdaladdo-${chartNumber}`,
       command: [
         'gdaladdo',

--- a/test/s57-converter.test.ts
+++ b/test/s57-converter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -295,6 +296,44 @@ describe('buildExportScript', () => {
       assert.match(s, /2>>\/output\/charts\/scratch\/\.export-errors\.log/);
       // Defaults must NOT leak through when prefixes are set.
       assert.doesNotMatch(s, /find \/input -name/);
+    }
+  });
+
+  it('parses cleanly under `bash -n` (regression: read -d is bash-only)', () => {
+    // The script uses `read -r -d ''` to consume `find -print0` output
+    // safely, which is a bash-ism; dash (Ubuntu's /bin/sh) rejects
+    // `-d` as illegal.  This test runs `bash -n` on both branches as
+    // a parse check — catches a regression where someone changes the
+    // converter back to invoke `sh -c` instead of `bash -c`, or
+    // introduces a different bash-only construct.  Skip if the test
+    // host has no bash (rare; CI runners and dev boxes all have it).
+    const which = spawnSync('bash', ['--version']);
+    if (which.status !== 0) {
+      // No bash on this host; skip rather than fail.
+      return;
+    }
+    for (const params of [
+      { multiFile: false, parallelism: 1 },
+      { multiFile: true, parallelism: 4 },
+      { multiFile: true, parallelism: 1, inputPrefix: '/input/sub', outputPrefix: '/output/sub' }
+    ]) {
+      const script = buildExportScript({ ...params, skipLayers });
+      const tmp = path.join(os.tmpdir(), `s57-export-script-${Date.now()}-${Math.random()}.sh`);
+      fs.writeFileSync(tmp, script);
+      try {
+        const result = spawnSync('bash', ['-n', tmp]);
+        assert.strictEqual(
+          result.status,
+          0,
+          `bash -n failed for params=${JSON.stringify(params)}:\n${result.stderr.toString()}`
+        );
+      } finally {
+        try {
+          fs.unlinkSync(tmp);
+        } catch {
+          // ignore
+        }
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary

Replaces the two upstream-pulled images (`ghcr.io/osgeo/gdal:alpine-small-latest` + the legacy `ghcr.io/dirkwa/.../tippecanoe`) with one combined `ghcr.io/dirkwa/.../charts-toolbox:1.0.0` (introduced in #92, image already published). A fresh `signalk-container` host now pays one image pull on first conversion instead of two.

Threads the toolbox image's `USER toolbox` UID/GID through the `runJob` wrapper so `signalk-container` 1.4.0 emits the right UID-mapping flag per detected runtime — `--user` for Docker / rootful Podman, `--userns=keep-id:uid=1001,gid=1001` for rootless Podman. Without it, bind-mount writes from the rootless image would land owned by the wrong UID and `promoteQuarantine` would fail with EACCES.

## Changes

### Converter

- `src/utils/s57-converter.ts` and `src/utils/rnc-converter.ts`: replaced `GDAL_IMAGE` / `TIPPECANOE_IMAGE` constants with a single `CHARTS_TOOLBOX_IMAGE` pinned to `:1.0.0`. Every `runJob` invocation in both files now refers to the toolbox image.
- Dropped the redundant second `ensureContainerImage(...)` call in `processS57Zip` — one image, one check.
- Progress messages updated from "Checking GDAL image" / "Checking tippecanoe image" to "Checking charts-toolbox image".

### Wrapper

- `src/utils/container-jobs.ts`: `runJob` defaults `user: { inImageUid: 1001, inImageGid: 1001 }` matching the toolbox image's `USER toolbox`. Single source of truth — bumping the toolbox image's USER means changing one constant. Callers can override (e.g. `user: false` for debug, or different IDs for a hypothetical future non-toolbox image).
- `src/utils/container-manager.ts`: local `ContainerJobConfig` shim extended with the new `user?` field mirroring `signalk-container` 1.4.0.

### Docs

- README plugin-runtime images list collapsed from two entries to one.
- "Standalone container image (third-party use)" section retained — re-anchored to note the toolbox image is the same one the plugin uses internally.

### Misc

- `peerDependencies` block removed. The plugin doesn't have NPM-resolvable runtime deps on `signalk-container` (it discovers the manager via `globalThis`), and the App Store's `signalk.requires` already prompts users to install it. NPM-enforcing the version coupling adds no value here.

## Backwards compat

Plugin running against `signalk-container` < 1.4.0 still works — the new `user` field gets silently ignored by the older `runJob`. Rootful Docker / rootful Podman users will see no behaviour change. Rootless Podman users on signalk-container ≤ 1.3.x will get EACCES on bind-mount writes (the toolbox image runs as UID 1001, not the host UID); upgrading to 1.4.0 fixes it.

## Tested

- format / build / lint clean.
- `npm test`: 247/247 pass.
- cr review locally: no findings.
- Manual smoke test against the live install: deferred to post-merge — restart the plugin on `~/.signalk-charts-docker` and re-convert a Waddenzee bundle. The plugin's symlinked install picks up the new `dist/` automatically; the new toolbox image is already pulled (verified post-#92 with `podman run … gdalinfo --version`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add option to override container job UID/GID (with an opt-out) so conversion jobs align file ownership with the host.

* **Chores**
  * Consolidated chart conversion into a single pinned charts-toolbox image (v1.0.0) used for all conversion steps.
  * Removed a peerDependency entry for the container integration.

* **Documentation**
  * README updated to document the consolidated toolbox image, pinned tag, multi-arch support, and external-use note.

* **Tests**
  * Added regression test validating generated conversion script syntax with bash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->