### PR TITLE
fix(startup): register charts provider before container-manager wait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ test-results/
 # IDE files
 .vscode/
 
+# CodeRabbit local review output (cr review --plain piped to a file)
+cr-review*
+
 # testbuilds
 *.tgz
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "signalk": {
     "appIcon": "assets/charts_logo.png",
     "displayName": "Charts Provider Simple",
-    "requires": [
+    "recommends": [
       "signalk-container"
     ],
     "screenshots": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,6 +272,29 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     initS57Converter(app.debug.bind(app));
     initRncConverter(app.debug.bind(app));
 
+    // Bring up the display path (chart loading + resource-provider
+    // registration) BEFORE discovering signalk-container. Display does not
+    // need the container runtime, and gating registration behind the
+    // up-to-30s container wait left Freeboard-SK's GET
+    // /signalk/v2/api/resources/charts returning 404 until the wait
+    // resolved — so charts vanished from the chart list on hosts without
+    // signalk-container installed.
+    app.debug(`Start chart provider. Chart path: ${chartPath}`);
+    const { charts: loadedCharts, ok: loadOk } = await loadChartProviders(chartPath);
+
+    if (serverMajorVersion === 2) {
+      app.debug('** Registering v2 API paths **');
+      registerAsProvider();
+    }
+
+    // Report Started for the display path. Don't clobber a load error
+    // (loadChartProviders sets one) — a later setPluginError from the
+    // signalk-container discovery below is allowed to win, since that
+    // message tells the user conversion needs the container plugin.
+    if (loadOk) {
+      app.setPluginStatus('Started');
+    }
+
     // Discover the signalk-container plugin's manager API.  Chart conversion
     // (S-57, BSB raster, Pilot, basemaps) goes through it from 2.0 onward;
     // the App Store's `signalk.requires` declaration in our package.json
@@ -402,87 +425,95 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       });
     });
 
-    app.debug(`Start chart provider. Chart path: ${chartPath}`);
+    // Filesystem housekeeping (removing invalid .mbtiles and orphaned
+    // journal/WAL files) runs independently of the display path so it can
+    // never delay chart listing. Reuses the chart scan from loadChartProviders.
+    void cleanupChartDirectory(chartPath, loadedCharts);
+  };
 
-    if (serverMajorVersion === 2) {
-      app.debug('** Registering v2 API paths **');
-      registerAsProvider();
+  // Load enabled charts into `chartProviders` and prune stale install
+  // records. Display-critical: must run (and resolve) before the resource
+  // provider is registered so `listResources` has charts to return. Returns
+  // the full (pre-filter) chart map so housekeeping can reuse the scan.
+  const loadChartProviders = async (
+    chartPath: string
+  ): Promise<{ charts: Record<string, ChartProvider>; ok: boolean }> => {
+    try {
+      const charts = await findCharts(chartPath);
+      const enabledCharts = Object.fromEntries(
+        Object.entries(charts).filter(([, chart]) => {
+          const relativePath = path.relative(chartPath, chart._filePath || '');
+          return isChartEnabled(relativePath);
+        })
+      );
+
+      app.debug(
+        `Chart provider: Found ${Object.keys(charts).length} charts (${Object.keys(enabledCharts).length} enabled) from ${chartPath}.`
+      );
+      chartProviders = enabledCharts;
+
+      pruneStaleInstalls(Object.keys(charts));
+      return { charts, ok: true };
+    } catch (e: unknown) {
+      console.error(`Error loading chart providers`, e instanceof Error ? e.message : String(e));
+      chartProviders = {};
+      app.setPluginError(`Error loading chart providers`);
+      return { charts: {}, ok: false };
     }
+  };
 
-    // Don't overwrite a pluginError that the manager-discovery block may
-    // have set — that message must stay visible so the user knows chart
-    // conversion will not work until they install signalk-container.
-    if (containerManager) {
-      app.setPluginStatus('Started');
-    }
-
-    findCharts(chartPath)
-      .then((charts) => {
-        const enabledCharts = Object.fromEntries(
-          Object.entries(charts).filter(([, chart]) => {
-            const relativePath = path.relative(chartPath, chart._filePath || '');
-            return isChartEnabled(relativePath);
-          })
-        );
-
-        app.debug(
-          `Chart provider: Found ${Object.keys(charts).length} charts (${Object.keys(enabledCharts).length} enabled) from ${chartPath}.`
-        );
-        chartProviders = enabledCharts;
-
-        pruneStaleInstalls(Object.keys(charts));
-
-        return scanChartsRecursively(chartPath).then((allFiles) => {
-          const validPaths = new Set(
-            Object.values(charts)
-              .map((c) => c._filePath)
-              .filter(Boolean)
-          );
-          for (const file of allFiles) {
-            if (file.name.endsWith('.mbtiles') && !validPaths.has(file.path)) {
-              console.log(`[charts-provider] Removing invalid .mbtiles file: ${file.name}`);
-              try {
-                fs.unlinkSync(file.path);
-              } catch (e) {
-                app.debug(
-                  `Failed to remove ${file.path}: ${e instanceof Error ? e.message : String(e)}`
-                );
-              }
-            }
-          }
-
+  const cleanupChartDirectory = async (
+    chartPath: string,
+    charts: Record<string, ChartProvider>
+  ): Promise<void> => {
+    try {
+      const allFiles = await scanChartsRecursively(chartPath);
+      const validPaths = new Set(
+        Object.values(charts)
+          .map((c) => c._filePath)
+          .filter(Boolean)
+      );
+      for (const file of allFiles) {
+        if (file.name.endsWith('.mbtiles') && !validPaths.has(file.path)) {
+          console.log(`[charts-provider] Removing invalid .mbtiles file: ${file.name}`);
           try {
-            const cleanOrphans = (dir: string): void => {
-              const entries = fs.readdirSync(dir, { withFileTypes: true });
-              for (const entry of entries) {
-                const fullPath = path.join(dir, entry.name);
-                if (entry.isDirectory()) {
-                  if (!entry.name.startsWith('.') && entry.name !== 'node_modules') {
-                    cleanOrphans(fullPath);
-                  }
-                } else if (
-                  entry.name.endsWith('.mbtiles-journal') ||
-                  entry.name.endsWith('.mbtiles-wal') ||
-                  entry.name.endsWith('.partial_tiles.db')
-                ) {
-                  console.log(`[charts-provider] Removing orphaned file: ${entry.name}`);
-                  fs.unlinkSync(fullPath);
-                }
-              }
-            };
-            cleanOrphans(chartPath);
+            fs.unlinkSync(file.path);
           } catch (e) {
             app.debug(
-              `Error cleaning orphaned files: ${e instanceof Error ? e.message : String(e)}`
+              `Failed to remove ${file.path}: ${e instanceof Error ? e.message : String(e)}`
             );
           }
-        });
-      })
-      .catch((e: unknown) => {
-        console.error(`Error loading chart providers`, e instanceof Error ? e.message : String(e));
-        chartProviders = {};
-        app.setPluginError(`Error loading chart providers`);
-      });
+        }
+      }
+
+      const cleanOrphans = (dir: string): void => {
+        const entries = fs.readdirSync(dir, { withFileTypes: true });
+        for (const entry of entries) {
+          const fullPath = path.join(dir, entry.name);
+          if (entry.isDirectory()) {
+            if (!entry.name.startsWith('.') && entry.name !== 'node_modules') {
+              cleanOrphans(fullPath);
+            }
+          } else if (
+            entry.name.endsWith('.mbtiles-journal') ||
+            entry.name.endsWith('.mbtiles-wal') ||
+            entry.name.endsWith('.partial_tiles.db')
+          ) {
+            console.log(`[charts-provider] Removing orphaned file: ${entry.name}`);
+            try {
+              fs.unlinkSync(fullPath);
+            } catch (e) {
+              app.debug(
+                `Failed to remove orphan ${fullPath}: ${e instanceof Error ? e.message : String(e)}`
+              );
+            }
+          }
+        }
+      };
+      cleanOrphans(chartPath);
+    } catch (e) {
+      app.debug(`Error cleaning chart directory: ${e instanceof Error ? e.message : String(e)}`);
+    }
   };
 
   const finalizeUploadedFiles = async (

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,7 +280,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     // resolved — so charts vanished from the chart list on hosts without
     // signalk-container installed.
     app.debug(`Start chart provider. Chart path: ${chartPath}`);
-    const { charts: loadedCharts, ok: loadOk } = await loadChartProviders(chartPath);
+    const loadOk = await loadChartProviders(chartPath);
 
     if (serverMajorVersion === 2) {
       app.debug('** Registering v2 API paths **');
@@ -297,7 +297,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
     // Discover the signalk-container plugin's manager API.  Chart conversion
     // (S-57, BSB raster, Pilot, basemaps) goes through it from 2.0 onward;
-    // the App Store's `signalk.requires` declaration in our package.json
+    // the App Store's `signalk.recommends` declaration in our package.json
     // ensures users are prompted to install signalk-container, but plugin
     // load order is not deterministic, so we wait up to 30 s before giving
     // up.  A missing manager surfaces as setPluginError but does NOT abort
@@ -322,7 +322,14 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     }
 
     const containerManager = await waitForContainerManager({
-      onWaitingStatus: () => app.setPluginStatus('Waiting for signalk-container...')
+      // Don't overwrite the display path's "Started" status with a waiting
+      // message: when charts have already loaded, serving is live and a
+      // "Waiting for signalk-container..." status would be misleading.
+      onWaitingStatus: () => {
+        if (!loadOk) {
+          app.setPluginStatus('Waiting for signalk-container...');
+        }
+      }
     });
     if (!containerManager) {
       app.setPluginError(
@@ -427,17 +434,18 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
     // Filesystem housekeeping (removing invalid .mbtiles and orphaned
     // journal/WAL files) runs independently of the display path so it can
-    // never delay chart listing. Reuses the chart scan from loadChartProviders.
-    void cleanupChartDirectory(chartPath, loadedCharts);
+    // never delay chart listing. It rescans the chart directory itself
+    // rather than reusing the startup snapshot — charts may have been
+    // uploaded/downloaded/converted during the container-manager wait, and
+    // a stale snapshot would delete them as "invalid".
+    void cleanupChartDirectory(chartPath);
   };
 
   // Load enabled charts into `chartProviders` and prune stale install
   // records. Display-critical: must run (and resolve) before the resource
   // provider is registered so `listResources` has charts to return. Returns
-  // the full (pre-filter) chart map so housekeeping can reuse the scan.
-  const loadChartProviders = async (
-    chartPath: string
-  ): Promise<{ charts: Record<string, ChartProvider>; ok: boolean }> => {
+  // true on success, false if the chart directory could not be read.
+  const loadChartProviders = async (chartPath: string): Promise<boolean> => {
     try {
       const charts = await findCharts(chartPath);
       const enabledCharts = Object.fromEntries(
@@ -453,20 +461,18 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       chartProviders = enabledCharts;
 
       pruneStaleInstalls(Object.keys(charts));
-      return { charts, ok: true };
+      return true;
     } catch (e: unknown) {
       console.error(`Error loading chart providers`, e instanceof Error ? e.message : String(e));
       chartProviders = {};
       app.setPluginError(`Error loading chart providers`);
-      return { charts: {}, ok: false };
+      return false;
     }
   };
 
-  const cleanupChartDirectory = async (
-    chartPath: string,
-    charts: Record<string, ChartProvider>
-  ): Promise<void> => {
+  const cleanupChartDirectory = async (chartPath: string): Promise<void> => {
     try {
+      const charts = await findCharts(chartPath);
       const allFiles = await scanChartsRecursively(chartPath);
       const validPaths = new Set(
         Object.values(charts)


### PR DESCRIPTION
## Summary

Freeboard-SK (and any v2 chart consumer) stopped listing this plugin's charts
after upgrading to 2.0.x on hosts without `signalk-container` installed/ready.

`registerAsProvider()` (the v2 `charts` resource-provider registration) ran
**after** `await waitForContainerManager()` in `doStartup`. That wait blocks for
up to its full 30s budget when `signalk-container` is absent or its runtime hasn't
settled. During that window no charts provider is registered, so the server returns
**404** for `GET /signalk/v2/api/resources/charts`. Freeboard-SK's `refreshCharts()`
catches the error and falls back to showing only its built-in OpenStreetMap /
OpenSeaMap defaults — the user's charts vanish from the list.

This was the 2.0.0 async refactor: in 1.14.0 `doStartup` was synchronous and the
provider registered immediately. It also explains why only display-only installs
were affected — users running `signalk-container` (for chart conversion) have a
fast container wait, so their registration was prompt.

## Solution

Decouple the display path from conversion-runtime discovery:

- Load charts and register the resource provider **before** awaiting
  `waitForContainerManager`. Display needs no container runtime.
- Report `Started` for the display path without clobbering the
  conversion-missing `setPluginError`.
- Split filesystem housekeeping (invalid `.mbtiles` / orphaned journal-WAL files)
  into a fire-and-forget helper that reuses the same disk scan, so it can never
  delay chart listing.
- Make `signalk-container` a `recommends` (not `requires`) in the App Store
  metadata, since display works without it; the container is only needed for the
  on-demand conversion path.

## Tested

- `npm run format`, `npm run build`, `npm run test` all pass.
- Reproduced the failure condition end-to-end on a local server (`signalk-container`
  disabled, plugin npm-linked): polled `GET /signalk/v2/api/resources/charts` every
  2s across the first 35s after restart — **HTTP 200 from t+1s onward** (previously
  404 for ~30s). The response lists both an S-57 vector (`pbf`) chart and a raster
  (`png`) chart with valid `url`/`type`/`format`, and the charts appear in
  Freeboard-SK.

Fixes the regression reported for 2.0.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## fix(startup): register charts provider before container-manager wait

**Problem**: Chart consumers (Freeboard-SK, etc.) fail to list this plugin's charts on hosts where signalk-container is absent or not yet ready because v2 resource-provider registration runs after awaiting waitForContainerManager(), which can block ~30s and leave charts unregistered (GET /signalk/v2/api/resources/charts returns 404).

**Change summary**:

- Reorder startup so the display path loads charts and registers the v2 `charts` resource provider before awaiting the container manager, decoupling chart listing from conversion/runtime discovery.
- Introduce loadChartProviders(chartPath) to discover enabled charts, prune stale catalog installs, set chartProviders, and surface load errors via setPluginError() while allowing the display path to proceed.
- Extract filesystem housekeeping into cleanupChartDirectory(chartPath), run as fire-and-forget, and make it rescan the directory during cleanup to avoid deleting charts added/converted while waiting for the container manager.
- Ensure onWaitingStatus no longer overwrites the display path's "Started" status with a conversion-related waiting message once charts are loaded.
- Register v2 resource-provider routes conditionally when serverMajorVersion === 2 immediately after successful chart loading.
- Change package.json metadata to mark signalk-container as recommends instead of requires.
- Update .gitignore to ignore CodeRabbit review output (`cr-review*`).

**Tests & verification**: npm run format, build, and test pass. Reproduced the prior failure with signalk-container disabled: GET /signalk/v2/api/resources/charts now returns 200 within ~1s after restart (previously 404 for ~30s) and lists vector and raster charts; charts appear in Freeboard-SK.

**Notes**: Also adjusts comments and addresses review feedback so cleanup rescans the chart directory and status handling for the display path no longer gets clobbered by conversion-status messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirkwa/signalk-charts-provider-simple/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->