### PR TITLE
chore(release): 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release 2.1.0.

Minor bump for the MBTiles repair feature merged in #115: charts dropped for missing `metadata.bounds` are now surfaced in the Manage UI and can be repaired in place (bounds/zoom/format derived from the tile pyramid; 512px tile size detected and advertised on the v2 descriptor).