### PR TITLE
chore(release): 2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Patch release bundling the #112 fix and follow-up hardening (PR #113).

## Included since 2.0.4

- **fix(download): send chartName from the URL-download form** — adds the missing **Chart Name** input so the Download-from-URL tab no longer fails with HTTP 400 (fixes #112).
- **fix(download): reject chartName path traversal before writing** — `validateChartName` guards both download routes with a 400 before any filesystem write, plus a `path.basename` net at the write site, closing a path-traversal write primitive via `chartName`/`chartNumber`.
- **fix(download): mirror chart-name validation client-side** — immediate feedback for invalid names; the server stays the authoritative guard.

Bumps `package.json` to 2.0.5. Tagging `v2.0.5` after merge triggers `publish.yml`.