### PR TITLE
fix(download): send chartName from the URL-download form

### DIFF
--- a/public/js/download-simple.ts
+++ b/public/js/download-simple.ts
@@ -79,6 +79,16 @@ function initDownloadInterface(): void {
         </div>
 
         <div class="form-group">
+          <label for="downloadChartName">Chart Name</label>
+          <input
+            type="text"
+            id="downloadChartName"
+            placeholder="e.g. NOAA Chesapeake Bay"
+            class="input-field"
+          />
+        </div>
+
+        <div class="form-group">
           <label for="downloadFolder">Target Folder</label>
           <select id="downloadFolder" class="input-field">
             <option value="/">/</option>
@@ -172,18 +182,25 @@ async function loadFoldersForDownload(): Promise<void> {
 
 async function startDownload(): Promise<void> {
   const urlInput = document.getElementById('downloadUrl') as HTMLInputElement | null;
+  const chartNameInput = document.getElementById('downloadChartName') as HTMLInputElement | null;
   const folderInput = document.getElementById('downloadFolder') as HTMLSelectElement | null;
   const statusDiv = document.getElementById('downloadStatus');
 
-  if (!urlInput || !folderInput || !statusDiv) {
+  if (!urlInput || !chartNameInput || !folderInput || !statusDiv) {
     return;
   }
 
   const url = urlInput.value.trim();
+  const chartName = chartNameInput.value.trim();
   const folder = folderInput.value;
 
   if (!url) {
     statusDiv.innerHTML = '<div class="error-message">Please enter a URL</div>';
+    return;
+  }
+
+  if (!chartName) {
+    statusDiv.innerHTML = '<div class="error-message">Please enter a chart name</div>';
     return;
   }
 
@@ -201,6 +218,7 @@ async function startDownload(): Promise<void> {
     const formData = new FormData();
     formData.append('url', url);
     formData.append('targetFolder', folder);
+    formData.append('chartName', chartName);
 
     const response = await fetch(`${DOWNLOAD_API_BASE}/download-chart-locker`, {
       method: 'POST',
@@ -215,6 +233,7 @@ async function startDownload(): Promise<void> {
     if (result.success) {
       statusDiv.innerHTML = `<div class="success-message">Download started! Job ID: ${downloadEscapeHtml(result.jobId ?? '')}</div>`;
       urlInput.value = '';
+      chartNameInput.value = '';
       setTimeout(() => {
         void loadActiveDownloads();
       }, 500);

--- a/public/js/download-simple.ts
+++ b/public/js/download-simple.ts
@@ -204,6 +204,15 @@ async function startDownload(): Promise<void> {
     return;
   }
 
+  // The server rejects these with a 400 (the chart name becomes a
+  // filename); catch them here too so the user gets immediate feedback
+  // instead of a round-trip. The server stays the authoritative guard.
+  if (chartName.includes('/') || chartName.includes('\\') || chartName.includes('..')) {
+    statusDiv.innerHTML =
+      '<div class="error-message">Chart name cannot contain / \\ or ..</div>';
+    return;
+  }
+
   // Basic URL validation
   try {
     new URL(url);

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ import { writeChartPathMarker } from './utils/path-marker.js';
 import { parsePluginConfig } from './utils/plugin-config-schema.js';
 import { Type } from '@sinclair/typebox';
 import { parseBody, parseShape } from './utils/rest-validation.js';
-import { isWithinBase, arePairWithinBase } from './utils/path-safety.js';
+import { isWithinBase, arePairWithinBase, validateChartName } from './utils/path-safety.js';
 import Busboy from 'busboy';
 import { DatabaseSync } from 'node:sqlite';
 
@@ -652,6 +652,16 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           return;
         }
         const { url: downloadUrl, targetFolder, chartName } = parsed;
+
+        // chartName becomes the on-disk filename in download-manager; a
+        // value like `../../foo` would write outside the quarantine dir.
+        const chartNameCheck = validateChartName(chartName);
+        if (!chartNameCheck.valid) {
+          res
+            .status(400)
+            .json({ success: false, error: `Invalid chart name: ${chartNameCheck.reason}` });
+          return;
+        }
 
         try {
           console.log(`Creating download job for: ${downloadUrl}`);
@@ -1917,6 +1927,17 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       }
       const { url, chartNumber, catalogFile, zipfileDatetime, targetFolder, minzoom, maxzoom } =
         body;
+
+      // chartNumber reaches download-manager as the on-disk filename for
+      // the direct-.mbtiles branch; guard it the same way as the locker
+      // route so a crafted catalog entry can't escape the quarantine dir.
+      const chartNumberCheck = validateChartName(chartNumber);
+      if (!chartNumberCheck.valid) {
+        res
+          .status(400)
+          .json({ success: false, error: `Invalid chart number: ${chartNumberCheck.reason}` });
+        return;
+      }
 
       const registryEntry = getCatalogRegistry().find((r) => r.file === catalogFile);
       const catalogCategory = registryEntry ? registryEntry.category : '';

--- a/src/utils/download-manager.ts
+++ b/src/utils/download-manager.ts
@@ -288,9 +288,17 @@ class DownloadManager extends EventEmitter {
               }
             }
 
-            const targetPath = path.join(job.targetDir, fileName);
+            // Strip any directory component before joining, the same way
+            // the ZIP branch above does. The route handlers already reject
+            // unsafe chartName/chartNumber with a 400, so this only fires
+            // for any future non-route caller — but it keeps the write
+            // inside targetDir regardless. Reuse the basenamed value for
+            // targetFiles so the cancel/cleanup unlink paths reference the
+            // file that was actually written.
+            const safeFileName = path.basename(fileName);
+            const targetPath = path.join(job.targetDir, safeFileName);
 
-            job.targetFiles.push(fileName);
+            job.targetFiles.push(safeFileName);
             this.emit('job-updated', job);
 
             const fileStream = fs.createWriteStream(targetPath);

--- a/src/utils/path-safety.ts
+++ b/src/utils/path-safety.ts
@@ -33,3 +33,31 @@ function stripTrailingSep(p: string): string {
 export function arePairWithinBase(a: string, b: string, basePath: string): boolean {
   return isWithinBase(a, basePath) && isWithinBase(b, basePath);
 }
+
+/**
+ * Validate a user-supplied chart name/number before it is used as a
+ * write filename. Same intent as the inline guard in `promoteQuarantine`,
+ * surfaced as a route-level check so the handlers can answer 400 instead
+ * of letting a bad name fail the download job asynchronously.
+ *
+ * The backslash check is deliberately stricter than POSIX: on the Linux
+ * server `\` is an ordinary byte and can't escape the dir, but chart
+ * files get copied to and served from Windows hosts, where `\` is a
+ * separator — rejecting it keeps a name portable rather than turning into
+ * a traversal once the file leaves this machine.
+ */
+export function validateChartName(name: string): { valid: boolean; reason?: string } {
+  if (name === '') {
+    return { valid: false, reason: 'must not be empty' };
+  }
+  if (path.basename(name) !== name || name.includes('\\')) {
+    return { valid: false, reason: 'must not contain path separators' };
+  }
+  if (name.includes('..')) {
+    return { valid: false, reason: 'must not contain ".."' };
+  }
+  if (path.isAbsolute(name)) {
+    return { valid: false, reason: 'must not be an absolute path' };
+  }
+  return { valid: true };
+}

--- a/test/path-safety.test.ts
+++ b/test/path-safety.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import path from 'node:path';
 
-import { isWithinBase, arePairWithinBase } from '../dist/utils/path-safety.js';
+import { isWithinBase, arePairWithinBase, validateChartName } from '../dist/utils/path-safety.js';
 
 const BASE = '/srv/charts';
 
@@ -57,5 +57,53 @@ describe('arePairWithinBase', () => {
 
   it('rejects if either escapes (target escapes)', () => {
     assert.strictEqual(arePairWithinBase(path.join(BASE, 'a.mbtiles'), '/etc/shadow', BASE), false);
+  });
+});
+
+describe('validateChartName', () => {
+  it('accepts an ordinary name', () => {
+    assert.strictEqual(validateChartName('Chesapeake').valid, true);
+  });
+
+  it('accepts a name with spaces', () => {
+    assert.strictEqual(validateChartName('NOAA Chesapeake Bay').valid, true);
+  });
+
+  it('accepts a unicode name with parentheses', () => {
+    assert.strictEqual(validateChartName('Île de Ré (2024)').valid, true);
+  });
+
+  it('accepts a name that already carries the .mbtiles suffix', () => {
+    assert.strictEqual(validateChartName('already.mbtiles').valid, true);
+  });
+
+  it('rejects an empty name', () => {
+    assert.strictEqual(validateChartName('').valid, false);
+  });
+
+  it('rejects a forward-slash traversal', () => {
+    assert.strictEqual(validateChartName('../../tmp/pwn').valid, false);
+  });
+
+  it('rejects an absolute path', () => {
+    assert.strictEqual(validateChartName('/etc/passwd').valid, false);
+  });
+
+  it('rejects a nested path even without traversal', () => {
+    assert.strictEqual(validateChartName('sub/chart').valid, false);
+  });
+
+  it('rejects a backslash so the name stays safe on Windows hosts', () => {
+    // POSIX treats `\` as an ordinary byte, but a chart copied to a
+    // Windows host would see it as a separator — reject it here.
+    assert.strictEqual(validateChartName('sub\\evil').valid, false);
+  });
+
+  it('rejects ".." on its own', () => {
+    assert.strictEqual(validateChartName('..').valid, false);
+  });
+
+  it('rejects an embedded ".." sequence', () => {
+    assert.strictEqual(validateChartName('a..b').valid, false);
   });
 });


### PR DESCRIPTION
## Bug

Using the **Download Charts from URL** tab, every download attempt returned **HTTP 400** (issue #112).

## Root cause

The server schema `DownloadChartLockerFields` in `src/index.ts` requires three fields — `url`, `targetFolder`, and `chartName` — but `startDownload()` in `public/js/download-simple.ts` only posted `url` and `targetFolder`. `parseShape` rejected the missing required field and the endpoint returned 400.

## Fix

**1. The reported bug** — add a **Chart Name** input to the Download-from-URL form, validate it is non-empty, and include it in the multipart body. The field is cleared alongside the URL on a successful start. Only `public/js/download-simple.ts` is tracked; the served `public/js/*.js` is gitignored and regenerated by `build:public`.

**2. Path-traversal hardening (review follow-up)** — while adding the field, review surfaced that `chartName` (and the catalog route's `chartNumber`) flow unsanitized into `download-manager` where they become the on-disk filename. A value like `../../foo` or an absolute path would write outside the job's quarantine dir; the existing `makeQuarantineDir` sanitization only protected the directory name, not the filename.

- New `validateChartName` in `src/utils/path-safety.ts` reuses the same basename / `..` / absolute-path guard `promoteQuarantine` already uses, plus an explicit backslash reject so names stay safe once charts are copied to or served from a Windows host.
- Both download routes (`/download-chart-locker` and `/catalog/download`) now answer **400** on a bad name **before** any filesystem side effect.
- Defense-in-depth: the direct-download write site basenames the filename the way the ZIP-extraction branch already does, and reuses that value for `targetFiles` so the cancel/cleanup unlink paths reference the file actually written.

A `TypeBox` regex pattern was considered and rejected: it both excluded legitimate names with spaces (e.g. `NOAA Chesapeake Bay`) and failed to reject a backslash, so the `path`-module validator is used instead.

Fixes #112

## Tested

- `npm run format` / `npm run format:check` — clean (Prettier + ESLint)
- `npm run build` (incl. `build:public`) — clean; confirmed the regenerated `download-simple.js` carries the new field and handler
- `npm test` — 266 pass, 0 fail (11 new `validateChartName` cases in `test/path-safety.test.ts`)
- End-to-end simulation of route guard + write site: `NOAA Chesapeake Bay` writes inside the quarantine dir; `../../../tmp/pwn`, `/etc/cron.d/x`, `sub\evil`, and `..` are each rejected with 400
- `cr review --plain` — no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

The download UI adds a "Chart Name" input and requires a non-empty chart name when starting a URL download. startDownload() trims and validates the chart name client-side (rejecting path separators '/', backslash '\', "..", and empty values), includes chartName in the multipart POST to /download-chart-locker, and clears the chart name input on successful job creation. Existing polling, cancel, and job rendering behavior remain unchanged.

A new validateChartName(name) helper in src/utils/path-safety.ts performs the same synchronous checks (empty, path separators including backslash, ".." segments, absolute paths). Server routes that accept chart names/numbers import and apply this guard (returning HTTP 400 with a structured JSON error on invalid names) before any filesystem operations. In download-manager, output filenames are normalized with path.basename(...) and job.targetFiles records the safe filename so write and cleanup operations cannot be influenced by directory components from the source name.

Tests add coverage for validateChartName, exercising accepted names (including spaces, unicode, and .mbtiles suffix) and rejected cases (empty, forward/backslash separators, nested or absolute paths, and ".." sequences).

## Impact

The UI now supplies the required chartName, preventing the HTTP 400 failures from the "Download Charts from URL" flow. Server-side validation and filename normalization harden against path-traversal and cross-platform separator issues so written files and cleanup use safe basenames and unsafe names are rejected before filesystem side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->