### PR TITLE
Make warnings for chart updates optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,13 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             '"all" uses every core for fastest single-bundle conversion; Signal K may be sluggish during a conversion.',
           enum: ['single-core', 'half', 'all'],
           default: 'half'
+        },
+        disableUpdateNotifications: {
+          type: 'boolean',
+          title: 'Disable chart update notifications',
+          description:
+            'When enabled, suppresses Signal K warn notifications about available chart catalog updates.',
+          default: false
         }
       }
     }),
@@ -2705,7 +2712,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         const updates = checkForUpdates();
         if (updates.length > 0) {
           app.debug(`Found ${updates.length} chart update(s) available from catalog`);
-          emitCatalogUpdateNotification(updates);
+          if (props.disableUpdateNotifications) {
+            app.debug('Chart update notifications are disabled; skipping notification emit');
+          } else {
+            emitCatalogUpdateNotification(updates);
+          }
         }
       } catch (error) {
         app.debug(

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,11 +133,15 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           enum: ['single-core', 'half', 'all'],
           default: 'half'
         },
+        _notificationsHeader: {
+          type: 'null',
+          title: 'Notifications',
+          description:
+            'When enabled, suppresses Signal K warn notifications about available chart catalog updates.'
+        },
         disableUpdateNotifications: {
           type: 'boolean',
           title: 'Disable chart update notifications',
-          description:
-            'When enabled, suppresses Signal K warn notifications about available chart catalog updates.',
           default: false
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,15 +133,17 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           enum: ['single-core', 'half', 'all'],
           default: 'half'
         },
+        // A `null`-typed field renders as a section header in the admin UI,
+        // visually separating this toggle from the CPU-budget setting above.
         _notificationsHeader: {
           type: 'null',
-          title: 'Notifications',
-          description:
-            'When enabled, suppresses Signal K warn notifications about available chart catalog updates.'
+          title: 'Notifications'
         },
         disableUpdateNotifications: {
           type: 'boolean',
           title: 'Disable chart update notifications',
+          description:
+            'When enabled, suppresses Signal K warn notifications about available chart catalog updates.',
           default: false
         }
       }

--- a/src/utils/plugin-config-schema.ts
+++ b/src/utils/plugin-config-schema.ts
@@ -15,7 +15,8 @@ export const CpuBudgetPresetSchema = Type.Union([
 // `chartPath` to `''` before checking.
 export const PluginConfigSchema = Type.Object({
   chartPath: Type.String(),
-  cpuBudget: Type.Optional(CpuBudgetPresetSchema)
+  cpuBudget: Type.Optional(CpuBudgetPresetSchema),
+  disableUpdateNotifications: Type.Optional(Type.Boolean())
 });
 
 export type CpuBudgetPreset = Static<typeof CpuBudgetPresetSchema>;


### PR DESCRIPTION
The NL charts update very frequently. Causing notifications in all of the apps.
Prefer not to receive warnings for chart updates. This PR allows to disable them.

Note the _notificationsHeader is not really doing anything beside making the config UI look bit more consistent.
without it, it looks like the setting belongs to the CPU settings due to the different rendering for checkboxes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

Adds a configuration option to disable chart update notifications so users can suppress frequent warnings when chart catalogs update.

The plugin schema now exposes:
- `disableUpdateNotifications`: optional boolean (default false) that, when true, suppresses Signal K warn notifications about available chart catalog updates and causes the code to log a debug message instead of emitting the warning.
- `_notificationsHeader`: a null-typed UI header that visually separates the Notifications section from the CPU budget setting; the explanatory help text for the notification setting is moved onto the `disableUpdateNotifications` toggle so the checkbox shows the help text.
- `cpuBudget`: optional CPU budget setting (existing preset enum) is available in the schema and PluginConfig type.

The plugin's periodic catalog update check conditionally emits the catalog update warning based on `disableUpdateNotifications`: it emits warnings when the setting is false or unset, and skips emitting them (logging debug) when the setting is true.

The exported `PluginConfig` type is updated to include the new optional fields.

## Files changed
- `src/index.ts`: +18/-1
- `src/utils/plugin-config-schema.ts`: +2/-1
<!-- end of auto-generated comment: release notes by coderabbit.ai -->