### PR TITLE
ci: run the SignalK plugin CI workflow on pull requests

### DIFF
--- a/.github/workflows/signalk-ci.yml
+++ b/.github/workflows/signalk-ci.yml
@@ -7,6 +7,8 @@ name: Test SignalK Plugin CI
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

The reusable SignalK plugin-CI workflow (`signalk-ci.yml`) only triggered on `push` to `main` and `workflow_dispatch`, so PRs didn't get plugin-CI coverage before merge. Add a `pull_request` trigger so it runs on PRs to `main` as well.

## Tested

- YAML validated; `prettier --check` passes.
- This PR itself exercises the new trigger — the Test SignalK Plugin CI workflow should now appear in its checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The SignalK plugin-CI workflow (`Test SignalK Plugin CI`) now triggers on pull requests targeting the `main` branch, in addition to existing `push` and manual (`workflow_dispatch`) triggers. This enables plugin CI coverage for pull requests before merge by invoking the reusable `SignalK/signalk-server` `plugin-ci.yml` workflow with `enable-armv7: false` and `enable-signalk-integration: true` configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dirkwa/signalk-charts-provider-simple/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->