### PR TITLE
chore(release): 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Patch release bumping the version to 2.0.3.

Includes since 2.0.2:
- #67: catalog download folder defaults based on the catalog label (avoids name collisions like the Dutch ENC `0.mbtiles`).
- #107: move the "(new)" folder highlight to a CSS class, harden `catalogLabelToFolder` against traversal/relative folder names, and update messaging — `signalk-container` is recommended (not required) since chart display works without it; convert banner/docs point at the plugin rather than a raw Docker/Podman socket.
- #108: run the SignalK plugin CI workflow on pull requests.