### PR TITLE
feat(catalog): add updates section and enhance update handling

### DIFF
--- a/e2e/catalog.spec.ts
+++ b/e2e/catalog.spec.ts
@@ -112,4 +112,57 @@ test.describe('Chart Catalog tab', () => {
     const sentinel = await pill.getAttribute('data-e2e-sentinel');
     expect(sentinel).toBe('pre-poll');
   });
+
+  test('a failed update surfaces an error in the updates panel (not a silent skip)', async ({
+    page
+  }) => {
+    // Regression for the queue silently skipping a chart whose download
+    // POST failed: downloadUpdateChart must record catalogConversionErrors
+    // so the failure shows in the panel (and the queue stops on it) rather
+    // than the chart vanishing with no trace.
+    await page.goto('/plugins/signalk-charts-provider-simple/');
+    await setMockState(page, {
+      registry: [
+        {
+          file: 'NOAA_MBTiles_Catalog.xml',
+          label: 'NOAA MBTiles',
+          category: 'mbtiles',
+          chartCount: 1,
+          cachedAt: '2026-05-07T10:00:00Z'
+        }
+      ],
+      catalogUpdates: [
+        {
+          chartNumber: '1',
+          catalogFile: 'NOAA_MBTiles_Catalog.xml',
+          title: 'Boston Harbor',
+          installedDate: '2024-01-01T00:00:00Z',
+          availableDate: '2026-05-01T00:00:00Z',
+          downloadUrl: 'https://example.com/boston.mbtiles',
+          installedFolder: '/'
+        }
+      ],
+      // The next /catalog/download POST returns HTTP 500.
+      downloadFailStatus: 500
+    });
+
+    await page.getByRole('button', { name: /Chart Catalog/i }).click();
+
+    const row = page.locator('.catalog-update-row[data-chart-number="1"]');
+    await expect(row).toContainText('Boston Harbor');
+
+    // Click the per-chart Update button; the mocked POST fails.
+    await row.locator('[data-catalog-update="1"]').click();
+
+    // The failure must surface as a visible error with a Dismiss button,
+    // not disappear silently.
+    const errorText = row.locator('.conversion-error-text');
+    await expect(errorText).toBeVisible();
+    await expect(errorText).toContainText(/mock download failure/i);
+
+    // Dismiss must clear it from the panel (the Dismiss button under
+    // #catalogUpdatesSection is wired and re-renders the section).
+    await row.locator('[data-catalog-dismiss="1"]').click();
+    await expect(row.locator('.conversion-error-text')).toHaveCount(0);
+  });
 });

--- a/e2e/mock-server.ts
+++ b/e2e/mock-server.ts
@@ -78,6 +78,18 @@ interface MockState {
     downloadedBytes: number;
     error?: string;
   }[];
+  catalogUpdates: {
+    chartNumber: string;
+    catalogFile: string;
+    title: string;
+    installedDate: string;
+    availableDate: string;
+    downloadUrl: string;
+    installedFolder: string;
+  }[];
+  // When set, POST /catalog/download responds with this HTTP status and an
+  // error body so tests can exercise the update-failure path.
+  downloadFailStatus: number | null;
   s57PodmanAvailable: boolean;
   podmanVersion: string | null;
   containerRuntimeEngine: string | null;
@@ -91,6 +103,8 @@ const initialState: MockState = {
   catalogs: {},
   localCharts: { charts: [], folders: ['/'], basePath: '/tmp/charts' },
   downloadJobs: [],
+  catalogUpdates: [],
+  downloadFailStatus: null,
   s57PodmanAvailable: true,
   podmanVersion: 'podman version 5.4.2',
   containerRuntimeEngine: 'podman'
@@ -176,7 +190,7 @@ export function startMockServer(
   });
 
   router.get(`${PLUGIN_BASE}/catalog-updates`, (_req, res) => {
-    res.json([]);
+    res.json(state.catalogUpdates);
   });
 
   router.get(`${PLUGIN_BASE}/download-jobs`, (_req, res) => {
@@ -191,6 +205,10 @@ export function startMockServer(
     const { chartNumber } = req.body as { chartNumber?: string };
     if (!chartNumber) {
       res.status(400).json({ error: 'chartNumber required' });
+      return;
+    }
+    if (state.downloadFailStatus !== null) {
+      res.status(state.downloadFailStatus).json({ error: 'mock download failure' });
       return;
     }
     const jobId = `mock-${chartNumber}-${Date.now()}`;

--- a/public/css/chart-catalog.css
+++ b/public/css/chart-catalog.css
@@ -452,12 +452,17 @@ option.catalog-folder-option-new {
  * has a thin bar.  Two separate classes so pollConversions can update the
  * conversion pill without touching the download pill.  */
 .catalog-download-progress,
-.catalog-conversion-progress {
+.catalog-conversion-progress,
+.catalog-queue-waiting {
     display: flex;
     align-items: center;
     gap: var(--md-sys-spacing-2);
     font-size: 12px;
     color: var(--md-sys-color-on-surface-variant);
+}
+
+.catalog-queue-waiting {
+    opacity: 0.6;
 }
 
 .catalog-download-progress .progress-bar {

--- a/public/css/chart-catalog.css
+++ b/public/css/chart-catalog.css
@@ -692,8 +692,8 @@ option.catalog-folder-option-new {
 /* ---- Updates Section ---- */
 
 .catalog-updates-section {
-    background: rgba(139, 92, 246, 0.1);
-    border: 1px solid rgba(139, 92, 246, 0.35);
+    background: var(--md-sys-color-secondary-container);
+    border: 1px solid var(--md-sys-color-secondary);
     border-radius: var(--md-sys-shape-corner-medium);
     margin-bottom: var(--md-sys-spacing-4);
     overflow: hidden;
@@ -704,7 +704,7 @@ option.catalog-folder-option-new {
     align-items: center;
     justify-content: space-between;
     padding: var(--md-sys-spacing-3) var(--md-sys-spacing-4);
-    border-bottom: 1px solid rgba(139, 92, 246, 0.25);
+    border-bottom: 1px solid var(--md-sys-color-outline-variant);
     gap: var(--md-sys-spacing-3);
 }
 
@@ -777,7 +777,7 @@ option.catalog-folder-option-new {
     max-width: 200px;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 599px) {
     .catalog-update-row {
         flex-direction: column;
         align-items: flex-start;

--- a/public/css/chart-catalog.css
+++ b/public/css/chart-catalog.css
@@ -683,3 +683,108 @@ option.catalog-folder-option-new {
         font-size: 12px;
     }
 }
+
+/* ---- Updates Section ---- */
+
+.catalog-updates-section {
+    background: rgba(139, 92, 246, 0.1);
+    border: 1px solid rgba(139, 92, 246, 0.35);
+    border-radius: var(--md-sys-shape-corner-medium);
+    margin-bottom: var(--md-sys-spacing-4);
+    overflow: hidden;
+}
+
+.catalog-updates-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--md-sys-spacing-3) var(--md-sys-spacing-4);
+    border-bottom: 1px solid rgba(139, 92, 246, 0.25);
+    gap: var(--md-sys-spacing-3);
+}
+
+.catalog-updates-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--md-sys-color-on-surface);
+}
+
+.catalog-updates-rows {
+    display: flex;
+    flex-direction: column;
+}
+
+.catalog-update-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--md-sys-spacing-3);
+    padding: var(--md-sys-spacing-3) var(--md-sys-spacing-4);
+    border-bottom: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.catalog-update-row:last-child {
+    border-bottom: none;
+}
+
+.catalog-update-row.updating {
+    opacity: 0.6;
+}
+
+.catalog-update-row-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+    flex: 1;
+}
+
+.catalog-update-row-title {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--md-sys-color-on-surface);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.catalog-update-row-dates {
+    font-size: 11px;
+    color: var(--md-sys-color-on-surface-variant);
+}
+
+.catalog-update-row-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--md-sys-spacing-2);
+    flex-shrink: 0;
+}
+
+.catalog-update-row-updating {
+    display: flex;
+    align-items: center;
+    gap: var(--md-sys-spacing-2);
+    font-size: 13px;
+    color: var(--md-sys-color-on-surface-variant);
+}
+
+.catalog-update-folder-select {
+    max-width: 200px;
+}
+
+@media (max-width: 600px) {
+    .catalog-update-row {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .catalog-update-row-actions {
+        width: 100%;
+        flex-wrap: wrap;
+    }
+
+    .catalog-update-folder-select {
+        max-width: 100%;
+        width: 100%;
+    }
+}

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -98,6 +98,11 @@ let activeCategoryFilter: CatalogCategory | 'all' = 'all';
 const expandedCatalogs = new Set<string>();
 const catalogChartData: Record<string, CatalogData> = {};
 let catalogFolders: string[] = ['/'];
+
+// Update queue management
+let catalogUpdateQueue: CatalogUpdate[] = [];
+let catalogUpdateQueueIndex = -1;
+let catalogUpdateQueueRunning = false;
 const catalogDownloadJobs: Record<string, string> = {};
 let catalogConverting: Record<string, boolean> = {};
 let catalogConversionProgress: Record<string, ConversionProgress> = {};
@@ -321,20 +326,25 @@ function wireCatalogClickHandlers(): void {
         return;
       }
 
-      // "Update All" button
+      // "Update All" button - queue updates for sequential processing
       const updateAll = target.closest<HTMLElement>('[data-catalog-update-all]');
       if (updateAll) {
+        const updatesToQueue: CatalogUpdate[] = [];
         for (const update of catalogUpdates) {
           const alreadyActive =
             catalogDownloadJobs[update.chartNumber] !== undefined ||
             catalogConverting[update.chartNumber];
           if (!alreadyActive) {
-            const folderEl = document.getElementById(
-              `catalog-update-folder-${catalogEscapeId(update.chartNumber)}`
-            ) as HTMLSelectElement | null;
-            const targetFolder = folderEl ? folderEl.value : update.installedFolder;
-            void downloadUpdateChart(update, targetFolder);
+            updatesToQueue.push(update);
           }
+        }
+        
+        if (updatesToQueue.length > 0) {
+          catalogUpdateQueue = updatesToQueue;
+          catalogUpdateQueueIndex = 0;
+          catalogUpdateQueueRunning = true;
+          renderUpdatesSection();
+          void processUpdateQueue();
         }
         return;
       }
@@ -488,13 +498,43 @@ function renderUpdatesSection(): void {
       const isUpdating =
         catalogDownloadJobs[update.chartNumber] !== undefined ||
         catalogConverting[update.chartNumber];
+      const conversionError = catalogConversionErrors[update.chartNumber];
+      const isDownloading = catalogDownloadJobs[update.chartNumber] !== undefined;
+      const queuePosition = getQueuePosition(update.chartNumber);
+      const isInQueue = queuePosition !== null;
+      const isWaiting = queuePosition !== null && queuePosition > 0;
 
-      const actionHtml = isUpdating
-        ? `<div class="catalog-update-row-updating">
-            <div class="spinner" style="width:16px;height:16px;border-width:2px;flex-shrink:0;"></div>
-            <span>Updating…</span>
-           </div>`
-        : `<select class="catalog-folder-select catalog-update-folder-select" id="catalog-update-folder-${escapedNum}">
+      let actionHtml = '';
+      if (conversionError) {
+        actionHtml = `
+          <div class="catalog-conversion-error">
+            <span class="conversion-error-text">${catalogEscapeHtml(conversionError)}</span>
+            <button class="btn-catalog-log" data-catalog-log="${catalogEscapeAttr(update.chartNumber)}">Logs</button>
+            <button class="btn-catalog-dismiss" data-catalog-dismiss="${catalogEscapeAttr(update.chartNumber)}">Dismiss</button>
+          </div>`;
+      } else if (isWaiting) {
+        actionHtml = `
+          <div class="catalog-queue-waiting">
+            <div class="spinner" style="width:16px;height:16px;border-width:2px;opacity:0.5;"></div>
+            <span>Waiting in queue (position ${queuePosition})...</span>
+          </div>`;
+      } else if (isDownloading) {
+        actionHtml = `
+          <div class="catalog-download-progress" id="catalog-progress-${escapedNum}">
+            <div class="progress-bar"><div class="progress-fill" style="width: 0%"></div></div>
+            <span>Downloading...</span>
+          </div>`;
+      } else if (isUpdating) {
+        const progress = catalogConversionProgress[update.chartNumber];
+        const progressMsg = progress?.message ?? 'Converting S-57 to vector tiles...';
+        actionHtml = `
+          <div class="catalog-conversion-progress" id="catalog-conversion-${escapedNum}">
+            <div class="spinner" style="width:16px;height:16px;border-width:2px;"></div>
+            <span>${catalogEscapeHtml(progressMsg)}</span>
+            <button class="btn-catalog-log" data-catalog-log="${catalogEscapeAttr(update.chartNumber)}">Logs</button>
+          </div>`;
+      } else {
+        actionHtml = `<select class="catalog-folder-select catalog-update-folder-select" id="catalog-update-folder-${escapedNum}">
             ${buildFolderOptions(update.installedFolder)}
            </select>
            <button class="btn-catalog-download"
@@ -504,9 +544,10 @@ function renderUpdatesSection(): void {
                    data-catalog-update-datetime="${catalogEscapeAttr(update.availableDate)}">
              Update
            </button>`;
+      }
 
       return `
-        <div class="catalog-update-row${isUpdating ? ' updating' : ''}" data-chart-number="${catalogEscapeAttr(update.chartNumber)}">
+        <div class="catalog-update-row${isUpdating || isInQueue ? ' updating' : ''}" data-chart-number="${catalogEscapeAttr(update.chartNumber)}">
           <div class="catalog-update-row-info">
             <span class="catalog-update-row-title">${catalogEscapeHtml(update.title || update.chartNumber)}</span>
             <span class="catalog-update-row-dates">${catalogEscapeHtml(installedDateStr)} → ${catalogEscapeHtml(availableDateStr)}</span>
@@ -520,8 +561,21 @@ function renderUpdatesSection(): void {
 
   const allUpdating = catalogUpdates.every(
     (u) =>
-      catalogDownloadJobs[u.chartNumber] !== undefined || catalogConverting[u.chartNumber]
+      catalogDownloadJobs[u.chartNumber] !== undefined ||
+      catalogConverting[u.chartNumber] ||
+      catalogConversionErrors[u.chartNumber]
   );
+
+  // Show queue progress in the button
+  let updateAllButtonText = 'Update All';
+  let updateAllDisabled = allUpdating;
+  
+  if (catalogUpdateQueueRunning && catalogUpdateQueueIndex >= 0) {
+    const current = catalogUpdateQueueIndex + 1;
+    const total = catalogUpdateQueue.length;
+    updateAllButtonText = `Updating ${current} of ${total}...`;
+    updateAllDisabled = true;
+  }
 
   section.innerHTML = `
     <div class="catalog-updates-section">
@@ -529,9 +583,9 @@ function renderUpdatesSection(): void {
         <span class="catalog-updates-title">
           ${catalogUpdates.length} chart update${catalogUpdates.length !== 1 ? 's' : ''} available
         </span>
-        <button class="btn-catalog-download" ${allUpdating ? 'disabled' : ''}
+        <button class="btn-catalog-download" ${updateAllDisabled ? 'disabled' : ''}
                 data-catalog-update-all>
-          Update All
+          ${updateAllButtonText}
         </button>
       </div>
       <div class="catalog-updates-rows">
@@ -583,6 +637,87 @@ async function downloadUpdateChart(
     console.error('Failed to start chart update:', error);
     alert('Failed to start update. Check your network connection.');
   }
+}
+
+/**
+ * Process the update queue sequentially
+ */
+async function processUpdateQueue(): Promise<void> {
+  if (!catalogUpdateQueueRunning || catalogUpdateQueueIndex >= catalogUpdateQueue.length) {
+    // Queue complete
+    catalogUpdateQueue = [];
+    catalogUpdateQueueIndex = -1;
+    catalogUpdateQueueRunning = false;
+    renderUpdatesSection();
+    return;
+  }
+
+  const update = catalogUpdateQueue[catalogUpdateQueueIndex];
+  const folderEl = document.getElementById(
+    `catalog-update-folder-${catalogEscapeId(update.chartNumber)}`
+  ) as HTMLSelectElement | null;
+  const targetFolder = folderEl ? folderEl.value : update.installedFolder;
+
+  // Start the update
+  await downloadUpdateChart(update, targetFolder);
+
+  // Wait for this conversion to complete
+  await waitForConversion(update.chartNumber);
+
+  // Move to next item
+  catalogUpdateQueueIndex++;
+  renderUpdatesSection();
+
+  // Process next item
+  await processUpdateQueue();
+}
+
+/**
+ * Check if a chart is in the update queue
+ */
+function getQueuePosition(chartNumber: string): number | null {
+  if (!catalogUpdateQueueRunning) {
+    return null;
+  }
+  const index = catalogUpdateQueue.findIndex(u => u.chartNumber === chartNumber);
+  if (index === -1) {
+    return null;
+  }
+  return index - catalogUpdateQueueIndex; // 0 = currently processing, >0 = waiting
+}
+
+/**
+ * Poll until a chart's conversion is complete (success or failure)
+ */
+async function waitForConversion(chartNumber: string): Promise<void> {
+  const maxWait = 10 * 60 * 1000; // 10 minutes max
+  const pollInterval = 2000; // 2 seconds
+  const startTime = Date.now();
+  
+  while (Date.now() - startTime < maxWait) {
+    // Check if still downloading
+    if (catalogDownloadJobs[chartNumber] !== undefined) {
+      await new Promise(resolve => setTimeout(resolve, pollInterval));
+      continue;
+    }
+    
+    // Check if still converting
+    if (catalogConverting[chartNumber]) {
+      await new Promise(resolve => setTimeout(resolve, pollInterval));
+      continue;
+    }
+    
+    // Check if there's an error (conversion failed)
+    if (catalogConversionErrors[chartNumber]) {
+      return; // Conversion failed, stop waiting
+    }
+    
+    // If we get here, the conversion is complete (no longer in any tracking map)
+    return;
+  }
+  
+  // Timeout - conversion took too long
+  console.warn(`Conversion for ${chartNumber} timed out after 10 minutes`);
 }
 
 function renderFilterBar(): void {
@@ -675,11 +810,13 @@ async function toggleCatalog(catalogFile: string): Promise<void> {
   if (expandedCatalogs.has(catalogFile)) {
     expandedCatalogs.delete(catalogFile);
     renderCatalogList();
+    renderUpdatesSection();
     return;
   }
 
   expandedCatalogs.add(catalogFile);
   renderCatalogList();
+  renderUpdatesSection();
 
   // Load chart data if not already cached
   if (!catalogChartData[catalogFile]) {

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -57,6 +57,12 @@ interface ConversionProgress {
 
 interface CatalogUpdate {
   chartNumber: string;
+  catalogFile: string;
+  title: string;
+  installedDate: string;
+  availableDate: string;
+  downloadUrl: string;
+  installedFolder: string;
 }
 
 interface DownloadJobLite {
@@ -178,6 +184,7 @@ async function initCatalogTab(): Promise<void> {
         <a href="https://github.com/chartcatalogs/catalogs/issues" target="_blank" rel="noopener">catalog issue tracker</a>.
       </div>
       <div id="catalogPodmanWarning"></div>
+      <div id="catalogUpdatesSection"></div>
       <div id="catalogFilterBar"></div>
       <div id="catalogList">
         <div class="catalog-loading">
@@ -236,6 +243,7 @@ async function initCatalogTab(): Promise<void> {
 function wireCatalogClickHandlers(): void {
   const list = document.getElementById('catalogList');
   const filterBar = document.getElementById('catalogFilterBar');
+  const updatesSection = document.getElementById('catalogUpdatesSection');
 
   if (filterBar && !filterBar.dataset['catalogHandlerWired']) {
     filterBar.addEventListener('click', (ev) => {
@@ -301,6 +309,60 @@ function wireCatalogClickHandlers(): void {
     });
     list.dataset['catalogHandlerWired'] = '1';
   }
+
+  // Updates section uses event delegation on a stable parent container
+  // since its content is replaced on every renderUpdatesSection() call.
+  // The container itself is stable; only its innerHTML changes.
+  const output = document.getElementById('catalogOutput');
+  if (output && !output.dataset['catalogUpdateHandlerWired']) {
+    output.addEventListener('click', (ev) => {
+      const target = ev.target as HTMLElement | null;
+      if (!target) {
+        return;
+      }
+
+      // "Update All" button
+      const updateAll = target.closest<HTMLElement>('[data-catalog-update-all]');
+      if (updateAll) {
+        for (const update of catalogUpdates) {
+          const alreadyActive =
+            catalogDownloadJobs[update.chartNumber] !== undefined ||
+            catalogConverting[update.chartNumber];
+          if (!alreadyActive) {
+            const folderEl = document.getElementById(
+              `catalog-update-folder-${catalogEscapeId(update.chartNumber)}`
+            ) as HTMLSelectElement | null;
+            const targetFolder = folderEl ? folderEl.value : update.installedFolder;
+            void downloadUpdateChart(update, targetFolder);
+          }
+        }
+        return;
+      }
+
+      // Per-chart "Update" button
+      const updateBtn = target.closest<HTMLElement>('[data-catalog-update]');
+      if (updateBtn) {
+        const chartNumber = updateBtn.dataset['catalogUpdate'];
+        if (!chartNumber) {
+          return;
+        }
+        const update = catalogUpdates.find((u) => u.chartNumber === chartNumber);
+        if (!update) {
+          return;
+        }
+        const folderEl = document.getElementById(
+          `catalog-update-folder-${catalogEscapeId(chartNumber)}`
+        ) as HTMLSelectElement | null;
+        const targetFolder = folderEl ? folderEl.value : update.installedFolder;
+        void downloadUpdateChart(update, targetFolder);
+        return;
+      }
+    });
+    output.dataset['catalogUpdateHandlerWired'] = '1';
+  }
+
+  // Keep updatesSection reference used only to suppress unused-var warning.
+  void updatesSection;
 }
 
 /**
@@ -396,8 +458,130 @@ async function refreshUpdateBadge(): Promise<void> {
         badge.style.display = 'none';
       }
     }
+
+    renderUpdatesSection();
   } catch {
     // Ignore badge refresh errors
+  }
+}
+
+function renderUpdatesSection(): void {
+  const section = document.getElementById('catalogUpdatesSection');
+  if (!section) {
+    return;
+  }
+
+  if (catalogUpdates.length === 0) {
+    section.innerHTML = '';
+    return;
+  }
+
+  const rows = catalogUpdates
+    .map((update) => {
+      const installedDateStr = update.installedDate
+        ? new Date(update.installedDate).toLocaleDateString()
+        : '';
+      const availableDateStr = update.availableDate
+        ? new Date(update.availableDate).toLocaleDateString()
+        : '';
+      const escapedNum = catalogEscapeId(update.chartNumber);
+      const isUpdating =
+        catalogDownloadJobs[update.chartNumber] !== undefined ||
+        catalogConverting[update.chartNumber];
+
+      const actionHtml = isUpdating
+        ? `<div class="catalog-update-row-updating">
+            <div class="spinner" style="width:16px;height:16px;border-width:2px;flex-shrink:0;"></div>
+            <span>Updating…</span>
+           </div>`
+        : `<select class="catalog-folder-select catalog-update-folder-select" id="catalog-update-folder-${escapedNum}">
+            ${buildFolderOptions(update.installedFolder)}
+           </select>
+           <button class="btn-catalog-download"
+                   data-catalog-update="${catalogEscapeAttr(update.chartNumber)}"
+                   data-catalog-update-file="${catalogEscapeAttr(update.catalogFile)}"
+                   data-catalog-update-url="${catalogEscapeAttr(update.downloadUrl)}"
+                   data-catalog-update-datetime="${catalogEscapeAttr(update.availableDate)}">
+             Update
+           </button>`;
+
+      return `
+        <div class="catalog-update-row${isUpdating ? ' updating' : ''}" data-chart-number="${catalogEscapeAttr(update.chartNumber)}">
+          <div class="catalog-update-row-info">
+            <span class="catalog-update-row-title">${catalogEscapeHtml(update.title || update.chartNumber)}</span>
+            <span class="catalog-update-row-dates">${catalogEscapeHtml(installedDateStr)} → ${catalogEscapeHtml(availableDateStr)}</span>
+          </div>
+          <div class="catalog-update-row-actions">
+            ${actionHtml}
+          </div>
+        </div>`;
+    })
+    .join('');
+
+  const allUpdating = catalogUpdates.every(
+    (u) =>
+      catalogDownloadJobs[u.chartNumber] !== undefined || catalogConverting[u.chartNumber]
+  );
+
+  section.innerHTML = `
+    <div class="catalog-updates-section">
+      <div class="catalog-updates-header">
+        <span class="catalog-updates-title">
+          ${catalogUpdates.length} chart update${catalogUpdates.length !== 1 ? 's' : ''} available
+        </span>
+        <button class="btn-catalog-download" ${allUpdating ? 'disabled' : ''}
+                data-catalog-update-all>
+          Update All
+        </button>
+      </div>
+      <div class="catalog-updates-rows">
+        ${rows}
+      </div>
+    </div>
+  `;
+}
+
+async function downloadUpdateChart(
+  update: CatalogUpdate,
+  targetFolder: string
+): Promise<void> {
+  try {
+    const response = await fetch(`${CATALOG_API_BASE}/catalog/download`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: update.downloadUrl,
+        chartNumber: update.chartNumber,
+        catalogFile: update.catalogFile,
+        zipfileDatetime: update.availableDate,
+        targetFolder
+      })
+    });
+    if (!response.ok) {
+      let errorText: string;
+      try {
+        const body = (await response.json()) as { error?: string };
+        errorText = body.error ?? `HTTP ${response.status}`;
+      } catch {
+        errorText = `HTTP ${response.status}`;
+      }
+      alert(`Update failed: ${errorText}`);
+      return;
+    }
+    const result = (await response.json()) as CatalogDownloadResponse;
+    if (result.success) {
+      if (result.jobId && !result.jobId.startsWith('gshhg-')) {
+        catalogDownloadJobs[update.chartNumber] = result.jobId;
+      } else {
+        catalogConverting[update.chartNumber] = true;
+      }
+      renderUpdatesSection();
+    } else {
+      alert(`Update failed: ${result.error ?? ''}`);
+    }
+  } catch (error) {
+    console.error('Failed to start chart update:', error);
+    alert('Failed to start update. Check your network connection.');
   }
 }
 

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -253,7 +253,6 @@ async function initCatalogTab(): Promise<void> {
 function wireCatalogClickHandlers(): void {
   const list = document.getElementById('catalogList');
   const filterBar = document.getElementById('catalogFilterBar');
-  const updatesSection = document.getElementById('catalogUpdatesSection');
 
   if (filterBar && !filterBar.dataset['catalogHandlerWired']) {
     filterBar.addEventListener('click', (ev) => {
@@ -334,6 +333,11 @@ function wireCatalogClickHandlers(): void {
       // "Update All" button - queue updates for sequential processing
       const updateAll = target.closest<HTMLElement>('[data-catalog-update-all]');
       if (updateAll) {
+        // Ignore re-clicks while a queue is running — rebuilding the queue
+        // mid-run would reset the index and drop in-flight items.
+        if (catalogUpdateQueueRunning) {
+          return;
+        }
         const updatesToQueue: QueuedCatalogUpdate[] = [];
         for (const update of catalogUpdates) {
           const alreadyActive =
@@ -378,12 +382,35 @@ function wireCatalogClickHandlers(): void {
         void downloadUpdateChart(update, targetFolder);
         return;
       }
+
+      // Logs / Dismiss buttons rendered inside the updates panel. These
+      // live under #catalogOutput, so the #catalogList handler never sees
+      // them — wire them here too or they'd be dead in the updates panel.
+      // #catalogList is also a descendant of #catalogOutput, so skip clicks
+      // that originate there: its own handler already processes them and we
+      // must not fire twice.
+      if (!target.closest('#catalogList')) {
+        const updateLog = target.closest<HTMLElement>('[data-catalog-log]');
+        if (updateLog) {
+          const chartNumber = updateLog.dataset['catalogLog'];
+          if (chartNumber) {
+            void showConversionLog(chartNumber);
+          }
+          return;
+        }
+
+        const updateDismiss = target.closest<HTMLElement>('[data-catalog-dismiss]');
+        if (updateDismiss) {
+          const chartNumber = updateDismiss.dataset['catalogDismiss'];
+          if (chartNumber) {
+            dismissConversionError(chartNumber);
+          }
+          return;
+        }
+      }
     });
     output.dataset['catalogUpdateHandlerWired'] = '1';
   }
-
-  // Keep updatesSection reference used only to suppress unused-var warning.
-  void updatesSection;
 }
 
 /**
@@ -630,11 +657,16 @@ async function downloadUpdateChart(
       } catch {
         errorText = `HTTP ${response.status}`;
       }
-      alert(`Update failed: ${errorText}`);
+      failUpdate(update.chartNumber, errorText);
       return;
     }
     const result = (await response.json()) as CatalogDownloadResponse;
     if (result.success) {
+      // A retry has started — drop any error from the previous attempt so
+      // the row shows progress, not the stale failure (renderUpdatesSection
+      // checks conversionError before the in-progress state).
+      delete catalogConversionErrors[update.chartNumber];
+      dismissedConversionErrors.delete(update.chartNumber);
       if (result.jobId && !result.jobId.startsWith('gshhg-')) {
         catalogDownloadJobs[update.chartNumber] = result.jobId;
       } else {
@@ -642,12 +674,23 @@ async function downloadUpdateChart(
       }
       renderUpdatesSection();
     } else {
-      alert(`Update failed: ${result.error ?? ''}`);
+      failUpdate(update.chartNumber, result.error ?? 'Update failed');
     }
   } catch (error) {
     console.error('Failed to start chart update:', error);
-    alert('Failed to start update. Check your network connection.');
+    failUpdate(update.chartNumber, 'Failed to start update. Check your network connection.');
   }
+}
+
+/**
+ * Record a failed update so the queue (via waitForConversion) stops on it
+ * rather than silently skipping to the next chart, and the failure surfaces
+ * in the UI. `dismissedConversionErrors` is cleared so a retry's error shows.
+ */
+function failUpdate(chartNumber: string, errorText: string): void {
+  catalogConversionErrors[chartNumber] = errorText;
+  dismissedConversionErrors.delete(chartNumber);
+  renderUpdatesSection();
 }
 
 /**
@@ -655,6 +698,11 @@ async function downloadUpdateChart(
  * `catalogUpdateQueueRunning` is true while the queue is active;
  * `catalogUpdateQueueIndex` tracks the current item. Recursion advances
  * to the next chart only after `waitForConversion` resolves.
+ *
+ * A failed item does NOT abort the run: its error is recorded in
+ * `catalogConversionErrors` (shown per-row) and the queue continues, so one
+ * bad chart in an "Update All" batch doesn't strand the rest. The user sees
+ * exactly which charts failed and can retry those individually.
  */
 async function processUpdateQueue(): Promise<void> {
   if (!catalogUpdateQueueRunning || catalogUpdateQueueIndex >= catalogUpdateQueue.length) {
@@ -697,35 +745,28 @@ async function waitForConversion(chartNumber: string): Promise<void> {
   const maxWait = 10 * 60 * 1000; // 10 minutes max
   const pollInterval = 2000; // 2 seconds
   const startTime = Date.now();
-  let warned = false;
 
   while (true) {
-    // Check if still downloading
-    if (catalogDownloadJobs[chartNumber] !== undefined) {
-      if (!warned && Date.now() - startTime >= maxWait) {
-        console.warn(`Conversion for ${chartNumber} is taking longer than 10 minutes; still waiting...`);
-        warned = true;
+    const stillDownloading = catalogDownloadJobs[chartNumber] !== undefined;
+    const stillConverting = catalogConverting[chartNumber];
+
+    if (stillDownloading || stillConverting) {
+      // Hard timeout: a stuck download/conversion (hung runtime, lost
+      // progress updates) must not block the queue forever. Record a
+      // terminal error and stop waiting so the queue advances and the UI
+      // shows the failure instead of a permanent "Updating…" spinner.
+      if (Date.now() - startTime >= maxWait) {
+        delete catalogDownloadJobs[chartNumber];
+        delete catalogConverting[chartNumber];
+        failUpdate(chartNumber, 'Timed out waiting for conversion (10 min)');
+        return;
       }
       await new Promise(resolve => setTimeout(resolve, pollInterval));
       continue;
     }
 
-    // Check if still converting
-    if (catalogConverting[chartNumber]) {
-      if (!warned && Date.now() - startTime >= maxWait) {
-        console.warn(`Conversion for ${chartNumber} is taking longer than 10 minutes; still waiting...`);
-        warned = true;
-      }
-      await new Promise(resolve => setTimeout(resolve, pollInterval));
-      continue;
-    }
-
-    // Check if there's an error (conversion failed)
-    if (catalogConversionErrors[chartNumber]) {
-      return; // Conversion failed, stop waiting
-    }
-
-    // If we get here, the conversion is complete (no longer in any tracking map)
+    // Not downloading or converting any more: complete (success) or failed
+    // — either way the chart left the active maps, so stop waiting.
     return;
   }
 }
@@ -1084,6 +1125,7 @@ function dismissConversionError(chartNumber: string): void {
   delete catalogConversionErrors[chartNumber];
   dismissedConversionErrors.add(chartNumber);
   renderCatalogList();
+  renderUpdatesSection();
 }
 
 async function pollCatalogDownloads(): Promise<void> {
@@ -1145,6 +1187,7 @@ async function pollCatalogDownloads(): Promise<void> {
           }
         }
         renderCatalogList();
+        renderUpdatesSection();
       } else if (job.status === 'failed') {
         delete catalogDownloadJobs[chartNumber];
         if (progressEl) {
@@ -1160,6 +1203,7 @@ async function pollCatalogDownloads(): Promise<void> {
         }
         setTimeout(() => {
           renderCatalogList();
+          renderUpdatesSection();
         }, 5000);
       } else if (progressEl) {
         const fillEl = progressEl.querySelector<HTMLElement>('.progress-fill');
@@ -1321,6 +1365,7 @@ async function pollConversions(): Promise<void> {
     }
     if (stateChanged) {
       renderCatalogList();
+      renderUpdatesSection();
     } else {
       updateConversionMessagesInPlace();
     }

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -65,6 +65,11 @@ interface CatalogUpdate {
   installedFolder: string;
 }
 
+interface QueuedCatalogUpdate {
+  update: CatalogUpdate;
+  targetFolder: string;
+}
+
 interface DownloadJobLite {
   id: string;
   // chartName on the server side is the chartNumber the catalog
@@ -100,7 +105,7 @@ const catalogChartData: Record<string, CatalogData> = {};
 let catalogFolders: string[] = ['/'];
 
 // Update queue management
-let catalogUpdateQueue: CatalogUpdate[] = [];
+let catalogUpdateQueue: QueuedCatalogUpdate[] = [];
 let catalogUpdateQueueIndex = -1;
 let catalogUpdateQueueRunning = false;
 const catalogDownloadJobs: Record<string, string> = {};
@@ -329,13 +334,19 @@ function wireCatalogClickHandlers(): void {
       // "Update All" button - queue updates for sequential processing
       const updateAll = target.closest<HTMLElement>('[data-catalog-update-all]');
       if (updateAll) {
-        const updatesToQueue: CatalogUpdate[] = [];
+        const updatesToQueue: QueuedCatalogUpdate[] = [];
         for (const update of catalogUpdates) {
           const alreadyActive =
             catalogDownloadJobs[update.chartNumber] !== undefined ||
             catalogConverting[update.chartNumber];
           if (!alreadyActive) {
-            updatesToQueue.push(update);
+            const folderEl = document.getElementById(
+              `catalog-update-folder-${catalogEscapeId(update.chartNumber)}`
+            ) as HTMLSelectElement | null;
+            updatesToQueue.push({
+              update,
+              targetFolder: folderEl ? folderEl.value : update.installedFolder
+            });
           }
         }
         
@@ -640,11 +651,13 @@ async function downloadUpdateChart(
 }
 
 /**
- * Process the update queue sequentially
+ * Serialize catalog updates so only one download/conversion runs at a time.
+ * `catalogUpdateQueueRunning` is true while the queue is active;
+ * `catalogUpdateQueueIndex` tracks the current item. Recursion advances
+ * to the next chart only after `waitForConversion` resolves.
  */
 async function processUpdateQueue(): Promise<void> {
   if (!catalogUpdateQueueRunning || catalogUpdateQueueIndex >= catalogUpdateQueue.length) {
-    // Queue complete
     catalogUpdateQueue = [];
     catalogUpdateQueueIndex = -1;
     catalogUpdateQueueRunning = false;
@@ -652,34 +665,25 @@ async function processUpdateQueue(): Promise<void> {
     return;
   }
 
-  const update = catalogUpdateQueue[catalogUpdateQueueIndex];
-  const folderEl = document.getElementById(
-    `catalog-update-folder-${catalogEscapeId(update.chartNumber)}`
-  ) as HTMLSelectElement | null;
-  const targetFolder = folderEl ? folderEl.value : update.installedFolder;
-
-  // Start the update
+  const { update, targetFolder } = catalogUpdateQueue[catalogUpdateQueueIndex];
   await downloadUpdateChart(update, targetFolder);
-
-  // Wait for this conversion to complete
   await waitForConversion(update.chartNumber);
 
-  // Move to next item
   catalogUpdateQueueIndex++;
   renderUpdatesSection();
-
-  // Process next item
   await processUpdateQueue();
 }
 
 /**
- * Check if a chart is in the update queue
+ * Relative queue position for a chart number. Returns `0` when the chart
+ * is currently processing, a positive number when waiting, and `null`
+ * when the queue is not running or the chart is not queued.
  */
 function getQueuePosition(chartNumber: string): number | null {
   if (!catalogUpdateQueueRunning) {
     return null;
   }
-  const index = catalogUpdateQueue.findIndex(u => u.chartNumber === chartNumber);
+  const index = catalogUpdateQueue.findIndex(u => u.update.chartNumber === chartNumber);
   if (index === -1) {
     return null;
   }
@@ -693,31 +697,37 @@ async function waitForConversion(chartNumber: string): Promise<void> {
   const maxWait = 10 * 60 * 1000; // 10 minutes max
   const pollInterval = 2000; // 2 seconds
   const startTime = Date.now();
-  
-  while (Date.now() - startTime < maxWait) {
+  let warned = false;
+
+  while (true) {
     // Check if still downloading
     if (catalogDownloadJobs[chartNumber] !== undefined) {
+      if (!warned && Date.now() - startTime >= maxWait) {
+        console.warn(`Conversion for ${chartNumber} is taking longer than 10 minutes; still waiting...`);
+        warned = true;
+      }
       await new Promise(resolve => setTimeout(resolve, pollInterval));
       continue;
     }
-    
+
     // Check if still converting
     if (catalogConverting[chartNumber]) {
+      if (!warned && Date.now() - startTime >= maxWait) {
+        console.warn(`Conversion for ${chartNumber} is taking longer than 10 minutes; still waiting...`);
+        warned = true;
+      }
       await new Promise(resolve => setTimeout(resolve, pollInterval));
       continue;
     }
-    
+
     // Check if there's an error (conversion failed)
     if (catalogConversionErrors[chartNumber]) {
       return; // Conversion failed, stop waiting
     }
-    
+
     // If we get here, the conversion is complete (no longer in any tracking map)
     return;
   }
-  
-  // Timeout - conversion took too long
-  console.warn(`Conversion for ${chartNumber} timed out after 10 minutes`);
 }
 
 function renderFilterBar(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1833,7 +1833,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
     router.get('/catalog-updates', (_req: Request, res: Response) => {
       try {
-        const updates = checkForUpdates(props.chartPath || defaultChartsPath);
+        const updates = checkForUpdates();
         res.json(updates);
       } catch (error) {
         console.error('Error checking catalog updates:', error);
@@ -2870,7 +2870,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           await fetchCatalog(catalogFile);
         }
 
-        const updates = checkForUpdates(props.chartPath || defaultChartsPath);
+        const updates = checkForUpdates();
         if (updates.length > 0) {
           app.debug(`Found ${updates.length} chart update(s) available from catalog`);
           if (props.disableUpdateNotifications) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,81 +1,82 @@
-import path from 'path';
+import type { Path, Plugin } from '@signalk/server-api';
+import { SKVersion } from '@signalk/server-api';
+import { Type } from '@sinclair/typebox';
+import Busboy from 'busboy';
 import fs from 'fs';
 import https from 'https';
-import type { Plugin, Path } from '@signalk/server-api';
-import { SKVersion } from '@signalk/server-api';
+import { DatabaseSync } from 'node:sqlite';
+import path from 'path';
 import { findCharts, findRepairableCharts } from './charts-loader.js';
-import { scanChartsRecursively, scanAllFolders } from './utils/file-scanner.js';
-import { initChartState, isChartEnabled, setChartEnabled } from './utils/chart-state.js';
-import { downloadManager } from './utils/download-manager.js';
 import {
-  initCatalogManager,
-  getCatalogRegistry,
+  checkForUpdates,
+  classifyUrl,
   fetchCatalog,
   getCachedCatalog,
-  classifyUrl,
-  trackInstall,
-  setInstallFilename,
-  renameInstallFilename,
-  removeInstall,
-  removeInstallByFilename,
-  getInstalledCatalogCharts,
-  pruneStaleInstalls,
-  setConvertingState,
+  getCatalogRegistry,
+  getCatalogsWithInstalledCharts,
   getConvertingCharts,
   getConvertingCount,
-  checkForUpdates,
-  getCatalogsWithInstalledCharts
+  getInstalledCatalogCharts,
+  initCatalogManager,
+  pruneStaleInstalls,
+  removeInstall,
+  removeInstallByFilename,
+  renameInstallFilename,
+  setConvertingState,
+  setInstallFilename,
+  trackInstall
 } from './utils/catalog-manager.js';
-import {
-  initS57Converter,
-  processS57Zip,
-  getAllConversionProgress as getAllS57Progress,
-  getConversionProgress as getS57Progress,
-  setConversionFailed as setS57Failed
-} from './utils/s57-converter.js';
-import { getContainerManager, waitForContainerManager } from './utils/container-manager.js';
+import { cleanCatalogTitle } from './utils/catalog-title.js';
+import { initChartState, isChartEnabled, setChartEnabled } from './utils/chart-state.js';
+import { getCpuBudget, setCpuBudget } from './utils/concurrency.js';
 import { PLUGIN_OWNER_ID } from './utils/container-jobs.js';
+import { getContainerManager, waitForContainerManager } from './utils/container-manager.js';
+import { downloadManager } from './utils/download-manager.js';
+import { scanAllFolders, scanChartsRecursively } from './utils/file-scanner.js';
+import { repairMbtilesMetadata, setMbtilesDisplayName } from './utils/mbtiles-metadata.js';
+import { open as openMbtilesReader } from './utils/mbtiles-reader.js';
+import { writeChartPathMarker } from './utils/path-marker.js';
+import { arePairWithinBase, isWithinBase, validateChartName } from './utils/path-safety.js';
+import { parsePluginConfig } from './utils/plugin-config-schema.js';
 import {
   cleanupQuarantineDir,
   makeQuarantineDir,
   promoteQuarantine,
   sweepStaleQuarantineDirs
 } from './utils/quarantine.js';
-import { cleanCatalogTitle } from './utils/catalog-title.js';
-import { setMbtilesDisplayName, repairMbtilesMetadata } from './utils/mbtiles-metadata.js';
-import { open as openMbtilesReader } from './utils/mbtiles-reader.js';
+import { parseBody, parseShape } from './utils/rest-validation.js';
 import {
-  initRncConverter,
-  processRncZip,
-  processPilotTar,
   getAllConversionProgress as getAllRncProgress,
   getConversionProgress as getRncProgress,
+  initRncConverter,
+  processPilotTar,
+  processRncZip,
   setConversionFailed as setRncFailed
 } from './utils/rnc-converter.js';
-import { processGshhg, processShpBasemap } from './utils/s57-converter.js';
-import { getCpuBudget, setCpuBudget } from './utils/concurrency.js';
-import { writeChartPathMarker } from './utils/path-marker.js';
-import { parsePluginConfig } from './utils/plugin-config-schema.js';
-import { Type } from '@sinclair/typebox';
-import { parseBody, parseShape } from './utils/rest-validation.js';
-import { isWithinBase, arePairWithinBase, validateChartName } from './utils/path-safety.js';
-import Busboy from 'busboy';
-import { DatabaseSync } from 'node:sqlite';
+import {
+  getAllConversionProgress as getAllS57Progress,
+  getConversionProgress as getS57Progress,
+  initS57Converter,
+  processGshhg,
+  processS57Zip,
+  processShpBasemap,
+  setConversionFailed as setS57Failed
+} from './utils/s57-converter.js';
 
 // JSON import with type attribute (NodeNext ESM). package.json's `version`
 // is what the marker file records so users can confirm the running build.
 import packageJson from '../package.json' with { type: 'json' };
-const pluginVersion: string = (packageJson as { version: string }).version;
 import type {
-  ExtendedServerAPI,
-  PluginConfig,
   ChartProvider,
-  SanitizedChart,
+  DownloadJob,
+  ExtendedServerAPI,
   IRouter,
+  PluginConfig,
   Request,
   Response,
-  DownloadJob
+  SanitizedChart
 } from './types.js';
+const pluginVersion: string = (packageJson as { version: string }).version;
 
 // Single source of truth lives in container-jobs.ts as PLUGIN_OWNER_ID
 // (used as the `ownerPluginId` label on every runJob call). The plugin
@@ -1832,7 +1833,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
     router.get('/catalog-updates', (_req: Request, res: Response) => {
       try {
-        const updates = checkForUpdates();
+        const updates = checkForUpdates(props.chartPath || defaultChartsPath);
         res.json(updates);
       } catch (error) {
         console.error('Error checking catalog updates:', error);
@@ -2869,7 +2870,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           await fetchCatalog(catalogFile);
         }
 
-        const updates = checkForUpdates();
+        const updates = checkForUpdates(props.chartPath || defaultChartsPath);
         if (updates.length > 0) {
           app.debug(`Found ${updates.length} chart update(s) available from catalog`);
           if (props.disableUpdateNotifications) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,8 +181,13 @@ export interface DownloadJob {
 // it stays a plain interface.
 
 export type {
-    CatalogCategory, CatalogChart, CatalogData, CatalogHeader, CatalogInstall,
-    CatalogInstallsMap, CatalogRegistryEntry
+  CatalogCategory,
+  CatalogChart,
+  CatalogData,
+  CatalogHeader,
+  CatalogInstall,
+  CatalogInstallsMap,
+  CatalogRegistryEntry
 } from './utils/catalog-schemas.js';
 
 import type { CatalogRegistryEntry } from './utils/catalog-schemas.js';
@@ -322,4 +327,3 @@ export interface TilemapXml {
 // ---- Express route helpers ----
 
 export type { IRouter, Request, Response };
-

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { ServerAPI } from '@signalk/server-api';
-import type { Request, Response, IRouter } from 'express';
+import type { IRouter, Request, Response } from 'express';
 import type { MBTilesReader } from './utils/mbtiles-reader.js';
 
 // ---- Plugin Configuration ----
@@ -181,13 +181,8 @@ export interface DownloadJob {
 // it stays a plain interface.
 
 export type {
-  CatalogCategory,
-  CatalogRegistryEntry,
-  CatalogChart,
-  CatalogHeader,
-  CatalogData,
-  CatalogInstall,
-  CatalogInstallsMap
+    CatalogCategory, CatalogChart, CatalogData, CatalogHeader, CatalogInstall,
+    CatalogInstallsMap, CatalogRegistryEntry
 } from './utils/catalog-schemas.js';
 
 import type { CatalogRegistryEntry } from './utils/catalog-schemas.js';
@@ -222,6 +217,8 @@ export interface CatalogUpdate {
   installedDate: string;
   availableDate: string;
   downloadUrl: string;
+  /** Chart-path-relative folder of the installed file, e.g. "Netherlands Inland ENC". '/' means root. */
+  installedFolder: string;
 }
 
 // ---- Conversion Progress ----
@@ -324,4 +321,5 @@ export interface TilemapXml {
 
 // ---- Express route helpers ----
 
-export type { Request, Response, IRouter };
+export type { IRouter, Request, Response };
+

--- a/src/utils/catalog-manager.ts
+++ b/src/utils/catalog-manager.ts
@@ -583,11 +583,13 @@ export function checkForUpdates(chartPath: string): CatalogUpdate[] {
     ) {
       let installedFolder = '/';
       if (install.installedFilename) {
-        const rel = path.relative(chartPath, path.dirname(install.installedFilename));
-        // path.relative returns '' when the file is in chartPath root,
-        // and something like '../foo' when outside — treat both as root.
-        if (rel && !rel.startsWith('..') && rel !== '.') {
-          installedFolder = rel;
+        // installedFilename is already relative to chartPath (stored by
+        // setInstallFilename), so just extract the directory portion.
+        const folder = path.dirname(install.installedFilename);
+        // path.dirname returns '.' when the file is in the root folder,
+        // and could return '../foo' if somehow stored outside — treat both as root.
+        if (folder && folder !== '.' && !folder.startsWith('..')) {
+          installedFolder = folder;
         }
       }
       updates.push({

--- a/src/utils/catalog-manager.ts
+++ b/src/utils/catalog-manager.ts
@@ -562,7 +562,7 @@ export function getConvertingCount(): number {
   return Object.keys(converting).length;
 }
 
-export function checkForUpdates(chartPath = ''): CatalogUpdate[] {
+export function checkForUpdates(): CatalogUpdate[] {
   const updates: CatalogUpdate[] = [];
 
   for (const [chartNumber, install] of Object.entries(installs)) {

--- a/src/utils/catalog-manager.ts
+++ b/src/utils/catalog-manager.ts
@@ -562,7 +562,7 @@ export function getConvertingCount(): number {
   return Object.keys(converting).length;
 }
 
-export function checkForUpdates(chartPath: string): CatalogUpdate[] {
+export function checkForUpdates(chartPath = ''): CatalogUpdate[] {
   const updates: CatalogUpdate[] = [];
 
   for (const [chartNumber, install] of Object.entries(installs)) {

--- a/src/utils/catalog-manager.ts
+++ b/src/utils/catalog-manager.ts
@@ -584,11 +584,21 @@ export function checkForUpdates(): CatalogUpdate[] {
       let installedFolder = '/';
       if (install.installedFilename) {
         // installedFilename is already relative to chartPath (stored by
-        // setInstallFilename), so just extract the directory portion.
-        const folder = path.dirname(install.installedFilename);
-        // path.dirname returns '.' when the file is in the root folder,
-        // and could return '../foo' if somehow stored outside — treat both as root.
-        if (folder && folder !== '.' && !folder.startsWith('..')) {
+        // setInstallFilename). Normalize to forward slashes (the frontend
+        // joins this folder with '/', and dirname yields backslashes on
+        // Windows) and take the directory portion with posix semantics.
+        const normalized = install.installedFilename.replace(/\\/g, '/');
+        const folder = path.posix.dirname(normalized);
+        // dirname returns '.' for a file in the root folder. Treat that,
+        // any traversal ('../foo'), and any absolute path (a malformed
+        // record) as root — installedFolder must stay chart-path-relative.
+        if (
+          folder &&
+          folder !== '.' &&
+          folder !== '/' &&
+          !folder.startsWith('../') &&
+          !path.posix.isAbsolute(folder)
+        ) {
           installedFolder = folder;
         }
       }

--- a/src/utils/catalog-manager.ts
+++ b/src/utils/catalog-manager.ts
@@ -1,17 +1,17 @@
-import https from 'https';
 import fs from 'fs';
+import https from 'https';
 import path from 'path';
 import { parseStringPromise } from 'xml2js';
 import type {
+  CatalogCategory,
+  CatalogChart,
+  CatalogData,
+  CatalogInstallsMap,
   CatalogRegistryEntry,
   CatalogRegistryInfo,
-  CatalogCategory,
-  CatalogData,
-  CatalogChart,
-  CatalogInstallsMap,
-  UrlClassification,
   CatalogUpdate,
-  DebugFunction
+  DebugFunction,
+  UrlClassification
 } from '../types.js';
 import {
   CatalogDataSchema,
@@ -562,7 +562,7 @@ export function getConvertingCount(): number {
   return Object.keys(converting).length;
 }
 
-export function checkForUpdates(): CatalogUpdate[] {
+export function checkForUpdates(chartPath: string): CatalogUpdate[] {
   const updates: CatalogUpdate[] = [];
 
   for (const [chartNumber, install] of Object.entries(installs)) {
@@ -581,13 +581,23 @@ export function checkForUpdates(): CatalogUpdate[] {
       install.zipfile_datetime_iso8601 &&
       catalogChart.zipfile_datetime_iso8601 > install.zipfile_datetime_iso8601
     ) {
+      let installedFolder = '/';
+      if (install.installedFilename) {
+        const rel = path.relative(chartPath, path.dirname(install.installedFilename));
+        // path.relative returns '' when the file is in chartPath root,
+        // and something like '../foo' when outside — treat both as root.
+        if (rel && !rel.startsWith('..') && rel !== '.') {
+          installedFolder = rel;
+        }
+      }
       updates.push({
         chartNumber,
         catalogFile: install.catalogFile,
         title: catalogChart.title,
         installedDate: install.zipfile_datetime_iso8601,
         availableDate: catalogChart.zipfile_datetime_iso8601,
-        downloadUrl: catalogChart.zipfile_location
+        downloadUrl: catalogChart.zipfile_location,
+        installedFolder
       });
     }
   }

--- a/test/catalog-manager.test.ts
+++ b/test/catalog-manager.test.ts
@@ -13,6 +13,7 @@ import {
   getCatalogRegistry,
   classifyUrl,
   trackInstall,
+  setInstallFilename,
   removeInstall,
   getInstalledCatalogCharts,
   checkForUpdates,
@@ -293,6 +294,55 @@ describe('CatalogManager', () => {
       assert.strictEqual(updates.length, 0);
 
       removeInstall('same_date_chart');
+    });
+
+    it('reports installedFolder as POSIX, defaulting to root', () => {
+      const cacheDir = path.join(TEST_DATA_DIR, 'catalog-cache');
+      const cacheData = {
+        fetchedAt: new Date().toISOString(),
+        catalogFile: 'NOAA_MBTiles_Catalog.xml',
+        header: { title: 'Test' },
+        charts: [
+          {
+            number: 'folder_chart',
+            title: 'Folder Chart',
+            format: 'MBTiles',
+            zipfile_location: 'https://example.com/test.mbtiles',
+            zipfile_datetime_iso8601: '2024-06-01T00:00:00Z'
+          }
+        ]
+      };
+      fs.writeFileSync(
+        path.join(cacheDir, 'NOAA_MBTiles_Catalog.json'),
+        JSON.stringify(cacheData),
+        'utf-8'
+      );
+
+      // No installedFilename → folder defaults to root.
+      trackInstall(
+        'folder_chart',
+        'NOAA_MBTiles_Catalog.xml',
+        '2023-08-02T00:08:00Z',
+        'https://example.com/test.mbtiles'
+      );
+      assert.strictEqual(checkForUpdates()[0]!.installedFolder, '/');
+
+      // File in the chart-root → still root.
+      setInstallFilename('folder_chart', 'folder_chart.mbtiles');
+      assert.strictEqual(checkForUpdates()[0]!.installedFolder, '/');
+
+      // File in a nested folder → the folder, normalized to forward
+      // slashes. Build the stored relative path with the platform
+      // separator so the test exercises the normalization on Windows too.
+      setInstallFilename('folder_chart', path.join('Europe', 'NL', 'folder_chart.mbtiles'));
+      assert.strictEqual(checkForUpdates()[0]!.installedFolder, 'Europe/NL');
+
+      // A malformed absolute path must collapse to root, never leak a host
+      // folder (installedFolder is documented as chart-path-relative).
+      setInstallFilename('folder_chart', '/var/charts/folder_chart.mbtiles');
+      assert.strictEqual(checkForUpdates()[0]!.installedFolder, '/');
+
+      removeInstall('folder_chart');
     });
   });
 


### PR DESCRIPTION
This PR adds an easy update screen. 
You no longer need to remember / search for charts to update.

<img width="1890" height="936" alt="image" src="https://github.com/user-attachments/assets/d5cf24e7-f106-45e1-9584-11399cd42ffe" />

note: It looks like it works well, but needs further testing when #117 is closed
note: claude did some other changes to the imports that are I believe are not really needed. If undesired, I can instruct it to restore that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Adds a dedicated Updates section to the Chart Catalog UI so users can view and apply available chart updates from one place. The UI shows pending updates, per-chart folder selectors, per-chart Update actions, and a top-level "Update All" action that queues sequential updates.

## Changes

**UI & Styling**
- Adds styles in public/css/chart-catalog.css (+111/-1) for an Updates section: container, header, row layout, separators, title/date/action styles, an `.updating` opacity state, a constrained folder-select, and a mobile media query that stacks rows and makes actions/select span full width.

**Frontend Logic**
- Extends public/js/chart-catalog.ts with CatalogUpdate metadata and queued-update state to serialize “Update All” execution.
- Adds renderUpdatesSection() to build the updates header and per-chart rows, format installed/available dates, compute per-chart state (queued/waiting, downloading, converting, conversion error), and render appropriate action UI (folder selector + Update, queued/waiting message, or Logs/Dismiss for terminal/error states).
- Implements update actions and queue processing:
  - downloadUpdateChart() POSTs update parameters (download URL, chart id/number, catalog file, zip timestamp from availableDate, selected target folder) to the server, updates local tracking maps (catalogDownloadJobs, catalogConverting) on success, surfaces server errors on failure, and re-renders the section.
  - processUpdateQueue() runs queued updates sequentially and uses waitForConversion() polling (10-minute timeout) to wait for each conversion to finish.
  - getQueuePosition() computes per-chart queue positions; the Update All button text/disabled state reflect queue progress.
- Uses event delegation on the stable catalogOutput element for update-related click handling and re-renders the Updates section when catalogs expand/collapse or when update badge data is refreshed.

**Types & Data**
- Adds installedFolder: string to CatalogUpdate in src/types.ts (path-relative; '/' denotes root) to track the target folder for each update.

**Backend Logic**
- Updates src/utils/catalog-manager.ts so checkForUpdates(...) returns CatalogUpdate objects that include installedFolder (defaults to '/' or is derived from install.installedFilename with '.' and parent paths normalized to '/').
- Ensures index.ts calls checkForUpdates with the resolved chart base path (props.chartPath || defaultChartsPath) for the /catalog-updates route and background checker.
- Reorganizes some import/type ordering in src/index.ts and src/types.ts (no API signature changes).

## Notes

- Functionality appears to work but requires further testing once related issue/PR `#117` is closed.
- The contributor "claude" made import reordering changes that may be optional and can be reverted if undesired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->