### PR TITLE
feat(charts): repair MBTiles dropped for missing bounds metadata

### DIFF
--- a/public/js/globals.d.ts
+++ b/public/js/globals.d.ts
@@ -64,6 +64,9 @@ declare global {
     showRenameDialog(chartPath: string, currentName: string, folder: string): void;
     closeRenameModal(event?: Event): void;
     confirmRename(): Promise<void>;
+    showRepairDialog(chartPath: string, name: string): void;
+    closeRepairModal(event?: Event): void;
+    confirmRepair(): Promise<void>;
     closeDuplicateModal(event?: Event): void;
     confirmDuplicate(): void;
     toggleChart(relativePath: string): Promise<void>;

--- a/public/js/manage-charts-enhanced.ts
+++ b/public/js/manage-charts-enhanced.ts
@@ -23,6 +23,27 @@ interface LocalChartsResponse {
   basePath?: string;
 }
 
+interface RepairableChart {
+  identifier: string;
+  filePath: string;
+  relativePath: string;
+  name: string;
+  reason: string;
+  hasTiles: boolean;
+  derived: {
+    bounds: number[];
+    minzoom: number;
+    maxzoom: number;
+    format: string;
+    tileSize?: number;
+  } | null;
+}
+
+interface RepairableChartsResponse {
+  repairable?: RepairableChart[];
+  basePath?: string;
+}
+
 interface ChartMetadata {
   name?: string;
   description?: string;
@@ -57,6 +78,7 @@ interface DuplicateWarningOptions {
 
 // State management
 let chartsData: ManageChart[] = [];
+let repairableData: RepairableChart[] = [];
 let foldersData: string[] = [];
 let basePath = '';
 let selectedFolder: string | null = null; // null means show all folders
@@ -69,6 +91,7 @@ let pendingDeleteConfirm: (() => void | Promise<void>) | null = null;
 let pendingDuplicateConfirm: (() => void | Promise<void>) | null = null;
 let pendingDuplicateCancel: (() => void) | null = null;
 let pendingRename: { chartPath: string; currentName: string; folder: string } | null = null;
+let pendingRepair: { chartPath: string; name: string } | null = null;
 
 window.handleManageTabActive = function (): void {
   void loadCharts();
@@ -96,6 +119,11 @@ async function loadCharts(silent = false): Promise<void> {
     foldersData = data.folders ?? [];
     basePath = data.basePath ?? '';
 
+    // Surface charts the loader dropped for missing bounds but that can be
+    // repaired. Tolerant of failure — a problem here must not break the
+    // normal listing.
+    repairableData = await fetchRepairableCharts();
+
     renderChartsUI();
     setupAutoRefresh();
   } catch (error) {
@@ -111,6 +139,95 @@ async function loadCharts(silent = false): Promise<void> {
       `;
     }
   }
+}
+
+async function fetchRepairableCharts(): Promise<RepairableChart[]> {
+  try {
+    const response = await fetch(`${MANAGE_API_BASE}/repairable-charts`);
+    if (!response.ok) {
+      return [];
+    }
+    const data = (await response.json()) as RepairableChartsResponse;
+    return data.repairable ?? [];
+  } catch {
+    return [];
+  }
+}
+
+function renderRepairableSection(): string {
+  if (repairableData.length === 0) {
+    return '';
+  }
+
+  let html = `
+    <div class="repairable-section" style="margin-bottom: 24px; border: 1px solid var(--border-color); border-radius: 8px; padding: 16px; background: rgba(255, 193, 7, 0.06);">
+      <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+        ${window.getIcon('warning')}
+        <strong>Charts needing repair (${repairableData.length})</strong>
+      </div>
+      <p style="font-size: 0.9rem; color: var(--text-secondary); margin: 0 0 12px;">
+        These MBTiles have valid tiles but are missing the <code>bounds</code> metadata, so they
+        aren't served. Repair writes the missing metadata (derived from the tiles) into the file.
+      </p>
+      <div class="chart-${viewMode}">`;
+
+  repairableData.forEach((rc) => {
+    html += renderRepairableCard(rc);
+  });
+
+  html += `
+      </div>
+    </div>`;
+  return html;
+}
+
+function renderRepairableCard(rc: RepairableChart): string {
+  const attrPath = manageEscapeAttr(rc.relativePath);
+  const attrName = manageEscapeAttr(rc.name);
+  const d = rc.derived;
+  const boundsStr = d ? d.bounds.map((n) => n.toFixed(4)).join(', ') : 'unknown';
+  const zoomStr = d ? `${d.minzoom}–${d.maxzoom}` : 'unknown';
+  const formatStr = d ? d.format : 'unknown';
+  const tileSizeNote =
+    d && d.tileSize !== undefined && d.tileSize !== 256
+      ? `<div class="chart-meta-item" style="color: var(--accent-warning, #c77700);">
+           <span class="meta-label">${window.getIcon('warning')} Tile size:</span>
+           <span>${d.tileSize}px (may render mis-scaled in Freeboard)</span>
+         </div>`
+      : '';
+
+  return `
+    <div class="chart-card repairable-card">
+      <div class="chart-card-header">
+        <div class="chart-title" title="${attrName}">${manageEscapeHtml(rc.name)}</div>
+      </div>
+      <div class="chart-card-body">
+        <div class="chart-meta-item">
+          <span class="meta-label">${window.getIcon('folder')} Path:</span>
+          <span>${manageEscapeHtml(rc.relativePath)}</span>
+        </div>
+        <div class="chart-meta-item">
+          <span class="meta-label">Bounds:</span>
+          <span>${manageEscapeHtml(boundsStr)}</span>
+        </div>
+        <div class="chart-meta-item">
+          <span class="meta-label">Zoom:</span>
+          <span>${manageEscapeHtml(zoomStr)}</span>
+        </div>
+        <div class="chart-meta-item">
+          <span class="meta-label">Format:</span>
+          <span>${manageEscapeHtml(formatStr)}</span>
+        </div>
+        ${tileSizeNote}
+      </div>
+      <div class="chart-card-actions">
+        <button class="btn btn-primary" onclick="showRepairDialog('${attrPath}', '${attrName}')" ${
+          d ? '' : 'disabled'
+        }>
+          Repair
+        </button>
+      </div>
+    </div>`;
 }
 
 function setupAutoRefresh(): void {
@@ -188,7 +305,14 @@ function renderChartsUI(): void {
 
   if (chartsData.length === 0) {
     selectedFolder = '/';
-    manageOutput.innerHTML = `
+    // Repairable charts have no card in the normal grid (they're dropped by
+    // the loader), so when there are no served charts at all we still show
+    // them above the welcome state — otherwise the user's only chart would
+    // be invisible with no way to fix it.
+    const repairableHtml = renderRepairableSection();
+    manageOutput.innerHTML =
+      repairableHtml +
+      `
       <div class="empty-state">
         <div class="empty-state-icon">
           <svg viewBox="0 0 24 24" width="80" height="80" fill="none" stroke="currentColor" stroke-width="2">
@@ -248,6 +372,10 @@ function renderChartsUI(): void {
       </div>
     </div>
   `;
+
+  // Repairable charts (dropped by the loader for missing bounds) — shown
+  // above the served grid so the user can fix them.
+  html += renderRepairableSection();
 
   // Folder navigation
   if (foldersData.length > 1) {
@@ -1283,6 +1411,87 @@ async function confirmRename(): Promise<void> {
   }
 }
 
+function showRepairDialog(chartPath: string, name: string): void {
+  const rc = repairableData.find((r) => r.relativePath === chartPath);
+  const d = rc?.derived ?? null;
+  const boundsStr = d ? d.bounds.map((n) => n.toFixed(4)).join(', ') : 'unknown';
+  const tileSizeWarning =
+    d && d.tileSize !== undefined && d.tileSize !== 256
+      ? `<div class="delete-modal-warning">${window.getIcon('warning')} This chart uses ${d.tileSize}px tiles. Freeboard-SK renders charts at 256px and may show it mis-scaled until Freeboard adds tile-size support.</div>`
+      : '';
+
+  const modalHTML = `
+    <div class="delete-modal-overlay" id="repairModal" onclick="closeRepairModal(event)">
+      <div class="delete-modal" onclick="event.stopPropagation()">
+        <div class="delete-modal-header">
+          <div class="delete-modal-icon" style="color: var(--accent-primary);">
+            ${window.getIcon('warning')}
+          </div>
+          <h3>Repair Chart</h3>
+        </div>
+        <div class="delete-modal-body">
+          <p style="margin-bottom: 12px;">
+            Write the missing metadata into <strong>${manageEscapeHtml(name)}</strong> so it can be served?
+          </p>
+          <p style="font-size: 0.9rem; color: var(--text-secondary); margin: 0 0 8px;">
+            The following will be written (derived from the chart's tiles; existing values are kept):
+          </p>
+          <ul style="font-size: 0.9rem; color: var(--text-secondary); margin: 0 0 8px; padding-left: 20px;">
+            <li>bounds: ${manageEscapeHtml(boundsStr)}</li>
+            <li>zoom: ${d ? `${d.minzoom}–${d.maxzoom}` : 'unknown'}</li>
+            <li>format: ${manageEscapeHtml(d ? d.format : 'unknown')}</li>
+          </ul>
+          ${tileSizeWarning}
+        </div>
+        <div class="delete-modal-actions">
+          <button class="btn btn-secondary" onclick="closeRepairModal()">Cancel</button>
+          <button class="btn btn-primary" onclick="confirmRepair()">Repair</button>
+        </div>
+      </div>
+    </div>
+  `;
+
+  pendingRepair = { chartPath, name };
+  document.body.insertAdjacentHTML('beforeend', modalHTML);
+}
+
+function closeRepairModal(event?: Event): void {
+  if (event && (event.target as HTMLElement).id !== 'repairModal') {
+    return;
+  }
+  document.getElementById('repairModal')?.remove();
+  pendingRepair = null;
+}
+
+async function confirmRepair(): Promise<void> {
+  if (!pendingRepair) {
+    return;
+  }
+  const { chartPath, name } = pendingRepair;
+  closeRepairModal();
+
+  try {
+    const response = await fetch(`${MANAGE_API_BASE}/repair-chart`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chartPath })
+    });
+
+    if (response.ok) {
+      document.dispatchEvent(new CustomEvent('charts-changed'));
+      void loadCharts();
+      showRepairNotification(name);
+    } else {
+      const errorText = await response.text();
+      showErrorNotification(`Failed to repair chart: ${errorText}`);
+    }
+  } catch (error) {
+    console.error('Error repairing chart:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    showErrorNotification('Error repairing chart: ' + message);
+  }
+}
+
 function deleteFolder(folder: string): void {
   const folderHasCharts = chartsData.some((chart) => chart.folder === folder);
 
@@ -1487,6 +1696,23 @@ function showRenameNotification(oldName: string, newName: string): void {
     </div>
   `;
   fadeOutNotification('renameNotification', html);
+}
+
+function showRepairNotification(name: string): void {
+  const html = `
+    <div class="notification-toast" id="repairNotification">
+      <div class="notification-content">
+        <div class="notification-icon success">
+          ${window.getIcon('checkmark')}
+        </div>
+        <div class="notification-text">
+          <div class="notification-title">Chart Repaired</div>
+          <div class="notification-message">${manageEscapeHtml(name)} is now served</div>
+        </div>
+      </div>
+    </div>
+  `;
+  fadeOutNotification('repairNotification', html);
 }
 
 function showUploadNotification(fileCount: number): void {
@@ -1798,6 +2024,9 @@ window.confirmCreateFolder = confirmCreateFolder;
 window.showRenameDialog = showRenameDialog;
 window.closeRenameModal = closeRenameModal;
 window.confirmRename = confirmRename;
+window.showRepairDialog = showRepairDialog;
+window.closeRepairModal = closeRepairModal;
+window.confirmRepair = confirmRepair;
 window.deleteFolder = deleteFolder;
 window.closeDeleteModal = closeDeleteModal;
 window.confirmDelete = confirmDelete;

--- a/src/charts-loader.ts
+++ b/src/charts-loader.ts
@@ -2,7 +2,14 @@ import path from 'path';
 import { promises as fs } from 'fs';
 import { parseStringPromise } from 'xml2js';
 import { open as openMbtiles } from './utils/mbtiles-reader.js';
-import type { ChartProvider, TilemapXml, VectorLayer } from './types.js';
+import type { MBTilesReader } from './utils/mbtiles-reader.js';
+import type {
+  ChartProvider,
+  RepairableChart,
+  RepairableDerived,
+  TilemapXml,
+  VectorLayer
+} from './types.js';
 
 const KNOWN_CHART_TYPES = new Set(['tilelayer', 's-57', 'mapstylejson', 'tilejson', 'wms', 'wmts']);
 
@@ -76,6 +83,12 @@ async function openMbtilesFile(file: string, filename: string): Promise<ChartPro
 
     const vectorLayers = metadata.vector_layers ? parseVectorLayers(metadata.vector_layers) : [];
 
+    // Advertise a non-256 tile size so clients build the raster source on
+    // the right grid. We only read PNG dimensions (getTilePixelSize) and
+    // only carry the field when it isn't the conventional 256, keeping the
+    // common case's descriptor unchanged.
+    const tileSize = readTileSize(metadata.format, reader);
+
     const data: ChartProvider = {
       _fileFormat: 'mbtiles',
       _filePath: file,
@@ -91,6 +104,7 @@ async function openMbtilesFile(file: string, filename: string): Promise<ChartPro
       format: metadata.format ?? 'png',
       type: resolveChartType(metadata.type),
       scale: parseInt(metadata.scale ?? '', 10) || 250000,
+      ...(tileSize !== undefined ? { tileSize } : {}),
 
       v1: {
         tilemapUrl: `~tilePath~/${identifier}/{z}/{x}/{y}`,
@@ -99,7 +113,8 @@ async function openMbtilesFile(file: string, filename: string): Promise<ChartPro
 
       v2: {
         url: `~tilePath~/${identifier}/{z}/{x}/{y}`,
-        layers: vectorLayers
+        layers: vectorLayers,
+        ...(tileSize !== undefined ? { tileSize } : {})
       }
     };
     return data;
@@ -229,4 +244,133 @@ async function parseMetadataJson(metadataJsonPath: string): Promise<Partial<Char
 function parseIntIfNotUndefined(val: unknown): number | undefined {
   const parsed = parseInt(String(val));
   return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * Detect a non-default raster tile size for the chart descriptor. Returns a
+ * value only for raster formats (png/jpg/webp or unset, which defaults to
+ * png) when the detected size isn't the conventional 256; vector (pbf) and
+ * 256px charts get undefined so the descriptor stays minimal.
+ */
+function readTileSize(format: string | undefined, reader: MBTilesReader): number | undefined {
+  if (format === 'pbf') {
+    return undefined;
+  }
+  const size = reader.getTilePixelSize();
+  if (size === undefined || size === 256) {
+    return undefined;
+  }
+  return size;
+}
+
+/**
+ * Find MBTiles that `findCharts` drops because `metadata.bounds` is missing
+ * but that have a valid tile pyramid — i.e. they can be repaired by
+ * deriving the missing metadata from the tiles table. Directories and
+ * already-loadable charts are not returned. The returned `relativePath` is
+ * the wire id the repair route expects (mirrors the rename flow's
+ * `chartPath`).
+ */
+export async function findRepairableCharts(chartBaseDir: string): Promise<RepairableChart[]> {
+  try {
+    const results = await findRepairableRecursive(chartBaseDir, chartBaseDir);
+    return results.filter((c): c is RepairableChart => c !== null);
+  } catch (err) {
+    console.error(
+      `Error scanning for repairable charts in ${chartBaseDir}: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return [];
+  }
+}
+
+async function findRepairableRecursive(
+  currentDir: string,
+  baseDir: string
+): Promise<(RepairableChart | null)[]> {
+  const files = await fs.readdir(currentDir, { withFileTypes: true });
+  const results: (RepairableChart | null)[][] = [];
+
+  for (const file of files) {
+    const filePath = path.resolve(currentDir, file.name);
+
+    if (file.name.match(/\.mbtiles$/i)) {
+      results.push([await inspectMbtilesForRepair(filePath, file.name, baseDir)]);
+    } else if (file.isDirectory()) {
+      if (file.name.startsWith('.') || file.name === 'node_modules') {
+        results.push([]);
+        continue;
+      }
+      results.push(await findRepairableRecursive(filePath, baseDir));
+    } else {
+      results.push([]);
+    }
+  }
+
+  return results.flat();
+}
+
+/**
+ * Mirror of `openMbtilesFile` with the load gate inverted: a chart is
+ * repairable when its metadata table is non-empty, `bounds` is missing, and
+ * it has tiles to derive bounds from. Anything that already loads (has
+ * bounds) or can't be fixed (no tiles) returns null. The read-only reader is
+ * always closed before returning.
+ */
+async function inspectMbtilesForRepair(
+  file: string,
+  filename: string,
+  baseDir: string
+): Promise<RepairableChart | null> {
+  let reader: MBTilesReader | null = null;
+  try {
+    reader = await openMbtiles(file);
+    const metadata = reader.getInfo();
+
+    // Already loadable, or no metadata at all — not our case.
+    if (
+      !metadata ||
+      Object.keys(metadata).length === 0 ||
+      metadata.bounds !== undefined ||
+      !reader.hasTiles()
+    ) {
+      return null;
+    }
+
+    const bounds = reader.deriveBoundsFromTiles();
+    const zoom = reader.getZoomRangeFromTiles();
+    if (!bounds || !zoom) {
+      // Tiles present but unreadable extent — can't synthesize bounds.
+      return null;
+    }
+
+    const format = reader.sniffFormatFromTiles() ?? metadata.format ?? 'png';
+    const tileSize = readTileSize(format, reader);
+
+    const identifier = filename.replace(/\.mbtiles$/i, '');
+    const derived: RepairableDerived = {
+      bounds,
+      minzoom: zoom.minzoom,
+      maxzoom: zoom.maxzoom,
+      format,
+      ...(tileSize !== undefined ? { tileSize } : {})
+    };
+
+    return {
+      identifier,
+      filePath: file,
+      relativePath: path.relative(baseDir, file),
+      name: metadata.name ?? metadata.id ?? identifier,
+      reason: 'missing_bounds',
+      hasTiles: true,
+      derived
+    };
+  } catch (e) {
+    console.error(
+      `Error inspecting chart for repair ${file}`,
+      e instanceof Error ? e.message : String(e)
+    );
+    return null;
+  } finally {
+    reader?.close();
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import https from 'https';
 import type { Plugin, Path } from '@signalk/server-api';
 import { SKVersion } from '@signalk/server-api';
-import { findCharts } from './charts-loader.js';
+import { findCharts, findRepairableCharts } from './charts-loader.js';
 import { scanChartsRecursively, scanAllFolders } from './utils/file-scanner.js';
 import { initChartState, isChartEnabled, setChartEnabled } from './utils/chart-state.js';
 import { downloadManager } from './utils/download-manager.js';
@@ -42,7 +42,8 @@ import {
   sweepStaleQuarantineDirs
 } from './utils/quarantine.js';
 import { cleanCatalogTitle } from './utils/catalog-title.js';
-import { setMbtilesDisplayName } from './utils/mbtiles-metadata.js';
+import { setMbtilesDisplayName, repairMbtilesMetadata } from './utils/mbtiles-metadata.js';
+import { open as openMbtilesReader } from './utils/mbtiles-reader.js';
 import {
   initRncConverter,
   processRncZip,
@@ -606,6 +607,10 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
   const ChartMetadataBody = Type.Object({
     name: Type.String({ minLength: 1 })
+  });
+
+  const RepairChartBody = Type.Object({
+    chartPath: Type.String({ minLength: 1, pattern: '\\.mbtiles$' })
   });
 
   // Multipart/header field schemas. Same domain rules as the JSON-body
@@ -1262,6 +1267,121 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           .status(500)
           .send(
             'Error renaming chart: ' + (error instanceof Error ? error.message : String(error))
+          );
+      }
+    });
+
+    // List MBTiles that the loader dropped for missing `metadata.bounds`
+    // but that have a valid tile pyramid — the Manage UI surfaces these
+    // with a Repair action. Mirrors /local-charts' base-path resolution and
+    // error shape.
+    router.get('/repairable-charts', async (_req: Request, res: Response) => {
+      try {
+        const basePath = props.chartPath || defaultChartsPath;
+        const repairable = await findRepairableCharts(basePath);
+        res.json({ repairable, basePath });
+      } catch (error) {
+        console.error('Error listing repairable charts:', error);
+        res.status(500).send('Error listing repairable charts');
+      }
+    });
+
+    // Derive the missing metadata from the tile pyramid and write it into
+    // the file so the chart loads. Mirrors /rename-chart: path-safety guard,
+    // existence check, metadata write, refresh + delta. The read-only reader
+    // used to derive values is closed before the writer opens.
+    router.post('/repair-chart', async (req: Request, res: Response) => {
+      const body = parseBody(RepairChartBody, req, res);
+      if (!body) {
+        return;
+      }
+      const { chartPath: chartPathBody } = body;
+      app.debug(`Repair chart request: chartPath=${chartPathBody}`);
+
+      try {
+        const basePath = props.chartPath || defaultChartsPath;
+        const sourcePath = path.join(basePath, chartPathBody);
+
+        if (!isWithinBase(sourcePath, basePath)) {
+          res.status(403).send('Access denied: Invalid path');
+          return;
+        }
+
+        if (!fs.existsSync(sourcePath)) {
+          app.error(`Chart not found at: ${sourcePath}`);
+          res.status(404).send('Chart not found');
+          return;
+        }
+
+        // Re-derive from a fresh read-only reader, then close it before the
+        // writer opens — two handles on one sqlite file race on the lock.
+        const reader = await openMbtilesReader(sourcePath);
+        let derived;
+        try {
+          if (!reader.hasTiles()) {
+            res.status(422).json({ error: 'Chart has no tiles — cannot derive metadata' });
+            return;
+          }
+          const bounds = reader.deriveBoundsFromTiles();
+          const zoom = reader.getZoomRangeFromTiles();
+          if (!bounds || !zoom) {
+            res.status(422).json({ error: 'Could not derive bounds from tiles' });
+            return;
+          }
+          const format = reader.sniffFormatFromTiles() ?? reader.getInfo().format ?? 'png';
+          const tileSize = format === 'pbf' ? undefined : reader.getTilePixelSize();
+          derived = {
+            bounds,
+            minzoom: zoom.minzoom,
+            maxzoom: zoom.maxzoom,
+            format,
+            ...(tileSize !== undefined && tileSize !== 256 ? { tileSize } : {})
+          };
+        } finally {
+          reader.close();
+        }
+
+        const result = await repairMbtilesMetadata(sourcePath, derived, {
+          onMessage: (m) => app.debug(`repair-chart: ${m}`)
+        });
+        if (!result.ok) {
+          console.warn(
+            `[charts-provider] WARNING: ${result.message} (${path.basename(sourcePath)})`
+          );
+          res.status(500).json({ error: result.message });
+          return;
+        }
+
+        if (derived.tileSize !== undefined && derived.tileSize !== 256) {
+          console.warn(
+            `[charts-provider] ${path.basename(sourcePath)} uses ${derived.tileSize}px tiles; ` +
+              `Freeboard-SK renders charts at 256px and needs its own tileSize support to ` +
+              `display this correctly.`
+          );
+        }
+
+        await refreshChartProviders();
+
+        const chartId = path.basename(chartPathBody).replace(/\.mbtiles$/, '');
+        if (chartProviders[chartId]) {
+          const chartData = sanitizeProvider(chartProviders[chartId], 2);
+          emitChartDelta(chartId, chartData);
+        }
+
+        res.status(200).json({
+          success: true,
+          chartId,
+          written: result.written,
+          skipped: result.skipped
+        });
+      } catch (error) {
+        app.error(
+          'Error repairing chart: ' + (error instanceof Error ? error.message : String(error))
+        );
+        res
+          .status(500)
+          .send(
+            'Error repairing chart: ' + (error instanceof Error ? error.message : String(error))
           );
       }
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -493,6 +493,14 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           .map((c) => c._filePath)
           .filter(Boolean)
       );
+      // Repairable charts (valid tiles, missing metadata.bounds) are
+      // deliberately excluded from findCharts(), so they'd otherwise be
+      // unlinked here as "invalid" — destroying the very files the repair
+      // flow exists to fix. Treat them as valid so the sweep skips them.
+      const repairable = await findRepairableCharts(chartPath);
+      for (const rc of repairable) {
+        validPaths.add(rc.filePath);
+      }
       for (const file of allFiles) {
         if (file.name.endsWith('.mbtiles') && !validPaths.has(file.path)) {
           console.log(`[charts-provider] Removing invalid .mbtiles file: ${file.name}`);
@@ -610,7 +618,10 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
   });
 
   const RepairChartBody = Type.Object({
-    chartPath: Type.String({ minLength: 1, pattern: '\\.mbtiles$' })
+    // Case-insensitive: discovery matches `.mbtiles` case-insensitively, so
+    // a hand-copied FOO.MBTILES can appear in the repair list and must pass
+    // here too.
+    chartPath: Type.String({ minLength: 1, pattern: '\\.[mM][bB][tT][iI][lL][eE][sS]$' })
   });
 
   // Multipart/header field schemas. Same domain rules as the JSON-body
@@ -1362,7 +1373,9 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
         await refreshChartProviders();
 
-        const chartId = path.basename(chartPathBody).replace(/\.mbtiles$/, '');
+        // Case-insensitive strip so a repaired FOO.MBTILES still matches the
+        // chartProviders key the loader derives (also case-insensitive).
+        const chartId = path.basename(chartPathBody).replace(/\.mbtiles$/i, '');
         if (chartProviders[chartId]) {
           const chartData = sanitizeProvider(chartProviders[chartId], 2);
           emitChartDelta(chartId, chartData);

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,15 @@ export interface ChartV1Data {
 export interface ChartV2Data {
   url: string;
   layers: string[];
+  /**
+   * Tile edge length in pixels (256 or 512). Omitted means the
+   * conventional 256. Clients that build raster sources (Freeboard-SK's
+   * OpenLayers XYZ, MapLibre raster) need this to address 512px tiles on
+   * the correct grid; without it a 512px chart renders mis-scaled.
+   * Carried on the v2 descriptor only — that's the normalized shape
+   * Signal K v2 consumers read.
+   */
+  tileSize?: number;
 }
 
 export type ChartFileFormat = 'mbtiles' | 'directory';
@@ -53,6 +62,8 @@ export interface ChartProvider {
   format: string;
   type: ChartType;
   scale: number;
+  /** Detected tile pixel size (256/512) when known; see ChartV2Data.tileSize. */
+  tileSize?: number;
 
   v1: ChartV1Data;
   v2: ChartV2Data;
@@ -72,6 +83,40 @@ export interface SanitizedChart {
   chartLayers?: string[];
   url?: string;
   layers?: string[];
+  tileSize?: number;
+}
+
+// ---- Repairable charts ----
+// Valid MBTiles that `findCharts` drops because `metadata.bounds` is
+// missing (charts-loader's load gate). They have tiles but no usable
+// metadata, so they never enter `chartProviders` and have no card in the
+// Manage UI. `findRepairableCharts` surfaces them separately so the UI can
+// offer a Repair action that derives the missing metadata from the tile
+// pyramid and writes it back into the file.
+
+export type RepairReason = 'missing_bounds';
+
+export interface RepairableDerived {
+  bounds: number[];
+  minzoom: number;
+  maxzoom: number;
+  format: string;
+  tileSize?: number;
+}
+
+export interface RepairableChart {
+  /** Filename without `.mbtiles` — the `chartProviders` key once repaired. */
+  identifier: string;
+  /** Absolute path on disk. */
+  filePath: string;
+  /** Path relative to the chart base — the wire id the repair route POSTs. */
+  relativePath: string;
+  /** `metadata.name` if present, else the identifier. */
+  name: string;
+  reason: RepairReason;
+  hasTiles: boolean;
+  /** What repair would write, also shown as a preview in the UI. */
+  derived: RepairableDerived | null;
 }
 
 // ---- MBTiles Metadata ----

--- a/src/utils/mbtiles-metadata.ts
+++ b/src/utils/mbtiles-metadata.ts
@@ -293,20 +293,27 @@ export async function repairMbtilesMetadata(
         inTransaction = true;
 
         // Snapshot existing names so we only fill what's absent or empty.
-        const existing = new Map<string, string>();
+        // The metadata table has no UNIQUE constraint on `name` (see the
+        // patchS57Mbtiles note above), so a key can legitimately have
+        // several rows — including a mix of empty and non-empty values.
+        // Treat a name as "present" when ANY row for it is non-empty, so a
+        // stray empty duplicate doesn't trick us into inserting a second
+        // value row.
+        const existingNonEmpty = new Set<string>();
         for (const r of db.prepare('SELECT name, value FROM metadata').all() as {
           name: string;
           value: string | null;
         }[]) {
-          existing.set(r.name, r.value ?? '');
+          if (r.value !== null && r.value !== '') {
+            existingNonEmpty.add(r.name);
+          }
         }
 
         const written: string[] = [];
         const skipped: string[] = [];
         const insert = db.prepare('INSERT INTO metadata (name, value) VALUES (?, ?)');
         for (const c of candidates) {
-          const present = existing.get(c.name);
-          if (present !== undefined && present !== '') {
+          if (existingNonEmpty.has(c.name)) {
             skipped.push(c.name);
             continue;
           }
@@ -314,13 +321,18 @@ export async function repairMbtilesMetadata(
           written.push(c.name);
         }
 
-        // Verify-after-write: every name we wrote must read back equal.
+        // Verify-after-write: read the LAST row written for each name
+        // (ORDER BY rowid DESC) so the check is deterministic even when
+        // older duplicate rows exist for the same key.
         let verifyError = '';
+        const verify = db.prepare(
+          'SELECT value FROM metadata WHERE name = ? ORDER BY rowid DESC LIMIT 1'
+        );
         for (const c of candidates) {
           if (!written.includes(c.name)) {
             continue;
           }
-          const row = db.prepare('SELECT value FROM metadata WHERE name = ?').get(c.name);
+          const row = verify.get(c.name);
           const got =
             typeof row === 'object' && row !== null && 'value' in row ? String(row.value) : null;
           if (got !== c.value) {

--- a/src/utils/mbtiles-metadata.ts
+++ b/src/utils/mbtiles-metadata.ts
@@ -26,7 +26,7 @@ export interface PatchResult {
   message: string;
 }
 
-interface PatchOptions {
+export interface PatchOptions {
   /** Sleep callback for the retry — defaults to a real setTimeout. Tests inject. */
   sleep?: (ms: number) => Promise<void>;
   /** Retry delay in ms (default 500). */
@@ -194,6 +194,181 @@ export async function patchS57Mbtiles(
     name: null,
     attempts: 2,
     message: lastError || 'MBTiles metadata patch failed (unknown reason)'
+  };
+}
+
+export interface RepairDerived {
+  /** `[minLon, minLat, maxLon, maxLat]`, written as a comma string. */
+  bounds: number[];
+  minzoom: number;
+  maxzoom: number;
+  format: string;
+  /** 256/512 when known; omitted leaves no `tileSize` row. */
+  tileSize?: number;
+}
+
+export interface RepairResult {
+  ok: boolean;
+  /** Metadata names actually inserted (were absent). */
+  written: string[];
+  /** Metadata names left untouched because a non-empty row already existed. */
+  skipped: string[];
+  attempts: number;
+  message: string;
+}
+
+/**
+ * Backfill the metadata an MBTiles needs to load when a valid tile pyramid
+ * was imported without it. The loader drops any chart whose
+ * `metadata.bounds` is missing; this writes `bounds` (plus
+ * `minzoom`/`maxzoom`/`format`/`tileSize`) derived from the tiles table so
+ * the chart loads and serves.
+ *
+ * Only-fill-absent: a metadata name is written only when no non-empty row
+ * for it already exists. A chart that has, say, a correct `minzoom` but a
+ * missing `bounds` keeps its `minzoom`. We never DELETE — unlike the S-57
+ * patcher, repair must not clobber values the file already carries.
+ *
+ * Same atomicity and resilience as patchS57Mbtiles: a single transaction,
+ * verify-after-write inside it, ROLLBACK on mismatch, and one retry after
+ * `retryDelayMs` to ride out a transient sqlite lock. Best-effort: never
+ * throws. The caller must close any read-only reader on this file before
+ * calling — node:sqlite opens its own writable handle here.
+ */
+export async function repairMbtilesMetadata(
+  outputPath: string,
+  derived: RepairDerived,
+  options: PatchOptions = {}
+): Promise<RepairResult> {
+  const sleeper = options.sleep ?? sleep;
+  const retryMs = options.retryDelayMs ?? DEFAULT_RETRY_MS;
+  const log = (m: string): void => {
+    try {
+      options.onMessage?.(m);
+    } catch {
+      /* best-effort logging */
+    }
+  };
+
+  if (!fs.existsSync(outputPath)) {
+    const message = `MBTiles file does not exist: ${outputPath}`;
+    log(message);
+    return { ok: false, written: [], skipped: [], attempts: 0, message };
+  }
+
+  const sqlite = loadSqlite();
+  if (!sqlite.ok) {
+    log(sqlite.reason);
+    return { ok: false, written: [], skipped: [], attempts: 0, message: sqlite.reason };
+  }
+
+  // The full candidate set, in a stable order. tileSize is only a candidate
+  // when supplied (it's optional metadata).
+  const candidates: { name: string; value: string }[] = [
+    { name: 'bounds', value: derived.bounds.join(',') },
+    { name: 'minzoom', value: String(derived.minzoom) },
+    { name: 'maxzoom', value: String(derived.maxzoom) },
+    { name: 'format', value: derived.format }
+  ];
+  if (derived.tileSize !== undefined) {
+    candidates.push({ name: 'tilesize', value: String(derived.tileSize) });
+  }
+
+  let lastError = '';
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    if (attempt === 2) {
+      log(`Retrying MBTiles metadata repair after ${retryMs}ms…`);
+      try {
+        await sleeper(retryMs);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log(`Sleep before retry threw (continuing): ${msg}`);
+      }
+    }
+    try {
+      const db = new sqlite.DatabaseSync(outputPath);
+      let inTransaction = false;
+      try {
+        db.exec('BEGIN TRANSACTION');
+        inTransaction = true;
+
+        // Snapshot existing names so we only fill what's absent or empty.
+        const existing = new Map<string, string>();
+        for (const r of db.prepare('SELECT name, value FROM metadata').all() as {
+          name: string;
+          value: string | null;
+        }[]) {
+          existing.set(r.name, r.value ?? '');
+        }
+
+        const written: string[] = [];
+        const skipped: string[] = [];
+        const insert = db.prepare('INSERT INTO metadata (name, value) VALUES (?, ?)');
+        for (const c of candidates) {
+          const present = existing.get(c.name);
+          if (present !== undefined && present !== '') {
+            skipped.push(c.name);
+            continue;
+          }
+          insert.run(c.name, c.value);
+          written.push(c.name);
+        }
+
+        // Verify-after-write: every name we wrote must read back equal.
+        let verifyError = '';
+        for (const c of candidates) {
+          if (!written.includes(c.name)) {
+            continue;
+          }
+          const row = db.prepare('SELECT value FROM metadata WHERE name = ?').get(c.name);
+          const got =
+            typeof row === 'object' && row !== null && 'value' in row ? String(row.value) : null;
+          if (got !== c.value) {
+            verifyError = `repair verify failed for '${c.name}': got '${got}', wanted '${c.value}'`;
+            break;
+          }
+        }
+
+        if (verifyError) {
+          db.exec('ROLLBACK');
+          inTransaction = false;
+          lastError = verifyError;
+          log(lastError);
+          continue;
+        }
+
+        db.exec('COMMIT');
+        inTransaction = false;
+        const message =
+          `Repaired MBTiles metadata: wrote [${written.join(', ') || 'nothing'}]` +
+          (skipped.length ? `, kept existing [${skipped.join(', ')}]` : '') +
+          (attempt === 2 ? ' (on retry)' : '');
+        log(message);
+        return { ok: true, written, skipped, attempts: attempt, message };
+      } finally {
+        if (inTransaction) {
+          try {
+            db.exec('ROLLBACK');
+          } catch {
+            /* already committed or no transaction */
+          }
+        }
+        db.close();
+      }
+    } catch (err) {
+      lastError = `MBTiles metadata repair failed (attempt ${attempt}/2): ${
+        err instanceof Error ? err.message : String(err)
+      }`;
+      log(lastError);
+    }
+  }
+
+  return {
+    ok: false,
+    written: [],
+    skipped: [],
+    attempts: 2,
+    message: lastError || 'MBTiles metadata repair failed (unknown reason)'
   };
 }
 

--- a/src/utils/mbtiles-reader.ts
+++ b/src/utils/mbtiles-reader.ts
@@ -13,6 +13,41 @@ interface TileRow {
   tile_data: Uint8Array;
 }
 
+/**
+ * Convert a tile column/row range at a single zoom into Web-Mercator
+ * geographic bounds `[minLon, minLat, maxLon, maxLat]` (the MBTiles
+ * `bounds` order). Pure so it can be unit-tested without a database.
+ *
+ * MBTiles stores `tile_row` in **TMS** order (origin bottom-left), but the
+ * standard slippy-tile → lat/lon formulas are stated in **XYZ** order
+ * (origin top-left), so the rows are flipped first (`xyzY = n - 1 - tmsY`).
+ * Edges (not tile centers) are used: a tile column spans `[col, col+1)` and
+ * a tile row spans `[xyzY, xyzY+1)`, so the east/south edges add 1.
+ */
+export function tileRangeToBounds(
+  z: number,
+  minCol: number,
+  maxCol: number,
+  minTmsRow: number,
+  maxTmsRow: number
+): [number, number, number, number] {
+  const n = 2 ** z;
+  const lon = (col: number): number => (col / n) * 360 - 180;
+  const lat = (xyzRow: number): number =>
+    (Math.atan(Math.sinh(Math.PI * (1 - (2 * xyzRow) / n))) * 180) / Math.PI;
+
+  // TMS → XYZ: the highest TMS row is the northernmost tile.
+  const xyzTop = n - 1 - maxTmsRow;
+  const xyzBottom = n - 1 - minTmsRow;
+
+  const west = lon(minCol);
+  const east = lon(maxCol + 1);
+  const north = lat(xyzTop);
+  const south = lat(xyzBottom + 1);
+
+  return [west, south, east, north];
+}
+
 export class MBTilesReader {
   private filePath: string;
   private db: DatabaseSync | null;
@@ -142,6 +177,161 @@ export class MBTilesReader {
     }
 
     return { data, headers };
+  }
+
+  // ---- Repair helpers ----
+  // These read-only queries support `findRepairableCharts`: an MBTiles with
+  // a valid tile pyramid but no `metadata.bounds` is dropped by the loader
+  // gate, yet bounds/zoom/format/tileSize can all be derived from the tiles
+  // table. The reader is opened readOnly (see constructor), so these are
+  // safe to run during the management-UI scan without a write handle.
+
+  /** True if the `tiles` table exists and has at least one row. */
+  hasTiles(): boolean {
+    if (!this.db) {
+      throw new Error('Database is closed');
+    }
+    try {
+      const row = this.db.prepare('SELECT 1 AS one FROM tiles LIMIT 1').get();
+      return row !== undefined;
+    } catch {
+      // No `tiles` table at all (malformed file) — not repairable.
+      return false;
+    }
+  }
+
+  /** MIN/MAX of `zoom_level`, or null if the tiles table is empty. */
+  getZoomRangeFromTiles(): { minzoom: number; maxzoom: number } | null {
+    if (!this.db) {
+      throw new Error('Database is closed');
+    }
+    try {
+      const row = this.db
+        .prepare('SELECT MIN(zoom_level) AS lo, MAX(zoom_level) AS hi FROM tiles')
+        .get() as { lo: number | null; hi: number | null } | undefined;
+      if (!row || row.lo === null || row.hi === null) {
+        return null;
+      }
+      return { minzoom: row.lo, maxzoom: row.hi };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * First tile blob as a Buffer (no copy), or null if empty. Used to sniff
+   * format and read PNG pixel dimensions for the repair derivation.
+   */
+  getFirstTileRaw(): Buffer | null {
+    if (!this.db) {
+      throw new Error('Database is closed');
+    }
+    try {
+      const row = this.db.prepare('SELECT tile_data FROM tiles LIMIT 1').get() as unknown as
+        | TileRow
+        | undefined;
+      if (!row?.tile_data) {
+        return null;
+      }
+      const u = row.tile_data;
+      return Buffer.from(u.buffer, u.byteOffset, u.byteLength);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Sniff the tile format from the first tile's magic bytes:
+   * PNG/JPEG/WEBP raster or gzip-wrapped PBF vector. Returns null when the
+   * tiles table is empty or the bytes match nothing known.
+   */
+  sniffFormatFromTiles(): string | null {
+    const b = this.getFirstTileRaw();
+    if (!b || b.length < 4) {
+      return null;
+    }
+    if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) {
+      return 'png';
+    }
+    if (b[0] === 0xff && b[1] === 0xd8) {
+      return 'jpg';
+    }
+    // gzip magic — MBTiles stores vector PBF tiles gzip-compressed.
+    if (b[0] === 0x1f && b[1] === 0x8b) {
+      return 'pbf';
+    }
+    if (
+      b.length >= 12 &&
+      b[0] === 0x52 &&
+      b[1] === 0x49 &&
+      b[2] === 0x46 &&
+      b[3] === 0x46 && // 'RIFF'
+      b[8] === 0x57 &&
+      b[9] === 0x45 &&
+      b[10] === 0x42 &&
+      b[11] === 0x50 // 'WEBP'
+    ) {
+      return 'webp';
+    }
+    return null;
+  }
+
+  /**
+   * Tile edge length in pixels, read from the first tile. Only PNG is
+   * decoded (the IHDR width is a fixed big-endian uint32 at byte offset 16);
+   * JPEG/WEBP/PBF return undefined because their dimensions need a real
+   * decoder and a vector tile has no fixed pixel size. Undefined means
+   * "assume the conventional 256".
+   */
+  getTilePixelSize(): number | undefined {
+    const b = this.getFirstTileRaw();
+    if (!b || b.length < 24) {
+      return undefined;
+    }
+    // PNG only: signature (8) + IHDR length+type (8) → width at offset 16.
+    if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) {
+      return b.readUInt32BE(16);
+    }
+    return undefined;
+  }
+
+  /**
+   * Derive Web-Mercator bounds from the tile column/row extent at maxzoom.
+   * Returns null if there are no tiles. The bounds are the bounding box of
+   * the populated tiles — for a sparse pyramid this can be larger than the
+   * actual data extent, which is the standard (advisory) interpretation.
+   */
+  deriveBoundsFromTiles(): number[] | null {
+    if (!this.db) {
+      throw new Error('Database is closed');
+    }
+    const zr = this.getZoomRangeFromTiles();
+    if (!zr) {
+      return null;
+    }
+    const z = zr.maxzoom;
+    try {
+      const row = this.db
+        .prepare(
+          'SELECT MIN(tile_column) AS minc, MAX(tile_column) AS maxc, ' +
+            'MIN(tile_row) AS minr, MAX(tile_row) AS maxr FROM tiles WHERE zoom_level = ?'
+        )
+        .get(z) as
+        | { minc: number | null; maxc: number | null; minr: number | null; maxr: number | null }
+        | undefined;
+      if (
+        !row ||
+        row.minc === null ||
+        row.maxc === null ||
+        row.minr === null ||
+        row.maxr === null
+      ) {
+        return null;
+      }
+      return tileRangeToBounds(z, row.minc, row.maxc, row.minr, row.maxr);
+    } catch {
+      return null;
+    }
   }
 
   close(): void {

--- a/test/mbtiles-repair.test.ts
+++ b/test/mbtiles-repair.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Tests for the "repair broken MBTiles metadata" feature: deriving
+ * bounds/zoom/format/tileSize from the tiles table, surfacing dropped
+ * charts as repairable, and persisting the derived metadata back into the
+ * file so the chart loads.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+
+import { open, tileRangeToBounds } from '../dist/utils/mbtiles-reader.js';
+import { repairMbtilesMetadata } from '../dist/utils/mbtiles-metadata.js';
+import { findCharts, findRepairableCharts } from '../dist/charts-loader.js';
+
+// A minimal valid 1x1 PNG (same bytes the fixture builder uses). IHDR width
+// at offset 16 is 0x00000001 → readUInt32BE(16) === 1.
+const PNG_1x1 = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+  0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+  0x42, 0x60, 0x82
+]);
+
+/** A PNG header whose IHDR encodes the given square width (no valid body). */
+function pngHeaderWithWidth(width: number): Buffer {
+  const b = Buffer.from(PNG_1x1);
+  b.writeUInt32BE(width, 16); // width
+  b.writeUInt32BE(width, 20); // height
+  return b;
+}
+
+interface TileSpec {
+  z: number;
+  col: number;
+  row: number;
+  data?: Buffer;
+}
+
+interface BuildOpts {
+  metadata?: Record<string, string>;
+  tiles?: TileSpec[];
+  /** When true, omit the tiles table entirely. */
+  noTilesTable?: boolean;
+}
+
+/** Build a throwaway .mbtiles in a temp dir and return its path. */
+function buildMbtiles(dir: string, filename: string, opts: BuildOpts): string {
+  const filePath = path.join(dir, filename);
+  if (fs.existsSync(filePath)) {
+    fs.unlinkSync(filePath);
+  }
+  const db = new DatabaseSync(filePath);
+  db.exec('CREATE TABLE metadata (name TEXT, value TEXT);');
+  if (!opts.noTilesTable) {
+    db.exec(
+      'CREATE TABLE tiles (zoom_level INTEGER, tile_column INTEGER, tile_row INTEGER, tile_data BLOB);'
+    );
+  }
+  const insMeta = db.prepare('INSERT INTO metadata (name, value) VALUES (?, ?)');
+  for (const [name, value] of Object.entries(opts.metadata ?? {})) {
+    insMeta.run(name, value);
+  }
+  if (!opts.noTilesTable) {
+    const insTile = db.prepare(
+      'INSERT INTO tiles (zoom_level, tile_column, tile_row, tile_data) VALUES (?, ?, ?, ?)'
+    );
+    for (const t of opts.tiles ?? []) {
+      insTile.run(t.z, t.col, t.row, t.data ?? PNG_1x1);
+    }
+  }
+  db.close();
+  return filePath;
+}
+
+describe('tileRangeToBounds (pure)', () => {
+  it('derives full-world bounds at z0 from a single tile', () => {
+    const b = tileRangeToBounds(0, 0, 0, 0, 0);
+    assert.ok(Math.abs(b[0] - -180) < 1e-3, `west ${b[0]}`);
+    assert.ok(Math.abs(b[1] - -85.0511) < 1e-3, `south ${b[1]}`);
+    assert.ok(Math.abs(b[2] - 180) < 1e-3, `east ${b[2]}`);
+    assert.ok(Math.abs(b[3] - 85.0511) < 1e-3, `north ${b[3]}`);
+  });
+
+  it('derives full-world bounds at z9 from the complete grid', () => {
+    const b = tileRangeToBounds(9, 0, 511, 0, 511);
+    assert.ok(Math.abs(b[0] - -180) < 1e-3);
+    assert.ok(Math.abs(b[1] - -85.0511) < 1e-3);
+    assert.ok(Math.abs(b[2] - 180) < 1e-3);
+    assert.ok(Math.abs(b[3] - 85.0511) < 1e-3);
+  });
+
+  it('flips TMS→XYZ: high TMS row is the northern hemisphere', () => {
+    // z1, the single NW tile in TMS is col 0, row 1.
+    const b = tileRangeToBounds(1, 0, 0, 1, 1);
+    // west -180, east 0 (meridian), and a positive (northern) latitude band.
+    assert.ok(Math.abs(b[0] - -180) < 1e-3, `west ${b[0]}`);
+    assert.ok(Math.abs(b[2] - 0) < 1e-3, `east ${b[2]}`);
+    assert.ok(b[1] >= -1e-6, `south should be >= 0 (equator), got ${b[1]}`);
+    assert.ok(b[3] > 80, `north should be ~85, got ${b[3]}`);
+  });
+
+  it('handles a non-square regional range', () => {
+    // z9, cols 100..103 (4 wide), TMS rows 200..205 (6 tall).
+    const b = tileRangeToBounds(9, 100, 103, 200, 205);
+    const lon = (col: number): number => (col / 512) * 360 - 180;
+    const lat = (xyz: number): number =>
+      (Math.atan(Math.sinh(Math.PI * (1 - (2 * xyz) / 512))) * 180) / Math.PI;
+    assert.ok(Math.abs(b[0] - lon(100)) < 1e-6, 'west');
+    assert.ok(Math.abs(b[2] - lon(104)) < 1e-6, 'east edge = col+1');
+    // northern edge = highest TMS row → xyzTop = 511-205 = 306
+    assert.ok(Math.abs(b[3] - lat(306)) < 1e-6, 'north');
+    // southern edge = lowest TMS row → xyzBottom = 511-200 = 311, +1 = 312
+    assert.ok(Math.abs(b[1] - lat(312)) < 1e-6, 'south');
+    assert.ok(b[2] > b[0] && b[3] > b[1], 'box is well-ordered');
+  });
+});
+
+describe('MBTilesReader repair helpers', () => {
+  let dir: string;
+  before(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mbtiles-repair-'));
+  });
+  after(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('hasTiles / getZoomRangeFromTiles / deriveBoundsFromTiles', async () => {
+    const file = buildMbtiles(dir, 'helpers.mbtiles', {
+      metadata: { name: 'Helpers' },
+      tiles: [
+        { z: 0, col: 0, row: 0 },
+        { z: 1, col: 0, row: 1 },
+        { z: 1, col: 1, row: 1 }
+      ]
+    });
+    const reader = await open(file);
+    try {
+      assert.strictEqual(reader.hasTiles(), true);
+      assert.deepStrictEqual(reader.getZoomRangeFromTiles(), { minzoom: 0, maxzoom: 1 });
+      const bounds = reader.deriveBoundsFromTiles();
+      assert.ok(Array.isArray(bounds) && bounds.length === 4);
+    } finally {
+      reader.close();
+    }
+  });
+
+  it('hasTiles is false when there is no tiles table', async () => {
+    const file = buildMbtiles(dir, 'no-tiles.mbtiles', {
+      metadata: { name: 'Empty' },
+      noTilesTable: true
+    });
+    const reader = await open(file);
+    try {
+      assert.strictEqual(reader.hasTiles(), false);
+      assert.strictEqual(reader.getZoomRangeFromTiles(), null);
+      assert.strictEqual(reader.deriveBoundsFromTiles(), null);
+    } finally {
+      reader.close();
+    }
+  });
+
+  it('sniffFormatFromTiles detects png, jpg, pbf(gzip), webp', async () => {
+    const cases: { name: string; magic: Buffer; expect: string }[] = [
+      { name: 'png', magic: PNG_1x1, expect: 'png' },
+      { name: 'jpg', magic: Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0]), expect: 'jpg' },
+      { name: 'pbf', magic: Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0, 0, 0, 0]), expect: 'pbf' },
+      {
+        name: 'webp',
+        magic: Buffer.from([0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50]),
+        expect: 'webp'
+      }
+    ];
+    for (const c of cases) {
+      const file = buildMbtiles(dir, `sniff-${c.name}.mbtiles`, {
+        metadata: { name: c.name },
+        tiles: [{ z: 0, col: 0, row: 0, data: c.magic }]
+      });
+      const reader = await open(file);
+      try {
+        assert.strictEqual(reader.sniffFormatFromTiles(), c.expect, c.name);
+      } finally {
+        reader.close();
+      }
+    }
+  });
+
+  it('getTilePixelSize reads PNG IHDR (256 and 512), undefined for non-PNG', async () => {
+    const f256 = buildMbtiles(dir, 'px256.mbtiles', {
+      tiles: [{ z: 0, col: 0, row: 0, data: pngHeaderWithWidth(256) }]
+    });
+    const f512 = buildMbtiles(dir, 'px512.mbtiles', {
+      tiles: [{ z: 0, col: 0, row: 0, data: pngHeaderWithWidth(512) }]
+    });
+    const fjpg = buildMbtiles(dir, 'pxjpg.mbtiles', {
+      tiles: [
+        {
+          z: 0,
+          col: 0,
+          row: 0,
+          data: Buffer.from([
+            0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+          ])
+        }
+      ]
+    });
+    let r = await open(f256);
+    try {
+      assert.strictEqual(r.getTilePixelSize(), 256);
+    } finally {
+      r.close();
+    }
+    r = await open(f512);
+    try {
+      assert.strictEqual(r.getTilePixelSize(), 512);
+    } finally {
+      r.close();
+    }
+    r = await open(fjpg);
+    try {
+      assert.strictEqual(r.getTilePixelSize(), undefined);
+    } finally {
+      r.close();
+    }
+  });
+});
+
+describe('findRepairableCharts + repair round-trip', () => {
+  let dir: string;
+  before(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mbtiles-repair-loader-'));
+  });
+  after(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const BROKEN_TILES: TileSpec[] = [
+    { z: 0, col: 0, row: 0 },
+    { z: 1, col: 0, row: 0 },
+    { z: 1, col: 0, row: 1 },
+    { z: 1, col: 1, row: 0 },
+    { z: 1, col: 1, row: 1 }
+  ];
+
+  it('drops a no-bounds chart but surfaces it as repairable', async () => {
+    const sub = fs.mkdtempSync(path.join(dir, 'scan-'));
+    buildMbtiles(sub, 'broken.mbtiles', {
+      metadata: { name: 'Broken World', version: '1' }, // no bounds
+      tiles: BROKEN_TILES
+    });
+
+    const loaded = await findCharts(sub);
+    assert.strictEqual(Object.keys(loaded).length, 0, 'loader drops the no-bounds chart');
+
+    const repairable = await findRepairableCharts(sub);
+    assert.strictEqual(repairable.length, 1);
+    const rc = repairable[0];
+    assert.strictEqual(rc.reason, 'missing_bounds');
+    assert.strictEqual(rc.hasTiles, true);
+    assert.strictEqual(rc.relativePath, 'broken.mbtiles');
+    assert.ok(rc.derived, 'derived metadata present');
+    assert.deepStrictEqual([rc.derived.minzoom, rc.derived.maxzoom], [0, 1], 'derived zoom range');
+    assert.strictEqual(rc.derived.format, 'png');
+  });
+
+  it('a chart with no tiles is NOT repairable', async () => {
+    const sub = fs.mkdtempSync(path.join(dir, 'notiles-'));
+    buildMbtiles(sub, 'empty.mbtiles', {
+      metadata: { name: 'Empty' }, // no bounds, no tiles
+      tiles: []
+    });
+    assert.strictEqual((await findRepairableCharts(sub)).length, 0);
+  });
+
+  it('repairs the file: derived metadata written, then loads and is no longer repairable', async () => {
+    const sub = fs.mkdtempSync(path.join(dir, 'roundtrip-'));
+    const file = buildMbtiles(sub, 'fixme.mbtiles', {
+      metadata: { name: 'Fix Me' },
+      tiles: BROKEN_TILES
+    });
+
+    const before = await findRepairableCharts(sub);
+    assert.strictEqual(before.length, 1);
+    const derived = before[0].derived;
+    assert.ok(derived);
+
+    const result = await repairMbtilesMetadata(file, derived);
+    assert.strictEqual(result.ok, true);
+    assert.ok(result.written.includes('bounds'), 'bounds written');
+
+    // Re-read: bounds now present and equal to the derived value.
+    const reader = await open(file);
+    try {
+      const info = reader.getInfo();
+      assert.ok(Array.isArray(info.bounds) && info.bounds.length === 4, 'bounds persisted');
+      assert.deepStrictEqual(info.bounds, derived.bounds);
+      assert.strictEqual(info.minzoom, 0);
+      assert.strictEqual(info.maxzoom, 1);
+    } finally {
+      reader.close();
+    }
+
+    // Now it loads, and is no longer listed as repairable.
+    const loaded = await findCharts(sub);
+    assert.strictEqual(Object.keys(loaded).length, 1, 'repaired chart loads');
+    assert.strictEqual((await findRepairableCharts(sub)).length, 0);
+
+    // Idempotent: a second repair writes nothing.
+    const again = await repairMbtilesMetadata(file, derived);
+    assert.strictEqual(again.ok, true);
+    assert.strictEqual(again.written.length, 0, 'nothing left to write');
+    assert.ok(again.skipped.includes('bounds'));
+  });
+
+  it('only fills absent fields — never clobbers a present value', async () => {
+    const sub = fs.mkdtempSync(path.join(dir, 'absent-'));
+    // bounds missing, but a deliberately wrong-but-present minzoom.
+    const file = buildMbtiles(sub, 'partial.mbtiles', {
+      metadata: { name: 'Partial', minzoom: '99' },
+      tiles: BROKEN_TILES
+    });
+
+    const repairable = await findRepairableCharts(sub);
+    const derived = repairable[0]?.derived;
+    assert.ok(derived);
+
+    const result = await repairMbtilesMetadata(file, derived);
+    assert.strictEqual(result.ok, true);
+    assert.ok(result.written.includes('bounds'), 'bounds written');
+    assert.ok(result.skipped.includes('minzoom'), 'minzoom kept');
+
+    const reader = await open(file);
+    try {
+      // The pre-existing (wrong) minzoom is preserved, not overwritten.
+      assert.strictEqual(reader.getInfo().minzoom, 99);
+    } finally {
+      reader.close();
+    }
+  });
+});

--- a/test/mbtiles-repair.test.ts
+++ b/test/mbtiles-repair.test.ts
@@ -43,6 +43,8 @@ interface TileSpec {
 
 interface BuildOpts {
   metadata?: Record<string, string>;
+  /** Raw metadata rows, allowing duplicate names (the table has no UNIQUE constraint). */
+  metadataRows?: { name: string; value: string }[];
   tiles?: TileSpec[];
   /** When true, omit the tiles table entirely. */
   noTilesTable?: boolean;
@@ -64,6 +66,9 @@ function buildMbtiles(dir: string, filename: string, opts: BuildOpts): string {
   const insMeta = db.prepare('INSERT INTO metadata (name, value) VALUES (?, ?)');
   for (const [name, value] of Object.entries(opts.metadata ?? {})) {
     insMeta.run(name, value);
+  }
+  for (const row of opts.metadataRows ?? []) {
+    insMeta.run(row.name, row.value);
   }
   if (!opts.noTilesTable) {
     const insTile = db.prepare(
@@ -126,7 +131,14 @@ describe('MBTilesReader repair helpers', () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mbtiles-repair-'));
   });
   after(() => {
-    fs.rmSync(dir, { recursive: true, force: true });
+    // On Windows the node:sqlite file handle can linger briefly after
+    // close(), so an immediate recursive rm hits EPERM. Retry, and never
+    // let a teardown failure fail the suite — a leaked temp dir is harmless.
+    try {
+      fs.rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+    } catch {
+      /* best-effort temp cleanup */
+    }
   });
 
   it('hasTiles / getZoomRangeFromTiles / deriveBoundsFromTiles', async () => {
@@ -235,7 +247,14 @@ describe('findRepairableCharts + repair round-trip', () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mbtiles-repair-loader-'));
   });
   after(() => {
-    fs.rmSync(dir, { recursive: true, force: true });
+    // On Windows the node:sqlite file handle can linger briefly after
+    // close(), so an immediate recursive rm hits EPERM. Retry, and never
+    // let a teardown failure fail the suite — a leaked temp dir is harmless.
+    try {
+      fs.rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+    } catch {
+      /* best-effort temp cleanup */
+    }
   });
 
   const BROKEN_TILES: TileSpec[] = [
@@ -340,5 +359,54 @@ describe('findRepairableCharts + repair round-trip', () => {
     } finally {
       reader.close();
     }
+  });
+
+  it('is deterministic when metadata has duplicate name rows', async () => {
+    const sub = fs.mkdtempSync(path.join(dir, 'dupes-'));
+    // The table has no UNIQUE constraint: an EMPTY format row plus a
+    // non-empty one. A naive last-write-wins snapshot could read the empty
+    // row last and wrongly insert a second format. "Any non-empty = present"
+    // must skip it.
+    const file = buildMbtiles(sub, 'dupes.mbtiles', {
+      metadata: { name: 'Dupes' },
+      metadataRows: [
+        { name: 'format', value: '' },
+        { name: 'format', value: 'jpg' }
+      ],
+      tiles: BROKEN_TILES
+    });
+
+    const repairable = await findRepairableCharts(sub);
+    const derived = repairable[0]?.derived;
+    assert.ok(derived);
+
+    const result = await repairMbtilesMetadata(file, derived);
+    assert.strictEqual(result.ok, true);
+    assert.ok(result.written.includes('bounds'), 'bounds written');
+    assert.ok(result.skipped.includes('format'), 'present (non-empty) format kept, not duplicated');
+
+    // No new format row was added — the non-empty value is still 'jpg'.
+    const reader = await open(file);
+    try {
+      assert.strictEqual(reader.getInfo().format, 'jpg');
+    } finally {
+      reader.close();
+    }
+  });
+
+  it('surfaces and repairs an uppercase .MBTILES file', async () => {
+    const sub = fs.mkdtempSync(path.join(dir, 'upper-'));
+    const file = buildMbtiles(sub, 'WORLD.MBTILES', {
+      metadata: { name: 'Upper' },
+      tiles: BROKEN_TILES
+    });
+
+    const repairable = await findRepairableCharts(sub);
+    assert.strictEqual(repairable.length, 1, 'uppercase ext is discovered');
+    assert.strictEqual(repairable[0].relativePath, 'WORLD.MBTILES');
+
+    const result = await repairMbtilesMetadata(file, repairable[0].derived!);
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(Object.keys(await findCharts(sub)).length, 1, 'repaired uppercase loads');
   });
 });

--- a/test/mbtiles-repair.test.ts
+++ b/test/mbtiles-repair.test.ts
@@ -361,38 +361,53 @@ describe('findRepairableCharts + repair round-trip', () => {
     }
   });
 
-  it('is deterministic when metadata has duplicate name rows', async () => {
-    const sub = fs.mkdtempSync(path.join(dir, 'dupes-'));
-    // The table has no UNIQUE constraint: an EMPTY format row plus a
-    // non-empty one. A naive last-write-wins snapshot could read the empty
-    // row last and wrongly insert a second format. "Any non-empty = present"
-    // must skip it.
-    const file = buildMbtiles(sub, 'dupes.mbtiles', {
-      metadata: { name: 'Dupes' },
-      metadataRows: [
-        { name: 'format', value: '' },
-        { name: 'format', value: 'jpg' }
-      ],
-      tiles: BROKEN_TILES
+  // The table has no UNIQUE constraint, so a key can have both an empty and
+  // a non-empty row. "Any non-empty = present" must skip the key regardless
+  // of row order — the inverse (non-empty→empty) order is the one a naive
+  // last-row-wins read would get wrong, so both orders are exercised.
+  for (const order of ['empty-first', 'non-empty-first'] as const) {
+    it(`is deterministic when metadata has duplicate name rows (${order})`, async () => {
+      const sub = fs.mkdtempSync(path.join(dir, `dupes-${order}-`));
+      const rows =
+        order === 'empty-first'
+          ? [
+              { name: 'format', value: '' },
+              { name: 'format', value: 'jpg' }
+            ]
+          : [
+              { name: 'format', value: 'jpg' },
+              { name: 'format', value: '' }
+            ];
+      const file = buildMbtiles(sub, 'dupes.mbtiles', {
+        metadata: { name: 'Dupes' },
+        metadataRows: rows,
+        tiles: BROKEN_TILES
+      });
+
+      const repairable = await findRepairableCharts(sub);
+      const derived = repairable[0]?.derived;
+      assert.ok(derived);
+
+      const result = await repairMbtilesMetadata(file, derived);
+      assert.strictEqual(result.ok, true);
+      assert.ok(result.written.includes('bounds'), 'bounds written');
+      assert.ok(
+        result.skipped.includes('format'),
+        'present (non-empty) format kept, not duplicated'
+      );
+
+      // No third format row was inserted — the two seeded rows are unchanged.
+      const db = new DatabaseSync(file, { readOnly: true });
+      try {
+        const countRow = db
+          .prepare("SELECT COUNT(*) AS n FROM metadata WHERE name = 'format'")
+          .get() as { n: number };
+        assert.strictEqual(countRow.n, 2, 'no duplicate format row inserted');
+      } finally {
+        db.close();
+      }
     });
-
-    const repairable = await findRepairableCharts(sub);
-    const derived = repairable[0]?.derived;
-    assert.ok(derived);
-
-    const result = await repairMbtilesMetadata(file, derived);
-    assert.strictEqual(result.ok, true);
-    assert.ok(result.written.includes('bounds'), 'bounds written');
-    assert.ok(result.skipped.includes('format'), 'present (non-empty) format kept, not duplicated');
-
-    // No new format row was added — the non-empty value is still 'jpg'.
-    const reader = await open(file);
-    try {
-      assert.strictEqual(reader.getInfo().format, 'jpg');
-    } finally {
-      reader.close();
-    }
-  });
+  }
 
   it('surfaces and repairs an uppercase .MBTILES file', async () => {
     const sub = fs.mkdtempSync(path.join(dir, 'upper-'));


### PR DESCRIPTION
## Problem

The chart loader drops any MBTiles whose `metadata` table has no `bounds`, even when the file holds a complete, valid tile pyramid. A user supplied a global PNG chart (zoom 0–9, full TMS pyramid) that was silently not served for exactly this reason — and because a dropped chart has no card in the Manage UI, there was no way to even see it, let alone fix it.

## What this does

Surfaces such charts in the Manage UI under a **"Charts needing repair"** section with a **Repair** action that derives the missing metadata from the tiles table and writes it back into the file.

Derived values:
- **bounds** — from the tile column/row extent at maxzoom (TMS→XYZ Web-Mercator edge math)
- **minzoom/maxzoom** — `MIN/MAX(zoom_level)`
- **format** — sniffed from the first tile's magic bytes (png / jpg / webp / gzip-pbf)
- **tileSize** — read from the PNG IHDR (256/512)

The writer (`repairMbtilesMetadata`) mirrors the existing `patchS57Mbtiles` idiom: a single transaction, verify-after-write, one retry on a transient lock, best-effort/never-throws. It **only fills absent fields** — it never clobbers a value the file already carries. The read-only reader used to derive the values is closed before the writer opens its own handle.

## 512px tiles

Charts with 512px tiles now advertise `tileSize` on the v2 descriptor. Freeboard-SK currently renders all charts at 256px and does not yet honor a tile-size field, so the repair dialog and server log warn that a 512px chart may render mis-scaled until Freeboard-SK gains tile-size support (a follow-up change there).

## New surface

- `GET /repairable-charts` — lists dropped-but-repairable charts (mirrors `/local-charts`)
- `POST /repair-chart` — derives and persists the metadata (mirrors the `/rename-chart` flow: path-safety guard, refresh, delta)

## Tested

- `npm run format` / `npm run build` / `npm run lint` — clean
- `npm test` — 278 pass / 0 fail, including a new `test/mbtiles-repair.test.ts` (12 tests): `tileRangeToBounds` math (full-world z0/z9, TMS→XYZ flip, a non-square regional range), reader helpers, format sniff, `getTilePixelSize` 256/512/non-PNG, and a full round-trip (no-bounds chart dropped → surfaced as repairable → repaired → loads → no longer repairable, idempotent, only-fills-absent)
- End-to-end against the real user-supplied `world-coastline.mbtiles` (on a copy): dropped by `findCharts` → surfaced with correct derived `bounds [-180,-85.0511,180,85.0511]`, zoom 0–9, format png, tileSize 512 → repaired → served

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Adds MBTiles metadata repair capability that surfaces and fixes charts dropped by the chart loader because their metadata table lacks a bounds entry despite containing a valid tile pyramid. The feature adds a Manage UI "Charts needing repair" section, a repair confirmation dialog with window-level modal helpers, and API endpoints to derive and persist missing metadata fields.

## Metadata Derivation & Repair
The server derives and persistently backfills absent metadata fields:
- bounds — computed from tile column/row extents at maxzoom using TMS→XYZ Web-Mercator edge math (tileRangeToBounds).
- minzoom / maxzoom — MIN/MAX(zoom_level) from the tiles table.
- format — sniffed from the first tile's magic bytes (png / jpg / webp / gzip-pbf).
- tileSize — read from PNG IHDR (256 / 512) and included on v2 descriptors when non-default.

repairMbtilesMetadata writes only absent/empty metadata using a single-transaction, verify-after-write pattern, retries once on transient lock, and never throws (best-effort). The read-only MBTiles reader used to derive values is closed before the writer opens the file. PatchOptions, RepairDerived, and RepairResult types are exported to support the workflow.

## Chart Discovery & Startup Behavior
findRepairableCharts scans the chart directory (case-insensitive .mbtiles) for files that have tiles but are missing metadata.bounds, derives repairable metadata (including optional tileSize), and returns RepairableChart objects. Startup cleanup excludes files reported by findRepairableCharts so repairable MBTiles are not removed during validation sweeps.

## API Endpoints
- GET /repairable-charts — returns repairable MBTiles with derived metadata and base path.
- POST /repair-chart — validates a case-insensitive .mbtiles path, performs read-only derivation (then closes the reader), persists absent metadata via repairMbtilesMetadata, triggers provider refresh and chart delta, warns for non-256 tileSize, and returns diagnostics. Response codes: 200 with write/skip details on success; 422 for no tiles or inability to derive bounds/zoom; 403/404 for invalid/missing paths; 500 on unrecoverable failures.

## UI Changes
Manage Charts adds a "Charts needing repair" section that fetches /repairable-charts, displays derived bounds/minzoom/maxzoom/format and tile-size warnings, and opens a repair confirmation modal that posts to /repair-chart. Modal helper functions are declared on window (showRepairDialog, closeRepairModal, confirmRepair). On successful repair the UI refreshes charts and shows a "Chart Repaired" toast.

## Types & Descriptors
Chart types include optional tileSize?: number on ChartV2Data, ChartProvider, and SanitizedChart. New types model repairable charts (RepairReason, RepairableDerived, RepairableChart).

## Reader Helpers
MBTiles reader adds read-only helpers used for repair:
- tileRangeToBounds(z, minCol, maxCol, minTmsRow, maxTmsRow)
- hasTiles, getZoomRangeFromTiles, getFirstTileRaw, sniffFormatFromTiles, getTilePixelSize, deriveBoundsFromTiles

These helpers conservatively return null/false when tables are missing or queries fail.

## Tests and Validation
Adds test/mbtiles-repair.test.ts covering tileRangeToBounds math, reader helpers (tiles presence, zoom range, bounds derivation, format sniffing, PNG tile-size), and end-to-end discovery + repair round-trips, including idempotency, duplicate-metadata determinism, uppercase .MBTILES handling, and persistence verification. Build/lint/format are clean and npm test passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->