### PR TITLE
Catalog folder polish and signalk-container messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ The interface provides four tabs:
 - **Node.js >= 22.5** — uses the built-in `node:sqlite` module, no native compilation needed
 - **Not supported on Cerbo GX** — Venus OS ships Node.js 20, which lacks the `node:sqlite` module. Use v1.6.x if you need Cerbo support.
 
-### Required for chart conversion: `signalk-container` plugin
+### Recommended for chart conversion: `signalk-container` plugin
 
-To convert S-57 ENC, BSB raster, Pilot Charts, or basemaps, this plugin delegates all container work to the [`signalk-container`](https://github.com/dirkwa/signalk-container) plugin. The Signal K App Store handles installing it for you when you install Charts Provider Simple — the plugin's detail page shows it as a required plugin and offers a one-click bulk install.
+Displaying charts (serving tiles from `.mbtiles`) needs nothing extra. The [`signalk-container`](https://github.com/dirkwa/signalk-container) plugin is only needed to **convert** charts (S-57 ENC, BSB raster, Pilot Charts, or basemaps), where this plugin delegates all container work to it. The Signal K App Store lists it as a recommended plugin on the Charts Provider Simple detail page and offers a one-click bulk install; without it the plugin still loads and serves charts — only the Convert tab is disabled.
 
 `signalk-container` itself needs a Docker- or Podman-compatible runtime on the host. Both engines work the same way; pick whichever is easier:
 
@@ -133,7 +133,7 @@ The plugin uses one combined image that `signalk-container` pulls automatically 
 - **Signal K in Docker / Podman with a named volume** — the helper container mounts the same named volume. (1.x couldn't do this; named-volume deployments were unable to convert.)
 - **Signal K in Docker / Podman with bind-mounted data** — the helper container gets the resolved host path, even when the in-container path doesn't match the host path. (1.x relied on host/container paths matching exactly; mismatches silently failed.)
 
-**Signal K running in Docker?** See [docs/running-in-docker.md](docs/running-in-docker.md) for the docker-compose snippet.
+**Signal K running in Docker?** Runtime and socket setup is handled by `signalk-container` — see [docs/running-in-docker.md](docs/running-in-docker.md) for how conversion is delegated and where to configure the host.
 
 Conversion concurrency is configurable — see the [CPU budget](#cpu-budget-for-chart-conversion) section. MBTiles charts (display only, no conversion) work without any container runtime, and without `signalk-container`.
 

--- a/docs/running-in-docker.md
+++ b/docs/running-in-docker.md
@@ -1,126 +1,37 @@
 # Running Signal K (and this plugin) in Docker
 
-The plugin runs OCI containers to convert charts (S-57 ENC → vector MBTiles, BSB → raster MBTiles, basemaps). When Signal K itself runs inside a container, the conversions run in **sibling containers on the host** — the in-container plugin talks to the host's Docker (or Podman) daemon over a mounted socket. There's no need to install a container engine inside the Signal K container.
+Chart **display** (serving tiles from `.mbtiles`) needs nothing extra and works
+the same whether Signal K runs bare-metal or in a container. This page is only
+about chart **conversion** (S-57 ENC → vector MBTiles, BSB → raster MBTiles,
+basemaps), which runs OCI containers.
 
-This page covers the two common shapes:
-- Signal K in Docker on a Docker host (most users).
-- Signal K in Docker on a Podman host (the [issue #7](https://github.com/dirkwa/signalk-charts-provider-simple/issues/7) setup).
+## Conversion is delegated to `signalk-container`
 
-The bare-metal case (Signal K running directly on the host) is unchanged from previous releases — see the [README](../README.md#optional-container-runtime-for-chart-conversion) for the bare-metal install steps.
+From 2.0 onward this plugin does **not** talk to a Docker/Podman socket itself.
+All container work — runtime detection, image pulls, launching conversion jobs,
+mounting the Signal K data directory, and resolving host paths — is delegated to
+the [`signalk-container`](https://github.com/dirkwa/signalk-container) plugin.
 
-## How the plugin finds the daemon
+That means there is nothing Docker-specific to configure here. Install
+`signalk-container` from the App Store (the Charts Provider Simple detail page
+lists it as a recommended plugin) and make sure it reports a healthy runtime in
+its config panel. If conversion is unavailable, the Convert and Chart Catalog
+tabs show a warning; chart display keeps working regardless.
 
-At startup, the plugin tries these socket paths in order and uses the first one that responds:
+## Where to set up the runtime
 
-1. `DOCKER_HOST` env var with a `unix://` URI, if set.
-2. `/var/run/docker.sock` (default Docker location, also where rootful Podman puts its docker-compat socket).
-3. `/run/user/$UID/podman/podman.sock` (rootless Podman).
-4. `/run/podman/podman.sock` (rootful Podman as a system service).
+All host/runtime setup — mounting the Docker/Podman socket into a containerised
+Signal K, socket permissions, `DOCKER_HOST`, SELinux `:Z`, host-UID ownership,
+named-volume vs. bind-mount data sharing — now lives with `signalk-container`,
+which handles the bare-metal, Docker, and Podman topologies automatically. See:
 
-`DOCKER_HOST=tcp://...` is not supported yet; if you need a TCP-served daemon, route it through a local unix socket forwarder.
-
-If none respond, the plugin's startup log says so and the Convert / Catalog tabs show a warning. The plugin does **not** crash Signal K when no runtime is reachable — chart conversion just stays disabled.
-
-## Docker host, Signal K in Docker
-
-```yaml
-services:
-  signalk:
-    image: signalk/signalk-server:latest
-    volumes:
-      - ./signalk:/home/node/.signalk
-      # Mount the host's Docker socket so the plugin can launch sibling containers.
-      - /var/run/docker.sock:/var/run/docker.sock
-    group_add:
-      # GID of the `docker` group on the *host*, so the in-container `node`
-      # user can read the bind-mounted socket. Find it with:
-      #   getent group docker | cut -d: -f3
-      - "999"
-    ports:
-      - "3000:3000"
-```
-
-Verify after `docker compose up -d`:
-
-```bash
-docker compose exec -u node signalk \
-  curl -fsS --unix-socket /var/run/docker.sock http://d/_ping
-# expects: OK
-```
-
-If this returns `permission denied`, your `group_add` GID doesn't match the host's `docker` group. Adjust and recreate the container.
-
-## Podman host, Signal K in Docker
-
-This is GraffJosh's setup. The host runs Podman; Signal K still runs under Docker (or another container engine) but talks to the Podman socket. Podman serves a Docker-compatible API on its own socket, so the plugin code path is identical.
-
-Make sure the rootless Podman socket is up on the host:
-
-```bash
-systemctl --user enable --now podman.socket
-loginctl enable-linger "$USER"   # so it survives logout
-```
-
-The socket path is `/run/user/$(id -u)/podman/podman.sock` — typically `/run/user/1000/podman/podman.sock`.
-
-Then in `docker-compose.yml`:
-
-```yaml
-services:
-  signalk:
-    image: signalk/signalk-server:latest
-    environment:
-      # Tell the plugin which socket to dial. The container side of the bind mount
-      # is fixed to /run/podman/podman.sock for clarity.
-      - DOCKER_HOST=unix:///run/podman/podman.sock
-    volumes:
-      - ./signalk:/home/node/.signalk
-      - /run/user/1000/podman/podman.sock:/run/podman/podman.sock
-    ports:
-      - "3000:3000"
-```
-
-You may need to grant the in-container `node` user (uid 1000 by default) access to the host socket. Under rootful Docker, host UIDs don't map cleanly into the container, so the bind-mounted socket appears with surprising ownership inside.
-
-**Recommended — scoped ACL** for just the user that needs access:
-
-```bash
-setfacl -m u:1000:rw /run/user/1000/podman/podman.sock
-```
-
-ACLs survive socket re-creation if you use a systemd drop-in, but a one-off `setfacl` is wiped when the socket is recreated; reapply on each podman service restart, or wire it into a systemd `ExecStartPost=`.
-
-**Last resort — `chmod 666`** opens the socket to every local user. Only acceptable on a single-user host where you're sure no other process you don't trust runs as a different user:
-
-```bash
-# WARNING: grants podman API access to every local user on this host.
-chmod 666 /run/user/1000/podman/podman.sock
-```
-
-If you're using rootless Docker (or running Signal K under Podman directly), UIDs map and no permission tweak is needed.
-
-Verify:
-
-```bash
-docker compose exec -u node signalk \
-  curl -fsS --unix-socket /run/podman/podman.sock http://d/_ping
-# expects: OK
-```
-
-## Common pitfalls
-
-- **`DOCKER_HOST` vs `CONTAINER_HOST`** — the plugin reads `DOCKER_HOST`. Setting only `CONTAINER_HOST` (Podman's native variable) does nothing here.
-- **Stale value in `DOCKER_HOST`** — if you set it to a path that doesn't exist, the plugin will fall through to the standard fallbacks. The startup log shows which socket it actually picked.
-- **`privileged: true`** — not required, even for the Podman-host case. Mounting the socket is enough.
-- **SELinux** — on Fedora/RHEL/CentOS hosts, you may need `:Z` on the bind mounts (host side, on the daemon's bind, not the plugin's container args). The plugin's own bind syntax doesn't pass `:Z` since Docker doesn't accept it.
-- **Network isolation** — chart-conversion containers are short-lived and don't expose ports. They share whatever network the host daemon defaults to (usually `bridge`); no extra config needed.
-
-## What about plain Podman directly?
-
-If you run Signal K **directly on the host** (no Docker / Compose involved) and have Podman installed, do nothing — `systemctl --user enable --now podman.socket` is enough. The plugin defaults to dialing the rootless Podman socket and works as before.
+- [`signalk-container` README](https://github.com/dirkwa/signalk-container#readme)
+  — runtime detection, settings, and the config panel.
+- [`signalk-container` plugin developer / setup docs](https://github.com/dirkwa/signalk-container/tree/main/doc)
+  — deployment topologies and host configuration.
 
 ## See also
 
-- [Issue #7](https://github.com/dirkwa/signalk-charts-provider-simple/issues/7) — the original report that prompted this doc.
-- [Docker reference: bind mounts](https://docs.docker.com/storage/bind-mounts/)
-- [Podman: Docker-compatible API](https://docs.podman.io/en/latest/markdown/podman-system-service.1.html)
+- [Issue #7](https://github.com/dirkwa/signalk-charts-provider-simple/issues/7) —
+  the original Podman-host report that prompted the 1.x version of this doc, now
+  resolved by the `signalk-container` architecture.

--- a/public/css/chart-catalog.css
+++ b/public/css/chart-catalog.css
@@ -382,7 +382,6 @@ select.catalog-folder-select:hover {
     appearance: auto;
 }
 
-/* The auto-derived "(new)" folder option, highlighted to draw the eye. */
 option.catalog-folder-option-new {
     color: var(--md-sys-color-primary);
 }

--- a/public/css/chart-catalog.css
+++ b/public/css/chart-catalog.css
@@ -382,6 +382,11 @@ select.catalog-folder-select:hover {
     appearance: auto;
 }
 
+/* The auto-derived "(new)" folder option, highlighted to draw the eye. */
+option.catalog-folder-option-new {
+    color: var(--md-sys-color-primary);
+}
+
 /* Source attribution note */
 .catalog-source-note {
     padding: var(--md-sys-spacing-3) var(--md-sys-spacing-4);

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -1095,9 +1095,10 @@ function categoryLabel(category: CatalogCategory | string): string {
 
 /**
  * Derive a filesystem-safe folder name from a catalog label.
- * Strips path separators and illegal characters, collapses whitespace, and
- * removes leading dots so a label can't resolve to a traversal ('..') or a
- * hidden/relative folder ('.'). Falls back to '/' when nothing usable remains.
+ * Strips path separators and illegal characters, collapses whitespace, removes
+ * leading dots/spaces, and rejects a result of '.' or '..' so a label can't
+ * resolve to a traversal or a hidden/relative folder. Falls back to '/' when
+ * nothing usable remains.
  */
 function catalogLabelToFolder(label: string | undefined | null): string {
   if (!label) {
@@ -1107,9 +1108,9 @@ function catalogLabelToFolder(label: string | undefined | null): string {
     .replace(/[/\\:*?"<>|]/g, '')
     .replace(/\s+/g, ' ')
     .trim()
-    .replace(/^\.+/, '')
+    .replace(/^[.\s]+/, '')
     .trim();
-  return safe || '/';
+  return safe && safe !== '.' && safe !== '..' ? safe : '/';
 }
 
 function folderDisplayName(folder: string): string {

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -1095,8 +1095,9 @@ function categoryLabel(category: CatalogCategory | string): string {
 
 /**
  * Derive a filesystem-safe folder name from a catalog label.
- * Keeps letters, digits, spaces (trimmed), hyphens, underscores, and dots.
- * Falls back to '/' when the result would be empty.
+ * Strips path separators and illegal characters, collapses whitespace, and
+ * removes leading dots so a label can't resolve to a traversal ('..') or a
+ * hidden/relative folder ('.'). Falls back to '/' when nothing usable remains.
  */
 function catalogLabelToFolder(label: string | undefined | null): string {
   if (!label) {
@@ -1105,6 +1106,8 @@ function catalogLabelToFolder(label: string | undefined | null): string {
   const safe = label
     .replace(/[/\\:*?"<>|]/g, '')
     .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^\.+/, '')
     .trim();
   return safe || '/';
 }
@@ -1119,7 +1122,7 @@ function buildFolderOptions(defaultFolder: string): string {
 
   if (isNew) {
     options.push(
-      `<option value="${catalogEscapeAttr(defaultFolder)}" selected style="color:var(--md-sys-color-primary,#1a73e8)">${catalogEscapeHtml(folderDisplayName(defaultFolder))} (new)</option>`
+      `<option value="${catalogEscapeAttr(defaultFolder)}" selected class="catalog-folder-option-new">${catalogEscapeHtml(folderDisplayName(defaultFolder))} (new)</option>`
     );
   }
 

--- a/public/js/chart-convert.ts
+++ b/public/js/chart-convert.ts
@@ -61,8 +61,11 @@ async function initConvertTab(): Promise<void> {
         !convertPodmanAvailable
           ? `
         <div class="catalog-podman-warning">
-          <strong>Container runtime not reachable.</strong>
-          Chart conversion needs a Docker- or Podman-compatible socket.
+          <strong>Chart conversion unavailable.</strong>
+          Converting charts needs the
+          <a href="https://github.com/dirkwa/signalk-container" target="_blank" rel="noopener">signalk-container</a>
+          plugin (install it from the App Store) plus a Docker- or Podman-compatible
+          runtime on the host. Chart display works without it.
           <a href="https://github.com/dirkwa/signalk-charts-provider-simple/blob/main/docs/running-in-docker.md" target="_blank" rel="noopener">See setup notes</a>.
         </div>
       `
@@ -178,7 +181,7 @@ function setupDropZone(zoneId: string, inputId: string): void {
   zone.onclick = () => {
     if (!convertPodmanAvailable) {
       alert(
-        'Chart conversion needs a Docker- or Podman-compatible socket. See the warning above.'
+        'Chart conversion needs the signalk-container plugin and a Docker- or Podman-compatible runtime. See the warning above.'
       );
       return;
     }
@@ -199,7 +202,7 @@ function setupDropZone(zoneId: string, inputId: string): void {
     zone.classList.remove('dragover');
     if (!convertPodmanAvailable) {
       alert(
-        'Chart conversion needs a Docker- or Podman-compatible socket. See the warning above.'
+        'Chart conversion needs the signalk-container plugin and a Docker- or Podman-compatible runtime. See the warning above.'
       );
       return;
     }


### PR DESCRIPTION
Follow-up to #67. Two related cleanups around the catalog folder feature and the now-stale container messaging.

## Catalog folder option
- Move the auto-derived "(new)" folder `<option>` highlight from an inline `style` to a `catalog-folder-option-new` CSS class.
- `catalogLabelToFolder` strips leading dots after trimming, so a catalog label can no longer resolve to a traversal (`..`) or a hidden/relative folder (`.`); falls back to `/`.

## signalk-container messaging
Conversion is delegated to the `signalk-container` plugin from 2.0 onward, and it is recommended (not required) since chart display works without it.
- Convert tab banner and alerts now point at the `signalk-container` plugin plus a container runtime, instead of "a Docker- or Podman-compatible socket".
- README: "Required" → "Recommended" for `signalk-container`, clarifying display works without it.
- `running-in-docker.md`: replace the obsolete 1.x direct-socket setup with delegation to `signalk-container` and a pointer to its docs.

## Tested
- `npm run format`, `npm run build`, `npm run test` pass.
- Verified locally (plugin npm-linked, `signalk-container` disabled): the Convert tab shows the new "Chart conversion unavailable…" banner referencing the signalk-container plugin, and the Chart Catalog folder `<select>` shows the highlighted "(new)" option via the CSS class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Catalog folder polish

Moves the "(new)" folder option highlight from inline styling to a CSS class `catalog-folder-option-new`. Strengthens folder-name derivation: `catalogLabelToFolder` trims input, collapses whitespace, strips path separators and leading dots (preventing `.`/`..` and hidden/relative folders), and falls back to `/` if the result is unsafe.

## signalk-container messaging and documentation

Changes conversion delegation and messaging to reflect that chart conversion is delegated to the `signalk-container` plugin from v2.0 onward and is recommended (not required). Chart display continues to work without `signalk-container`, but the Convert tab is disabled.

README updates “Required” → “Recommended” for `signalk-container` and clarifies display works without it. The “Signal K running in Docker?” guidance points users to install/configure `signalk-container` to handle runtime/socket setup. docs/running-in-docker.md removes obsolete direct Docker/Podman socket instructions (daemon detection, compose examples, permission/SELinux pitfalls) and directs users to the `signalk-container` plugin docs and health checks.

UI text and alerts for the Convert tab now reference the `signalk-container` plugin and a container runtime rather than generic Docker/Podman socket wording.

## Tests and verification

npm format/build/test pass. Local verification confirms the new banner messaging when `signalk-container` is disabled and that the Catalog folder select uses the `catalog-folder-option-new` CSS class for the "(new)" option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirkwa/signalk-charts-provider-simple/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->