### PR TITLE
feat(ui): extend zoom range to z4-z22, default z4-z18

### DIFF
--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -608,8 +608,8 @@ function renderChartList(catalogFile: string): string {
             ? `
           <span class="catalog-zoom-label">Zoom</span>
           <select class="catalog-zoom-select" id="catalog-minzoom-${catalogEscapeId(chart.number)}">
-            ${[6, 7, 8, 9, 10, 11, 12]
-              .map((z) => `<option value="${z}" ${z === 9 ? 'selected' : ''}>${z}</option>`)
+            ${[4, 5, 6, 7, 8, 9, 10, 11, 12]
+              .map((z) => `<option value="${z}" ${z === 4 ? 'selected' : ''}>${z}</option>`)
               .join('')}
           </select>
           <span class="catalog-zoom-dash">-</span>

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -614,8 +614,8 @@ function renderChartList(catalogFile: string): string {
           </select>
           <span class="catalog-zoom-dash">-</span>
           <select class="catalog-zoom-select" id="catalog-maxzoom-${catalogEscapeId(chart.number)}">
-            ${[12, 13, 14, 15, 16, 17, 18]
-              .map((z) => `<option value="${z}" ${z === 16 ? 'selected' : ''}>${z}</option>`)
+            ${[12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
+              .map((z) => `<option value="${z}" ${z === 18 ? 'selected' : ''}>${z}</option>`)
               .join('')}
           </select>
         `

--- a/public/js/chart-convert.ts
+++ b/public/js/chart-convert.ts
@@ -94,8 +94,8 @@ async function initConvertTab(): Promise<void> {
           </select>
           <span class="catalog-zoom-dash">-</span>
           <select class="catalog-zoom-select" id="convertS57Maxzoom">
-            ${[12, 13, 14, 15, 16, 17, 18]
-              .map((z) => `<option value="${z}" ${z === 16 ? 'selected' : ''}>${z}</option>`)
+            ${[12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
+              .map((z) => `<option value="${z}" ${z === 18 ? 'selected' : ''}>${z}</option>`)
               .join('')}
           </select>
         </div>

--- a/public/js/chart-convert.ts
+++ b/public/js/chart-convert.ts
@@ -88,8 +88,8 @@ async function initConvertTab(): Promise<void> {
         <div class="convert-upload-options">
           <label>Zoom levels:</label>
           <select class="catalog-zoom-select" id="convertS57Minzoom">
-            ${[6, 7, 8, 9, 10, 11, 12]
-              .map((z) => `<option value="${z}" ${z === 9 ? 'selected' : ''}>${z}</option>`)
+            ${[4, 5, 6, 7, 8, 9, 10, 11, 12]
+              .map((z) => `<option value="${z}" ${z === 4 ? 'selected' : ''}>${z}</option>`)
               .join('')}
           </select>
           <span class="catalog-zoom-dash">-</span>

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -901,13 +901,17 @@ async function runPerBandPipeline(
     // Surface the per-band clamp: an all-Band-5 NOAA bundle with the
     // user asking for z22 used to silently produce z16 tiles. The
     // single-pass branch already logged this; the per-band branch did
-    // not.
-    const clampNote =
-      bandMaxzoom < userMaxzoom
-        ? `, clamped to band ceiling z${bandCeiling}`
-        : bandMinzoom > userMinzoom
-          ? `, raised to band floor z${bandFloor}`
-          : '';
+    // not. With the wide z4-z22 default range, both a floor-raise and
+    // a ceiling-clamp can apply to the same band — report each side
+    // independently rather than picking one.
+    const clampNotes: string[] = [];
+    if (bandMinzoom > userMinzoom) {
+      clampNotes.push(`raised to band floor z${bandFloor}`);
+    }
+    if (bandMaxzoom < userMaxzoom) {
+      clampNotes.push(`clamped to band ceiling z${bandCeiling}`);
+    }
+    const clampNote = clampNotes.length > 0 ? `, ${clampNotes.join('; ')}` : '';
     appendLog(
       chartNumber,
       `Band ${band}: z${bandMinzoom}-z${bandMaxzoom} (user requested z${userMinzoom}-z${userMaxzoom}${clampNote})`

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -898,6 +898,21 @@ async function runPerBandPipeline(
       continue;
     }
 
+    // Surface the per-band clamp: an all-Band-5 NOAA bundle with the
+    // user asking for z22 used to silently produce z16 tiles. The
+    // single-pass branch already logged this; the per-band branch did
+    // not.
+    const clampNote =
+      bandMaxzoom < userMaxzoom
+        ? `, clamped to band ceiling z${bandCeiling}`
+        : bandMinzoom > userMinzoom
+          ? `, raised to band floor z${bandFloor}`
+          : '';
+    appendLog(
+      chartNumber,
+      `Band ${band}: z${bandMinzoom}-z${bandMaxzoom} (user requested z${userMinzoom}-z${userMaxzoom}${clampNote})`
+    );
+
     const bandEncDir = path.join(tmpDir, `enc-band-${band}`);
     const bandGeojsonDir = path.join(tmpDir, `geojson-band-${band}`);
     fs.mkdirSync(bandEncDir, { recursive: true });

--- a/test/s57-band.test.ts
+++ b/test/s57-band.test.ts
@@ -171,6 +171,15 @@ describe('bandClampedMaxzoom', () => {
     assert.strictEqual(r.highestBand, 5);
   });
 
+  it('clamps to band ceiling even when user requests the schema max (z22)', () => {
+    // Tony's NOAA case: dropdown now exposes z22, but a Band-5-only bundle
+    // still tops out at z16 — the new tippecanoe envelope must not bypass
+    // the band ceiling.
+    const r = bandClampedMaxzoom(['US5MA1SK.000', 'US5NY1SK.000'], 22);
+    assert.strictEqual(r.effective, 16);
+    assert.strictEqual(r.highestBand, 5);
+  });
+
   it('handles paths with directory components by taking the basename', () => {
     const r = bandClampedMaxzoom(
       ['/tmp/enc/US3CO100/US3CO100.000', '/tmp/enc/US3CO200/US3CO200.000'],


### PR DESCRIPTION
## Summary

Two UI changes around the S-57 conversion zoom-range dropdowns:

- **Maxzoom dropdown** now offers z12..z22 (was z12..z18), default z18 (was z16). The TypeBox schema already accepted 0..22; only the UI was capped. The default bump is free for NOAA bundles — the per-band pipeline still clamps each IHO band to its native scale ceiling (Band 5 Harbour → z16, Band 6 Berthing → z18), so all-Band-5 cells produce the same z16 tiles regardless of what the user picks. Bundles that genuinely contain Band 6 Berthing cells (a few major harbors) now produce z17/z18 tiles by default.
- **Minzoom dropdown** now offers z4..z12 (was z6..z12), default z4 (was z9). NOAA bundles often contain Band 1/2/3 cells (Overview/General/Coastal) whose native floors are z4/z6/z8. With the previous default of z9, the per-band pipeline raised those bands' floors to z9, skipping Band 1/2 entirely and clipping Band 3 to z9-z12. Low-zoom tippecanoe passes have little geometry to tile, so the cost is negligible.
- **Per-band clamp log**: the single-pass branch in `runS57Conversion` already logged `→ tippecanoe maxzoom clamped to z16 (was z18)` when the bundle's highest band capped the user's request. The per-band branch silently dropped tiles. Each band now emits one log line like `Band 5: z12-z16 (user requested z4-z22, clamped to band ceiling z16)` so users who pick z22 on an all-Band-5 bundle can see why their mbtiles still tops out at z16.

Motivation: a Discord user reported "I can only get zoom 16, which means none of the detail in harbors are showing" — z17/z18 were already selectable but the default was z16, and the silent per-band clamp meant changing it didn't always have the expected effect. New defaults match what the per-band pipeline can actually emit, and the log line explains the rest.

Backend defaults in `src/index.ts` and `src/utils/s57-converter.ts` (`?? 16`, `?? 9`) are intentionally unchanged — they only fire when a client omits the field, and bumping them would surprise third-party callers.

## Tested

- `npm run format && npm run build && npm run test` (249 / 249)
- `cr review --plain` against both commits — No findings
- New regression test in `test/s57-band.test.ts`: `bandClampedMaxzoom(['US5MA1SK.000', 'US5NY1SK.000'], 22)` returns `effective: 16`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded S-57 conversion zoom selectors: minzoom now 4–12 (default 4); maxzoom now 12–22 (default 18).

* **Improvements**
  * Improved conversion logging to show effective zoom ranges and when ranges are clamped or raised.

* **Tests**
  * Added test coverage verifying zoom-range clamping behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirkwa/signalk-charts-provider-simple/pull/96)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->