### PR TITLE
feat(container): use whenReady() when available (signalk-container >= 1.6.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,13 +29,25 @@ This is a Signal K server plugin. The single entry is `src/index.ts`, which expo
    - `ChartProvider` exposes both `v1` and `v2` shapes (see `src/types.ts`) so the plugin works on Signal K v1 and v2 servers; `serverMajorVersion` is sniffed from `app.config.version`.
    - `utils/chart-state.ts` persists per-chart enable/disable in the plugin data dir; `utils/file-scanner.ts` enumerates folders for the management UI.
 
-2. **Convert charts on demand** (write path, requires Docker/Podman).
-   - `utils/container-runtime.ts` probes `DOCKER_HOST`, `/var/run/docker.sock`, and rootless Podman sockets (`/run/user/<uid>/podman/podman.sock`) and returns the first that pings. All conversion stages run as containers via `dockerode`.
+2. **Convert charts on demand** (write path, requires Docker/Podman via the `signalk-container` plugin — see the integration section below for the API contract).
+   - `utils/container-manager.ts` is the discovery + waiting layer for the `signalk-container` plugin's manager API. Converters call `getContainerManager()` after `start()` has resolved it; they never import `dockerode` directly.
    - `utils/s57-converter.ts` runs GDAL → tippecanoe pipelines for S-57 ENC, GSHHG, and SHP basemaps. `utils/s57-band.ts` sorts S-57 cells by chart-band and feeds tippecanoe per-band layers.
    - `utils/rnc-converter.ts` runs GDAL pipelines for BSB/KAP raster (`processRncZip`) and Pilot tarballs (`processPilotTar`).
    - `utils/concurrency.ts` is the **single source of truth for CPU usage**. The plugin config exposes a `cpuBudget` enum (`single-core` / `half` / `all`); `setCpuBudget` is called from `start()` and `getCpuBudget()` returns the live `{ maxConcurrentConversions, tippecanoeThreadsPerJob, gdalExportParallelism }` so converters pick up changes between jobs without a restart. Don't reimplement CPU/concurrency logic elsewhere — read it from this module.
    - `utils/catalog-manager.ts` fetches and caches catalogs from `chartcatalogs.github.io` and tracks installed catalog charts so update notifications can fire.
    - `utils/download-manager.ts` is a queue with progress for direct-URL downloads and ZIP extraction.
+
+### `signalk-container` integration
+
+From 2.0 onward, every container-runtime call (image pulls, helper-job execution, mount resolution, orphan cleanup) goes through the `signalk-container` plugin instead of `dockerode`. `utils/container-manager.ts` is a thin shim:
+
+- Defines a local `ContainerManagerApi` type that is a **subset** of `signalk-container`'s published API — only the methods chart-provider calls (`runJob`, `resolveSignalkDataMount`, `resolveHostPath`, `cleanupOrphanedJobs`, `getRuntime`, `pullImage`, `imageExists`, plus the optional `whenReady`). We don't `import` from `signalk-container` because it's a peer plugin (loaded by Signal K, not bundled), so the shim is the API contract we depend on.
+- `waitForContainerManager()` discovers the manager on `(globalThis as any).__signalk_containerManager`. Plugin load order is non-deterministic, so it polls up to 30 s.
+  - **signalk-container >= 1.6.0**: uses `manager.whenReady()` — a single await that resolves when runtime detection has settled. Faster than polling and avoids busy-checking `getRuntime()` every second.
+  - **signalk-container < 1.6.0**: falls back to the original `while (!getRuntime()) await sleep` loop. The `whenReady?():` declaration is intentionally optional so older versions keep working.
+  - Contract: `waitForContainerManager()` never rejects. `whenReady()` rejections are swallowed and treated as "detection didn't settle in time". The caller's job is to handle a `null` return by surfacing `setPluginError`, not to handle thrown errors.
+
+If `signalk-container` is missing, the plugin still loads and **serves charts** (display path needs no runtime); only the convert path is disabled, with `setPluginError` pointing the user at the App Store.
 
 ### Hot-apply config and the path marker
 

--- a/src/utils/container-manager.ts
+++ b/src/utils/container-manager.ts
@@ -207,11 +207,16 @@ export async function waitForContainerManager(opts: {
           opts.onWaitingStatus?.();
           signalledWait = true;
         }
-        // Swallow whenReady() rejections: callers rely on the documented
-        // contract that this function resolves (with manager or null) and
-        // never rejects, so a misbehaving shim can't crash plugin startup.
+        // Swallow whenReady() rejections AND synchronous throws: callers
+        // rely on the documented contract that this function resolves
+        // (with manager or null) and never rejects, so a misbehaving shim
+        // can't crash plugin startup. The `Promise.resolve().then(...)`
+        // wrapper converts a sync throw into a rejected promise that
+        // `.catch()` can handle.
         await Promise.race([
-          Promise.resolve(candidate.whenReady()).catch(() => undefined),
+          Promise.resolve()
+            .then(() => candidate.whenReady!())
+            .catch(() => undefined),
           new Promise((resolve) => setTimeout(resolve, Math.max(0, remaining)))
         ]);
         if (candidate.getRuntime()) {

--- a/src/utils/container-manager.ts
+++ b/src/utils/container-manager.ts
@@ -127,6 +127,14 @@ export interface ContainerMountResolution {
 
 export interface ContainerManagerApi {
   getRuntime(): ContainerRuntimeInfo | null;
+  /**
+   * Resolves once signalk-container's runtime detection has settled —
+   * succeeded or failed. After this awaits, `getRuntime()` returns the
+   * resolved value (or stays null if detection failed). Lets callers
+   * skip the polling loop. Available in signalk-container >= 1.6.0;
+   * optional so we keep working against earlier versions.
+   */
+  whenReady?(): Promise<void>;
   pullImage(image: string, onProgress?: (msg: string) => void): Promise<void>;
   imageExists(image: string): Promise<boolean>;
   runJob(config: ContainerJobConfig): Promise<ContainerJobResult>;
@@ -185,9 +193,29 @@ export async function waitForContainerManager(opts: {
   while (Date.now() < deadline) {
     const candidate = (globalThis as { __signalk_containerManager?: ContainerManagerApi })
       .__signalk_containerManager;
-    if (candidate && candidate.getRuntime()) {
-      resolvedManager = candidate;
-      return candidate;
+    if (candidate) {
+      // signalk-container >= 1.6.0 publishes whenReady(); race it against the
+      // remaining budget so a stuck runtime detection doesn't hang us past it.
+      if (typeof candidate.whenReady === 'function') {
+        const remaining = deadline - Date.now();
+        if (!signalledWait) {
+          opts.onWaitingStatus?.();
+          signalledWait = true;
+        }
+        await Promise.race([
+          candidate.whenReady(),
+          new Promise((resolve) => setTimeout(resolve, Math.max(0, remaining)))
+        ]);
+        if (candidate.getRuntime()) {
+          resolvedManager = candidate;
+          return candidate;
+        }
+        return null;
+      }
+      if (candidate.getRuntime()) {
+        resolvedManager = candidate;
+        return candidate;
+      }
     }
     if (!signalledWait) {
       opts.onWaitingStatus?.();

--- a/src/utils/container-manager.ts
+++ b/src/utils/container-manager.ts
@@ -194,6 +194,11 @@ export async function waitForContainerManager(opts: {
     const candidate = (globalThis as { __signalk_containerManager?: ContainerManagerApi })
       .__signalk_containerManager;
     if (candidate) {
+      // Fast path: detection already settled successfully, no need to wait.
+      if (candidate.getRuntime()) {
+        resolvedManager = candidate;
+        return candidate;
+      }
       // signalk-container >= 1.6.0 publishes whenReady(); race it against the
       // remaining budget so a stuck runtime detection doesn't hang us past it.
       if (typeof candidate.whenReady === 'function') {
@@ -202,8 +207,11 @@ export async function waitForContainerManager(opts: {
           opts.onWaitingStatus?.();
           signalledWait = true;
         }
+        // Swallow whenReady() rejections: callers rely on the documented
+        // contract that this function resolves (with manager or null) and
+        // never rejects, so a misbehaving shim can't crash plugin startup.
         await Promise.race([
-          candidate.whenReady(),
+          Promise.resolve(candidate.whenReady()).catch(() => undefined),
           new Promise((resolve) => setTimeout(resolve, Math.max(0, remaining)))
         ]);
         if (candidate.getRuntime()) {
@@ -211,10 +219,6 @@ export async function waitForContainerManager(opts: {
           return candidate;
         }
         return null;
-      }
-      if (candidate.getRuntime()) {
-        resolvedManager = candidate;
-        return candidate;
       }
     }
     if (!signalledWait) {

--- a/test/container-manager.test.ts
+++ b/test/container-manager.test.ts
@@ -208,6 +208,40 @@ describe('waitForContainerManager', () => {
     assert.strictEqual(getContainerManager(), null);
   });
 
+  it('returns null when whenReady() never settles and budget expires', async () => {
+    // Regression guard for the Promise.race against the remaining budget:
+    // a permanently pending whenReady() must not hang waitForContainerManager
+    // past its budgetMs. The outer race against a longer wall-clock timeout
+    // proves the call returned within budget rather than hanging forever.
+    const manager = makeManager(null, {
+      whenReady: () => new Promise(() => undefined)
+    });
+    globalThis[GLOBAL_KEY] = manager;
+
+    const TIMEOUT_SENTINEL: unique symbol = Symbol('timeout');
+    const resolved = await Promise.race<
+      Awaited<ReturnType<typeof waitForContainerManager>> | typeof TIMEOUT_SENTINEL
+    >([
+      waitForContainerManager({
+        budgetMs: 100,
+        pollIntervalMs: 20
+      }),
+      new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(TIMEOUT_SENTINEL);
+        }, 1000);
+      })
+    ]);
+
+    assert.notStrictEqual(
+      resolved,
+      TIMEOUT_SENTINEL,
+      'waitForContainerManager must return within budget, not hang on whenReady'
+    );
+    assert.strictEqual(resolved, null);
+    assert.strictEqual(getContainerManager(), null);
+  });
+
   it('swallows synchronous throws from whenReady() and returns null', async () => {
     // Even a shim that throws synchronously (before returning a Promise) must
     // not break the non-throwing contract of waitForContainerManager.

--- a/test/container-manager.test.ts
+++ b/test/container-manager.test.ts
@@ -207,4 +207,23 @@ describe('waitForContainerManager', () => {
     assert.strictEqual(resolved, null);
     assert.strictEqual(getContainerManager(), null);
   });
+
+  it('swallows synchronous throws from whenReady() and returns null', async () => {
+    // Even a shim that throws synchronously (before returning a Promise) must
+    // not break the non-throwing contract of waitForContainerManager.
+    const manager = makeManager(null, {
+      whenReady: () => {
+        throw new Error('synchronous detection failure');
+      }
+    });
+    globalThis[GLOBAL_KEY] = manager;
+
+    const resolved = await waitForContainerManager({
+      budgetMs: 2000,
+      pollIntervalMs: 50
+    });
+
+    assert.strictEqual(resolved, null);
+    assert.strictEqual(getContainerManager(), null);
+  });
 });

--- a/test/container-manager.test.ts
+++ b/test/container-manager.test.ts
@@ -158,4 +158,53 @@ describe('waitForContainerManager', () => {
     assert.strictEqual(resolved, null);
     assert.strictEqual(getContainerManager(), null);
   });
+
+  it('returns immediately without awaiting whenReady when getRuntime() already non-null', async () => {
+    // Belt-and-braces: even though whenReady is published, an already-ready
+    // manager should short-circuit and not fire onWaitingStatus.
+    let whenReadyCalled = false;
+    const manager: ContainerManagerApi = {
+      getRuntime: () => ({ runtime: 'docker', version: '28.0' }),
+      whenReady: () => {
+        whenReadyCalled = true;
+        return new Promise(() => undefined);
+      },
+      pullImage: () => Promise.resolve(),
+      imageExists: () => Promise.resolve(true),
+      runJob: () => Promise.resolve({ status: 'completed', exitCode: 0, log: [] }),
+      resolveSignalkDataMount: () => Promise.resolve(null),
+      resolveHostPath: () => Promise.resolve(null)
+    };
+    globalThis[GLOBAL_KEY] = manager;
+
+    let waitingFired = false;
+    const resolved = await waitForContainerManager({
+      budgetMs: 2000,
+      pollIntervalMs: 50,
+      onWaitingStatus: () => {
+        waitingFired = true;
+      }
+    });
+
+    assert.strictEqual(resolved, manager);
+    assert.strictEqual(whenReadyCalled, false, 'must not call whenReady when already ready');
+    assert.strictEqual(waitingFired, false, 'must not signal waiting when already ready');
+  });
+
+  it('swallows whenReady() rejections and returns null without throwing', async () => {
+    // Contract: waitForContainerManager never rejects, so a misbehaving shim
+    // that returns a rejected promise from whenReady() must not crash startup.
+    const manager = makeManager(null, {
+      whenReady: () => Promise.reject(new Error('detection blew up'))
+    });
+    globalThis[GLOBAL_KEY] = manager;
+
+    const resolved = await waitForContainerManager({
+      budgetMs: 2000,
+      pollIntervalMs: 50
+    });
+
+    assert.strictEqual(resolved, null);
+    assert.strictEqual(getContainerManager(), null);
+  });
 });

--- a/test/container-manager.test.ts
+++ b/test/container-manager.test.ts
@@ -28,8 +28,11 @@ afterEach(() => {
   delete globalThis[GLOBAL_KEY];
 });
 
-function makeManager(runtime: ContainerRuntimeInfo | null): ContainerManagerApi {
-  return {
+function makeManager(
+  runtime: ContainerRuntimeInfo | null,
+  opts: { whenReady?: () => Promise<void> } = {}
+): ContainerManagerApi {
+  const manager: ContainerManagerApi = {
     getRuntime: () => runtime,
     pullImage: () => Promise.resolve(),
     imageExists: () => Promise.resolve(true),
@@ -37,6 +40,10 @@ function makeManager(runtime: ContainerRuntimeInfo | null): ContainerManagerApi 
     resolveSignalkDataMount: () => Promise.resolve(null),
     resolveHostPath: () => Promise.resolve(null)
   };
+  if (opts.whenReady) {
+    manager.whenReady = opts.whenReady;
+  }
+  return manager;
 }
 
 describe('waitForContainerManager', () => {
@@ -104,5 +111,51 @@ describe('waitForContainerManager', () => {
 
     assert.strictEqual(resolved, manager);
     assert.strictEqual(getContainerManager(), manager);
+  });
+
+  it('uses whenReady() when the manager exposes it (signalk-container >= 1.6.0)', async () => {
+    // Manager is published with whenReady. getRuntime() starts null and
+    // flips to non-null only after whenReady() resolves — the
+    // 1.6.0 contract (detection is settled when whenReady() resolves).
+    let detected: ContainerRuntimeInfo | null = null;
+    const manager: ContainerManagerApi = {
+      getRuntime: () => detected,
+      whenReady: () =>
+        new Promise((resolve) =>
+          setTimeout(() => {
+            detected = { runtime: 'podman', version: '5.4' };
+            resolve();
+          }, 100)
+        ),
+      pullImage: () => Promise.resolve(),
+      imageExists: () => Promise.resolve(true),
+      runJob: () => Promise.resolve({ status: 'completed', exitCode: 0, log: [] }),
+      resolveSignalkDataMount: () => Promise.resolve(null),
+      resolveHostPath: () => Promise.resolve(null)
+    };
+    globalThis[GLOBAL_KEY] = manager;
+
+    const resolved = await waitForContainerManager({
+      budgetMs: 2000,
+      pollIntervalMs: 50
+    });
+
+    assert.strictEqual(resolved, manager);
+    assert.strictEqual(getContainerManager(), manager);
+  });
+
+  it('returns null when whenReady() resolves but runtime detection failed', async () => {
+    const manager = makeManager(null, {
+      whenReady: () => Promise.resolve()
+    });
+    globalThis[GLOBAL_KEY] = manager;
+
+    const resolved = await waitForContainerManager({
+      budgetMs: 2000,
+      pollIntervalMs: 50
+    });
+
+    assert.strictEqual(resolved, null);
+    assert.strictEqual(getContainerManager(), null);
   });
 });


### PR DESCRIPTION
## Summary

- signalk-container 1.6.0 added `containers.whenReady()`: a single await that resolves once runtime detection has settled (success OR failure), replacing the documented `while (!getRuntime()) await sleep` polling pattern
- `waitForContainerManager` now uses `whenReady()` when the published manager exposes it, racing against the remaining time budget so a stuck runtime detection still respects `budgetMs`
- The legacy poll loop stays in place for hosts running signalk-container < 1.6.0; the method is declared optional (`whenReady?()`) on the local API shim, so this is fully backward-compatible

## Tested

- `npm run format` clean
- `npm run build` clean
- `npm test` — 251/251 pass, including two new tests covering the `whenReady()` path (success and runtime-detection-failed)
- `cr review --plain` — no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Use an optional readiness API from container managers to speed and stabilize runtime detection, while preserving legacy polling fallback.

* **Tests**
  * Added coverage for readiness behaviors: wait-until-ready, timeouts, already-ready short-circuit, and swallowed errors.

* **Documentation**
  * Updated integration guidance to explain the new detection flow, version-specific behavior, and error-handling expectations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirkwa/signalk-charts-provider-simple/pull/98)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->