### PR TITLE
chore(release): 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Patch release bumping the version to 2.0.2.

Includes #105: chart provider now registers before the signalk-container
wait, so Freeboard-SK lists charts immediately on hosts without
signalk-container installed (previously the v2 resources/charts endpoint
returned 404 for up to 30s and FSK fell back to OSM-only). Also makes
signalk-container a `recommends` rather than `requires`, since chart
display does not need the container runtime.