### PR TITLE
chore(release): 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.0.1-beta.1",
+  "version": "2.0.1",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Stable release of the #99 tile-route fix. Beta 2.0.1-beta.1 verified by reporter.