### PR TITLE
chore(release): 2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Patch release.

## Changes since 2.0.3

- #110 — Make chart-update warnings optional (`disableUpdateNotifications` config option), plus help-text/UI-header polish.

Tagging `v2.0.4` after merge triggers the publish workflow (GitHub release + npm publish).