### PR TITLE
fix permission issues when downloading charts

### DIFF
--- a/src/utils/container-fs.ts
+++ b/src/utils/container-fs.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+
+// The charts-toolbox image runs as `USER toolbox` (UID/GID 1001). Host
+// processes create scratch dirs as 0o755 owned by the host UID, which the
+// container user cannot write — the root cause of the "/output: Permission
+// denied" failures when converting charts in a rootless container.
+const TOOLBOX_UID = 1001;
+
+/**
+ * Create a scratch directory and make it writable by the toolbox container
+ * user. Prefer transferring ownership to UID 1001 (keeps the dir at a
+ * least-privilege 0o755); fall back to world-writable 0o777 only when the
+ * host process lacks CAP_CHOWN (the common rootless case, where chown EPERMs).
+ *
+ * Use this for any dir that gets bind-mounted as a writable container mount
+ * (`/output`, `/work`, …). Input-only mounts don't need it.
+ */
+export function makeContainerWritableDir(dir: string): string {
+  fs.mkdirSync(dir, { recursive: true });
+  makeContainerWritable(dir);
+  return dir;
+}
+
+/**
+ * Make an already-created directory writable by the toolbox container user.
+ * Same policy as {@link makeContainerWritableDir} for callers that mkdir
+ * separately (e.g. with extra options).
+ */
+export function makeContainerWritable(dir: string): void {
+  try {
+    fs.chownSync(dir, TOOLBOX_UID, -1);
+    fs.chmodSync(dir, 0o755);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EPERM') {
+      fs.chmodSync(dir, 0o777);
+    } else {
+      throw err;
+    }
+  }
+}

--- a/src/utils/quarantine.ts
+++ b/src/utils/quarantine.ts
@@ -37,9 +37,20 @@ export function makeQuarantineDir(dataDir: string, chartNumber: string): string 
   const dir = path.join(dataDir, QUARANTINE_ROOT_NAME, sanitizeIdSegment(chartNumber));
   fs.mkdirSync(dir, { recursive: true });
   // Container runs as UID 1001 (toolbox user); host-created dirs default
-  // to 0o755 owned by the host process UID. Chmod to 0o777 so the container
-  // can write .mbtiles output files.
-  fs.chmodSync(dir, 0o777);
+  // to 0o755 owned by the host process UID. Transfer ownership to the
+  // container user if possible, otherwise fall back to world-writable.
+  try {
+    fs.chownSync(dir, 1001, -1);
+    fs.chmodSync(dir, 0o755);
+  } catch (err) {
+    // Host process lacks CAP_CHOWN; fall back to world-writable so
+    // the container can still write output.
+    if ((err as NodeJS.ErrnoException).code === 'EPERM') {
+      fs.chmodSync(dir, 0o777);
+    } else {
+      throw err;
+    }
+  }
   return dir;
 }
 

--- a/src/utils/quarantine.ts
+++ b/src/utils/quarantine.ts
@@ -36,6 +36,10 @@ const QUARANTINE_ROOT_NAME = 'in-progress';
 export function makeQuarantineDir(dataDir: string, chartNumber: string): string {
   const dir = path.join(dataDir, QUARANTINE_ROOT_NAME, sanitizeIdSegment(chartNumber));
   fs.mkdirSync(dir, { recursive: true });
+  // Container runs as UID 1001 (toolbox user); host-created dirs default
+  // to 0o755 owned by the host process UID. Chmod to 0o777 so the container
+  // can write .mbtiles output files.
+  fs.chmodSync(dir, 0o777);
   return dir;
 }
 

--- a/src/utils/quarantine.ts
+++ b/src/utils/quarantine.ts
@@ -24,6 +24,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { makeContainerWritable } from './container-fs.js';
 
 const QUARANTINE_ROOT_NAME = 'in-progress';
 
@@ -36,21 +37,7 @@ const QUARANTINE_ROOT_NAME = 'in-progress';
 export function makeQuarantineDir(dataDir: string, chartNumber: string): string {
   const dir = path.join(dataDir, QUARANTINE_ROOT_NAME, sanitizeIdSegment(chartNumber));
   fs.mkdirSync(dir, { recursive: true });
-  // Container runs as UID 1001 (toolbox user); host-created dirs default
-  // to 0o755 owned by the host process UID. Transfer ownership to the
-  // container user if possible, otherwise fall back to world-writable.
-  try {
-    fs.chownSync(dir, 1001, -1);
-    fs.chmodSync(dir, 0o755);
-  } catch (err) {
-    // Host process lacks CAP_CHOWN; fall back to world-writable so
-    // the container can still write output.
-    if ((err as NodeJS.ErrnoException).code === 'EPERM') {
-      fs.chmodSync(dir, 0o777);
-    } else {
-      throw err;
-    }
-  }
+  makeContainerWritable(dir);
   return dir;
 }
 

--- a/src/utils/rnc-converter.ts
+++ b/src/utils/rnc-converter.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import unzipper from 'unzipper';
+import { makeContainerWritableDir } from './container-fs.js';
 import { CHARTS_TOOLBOX_IMAGE } from './container-images.js';
 import {
   ensureImage as ensureContainerImage,
@@ -388,8 +389,7 @@ export async function processPilotTar(
 ): Promise<RncConversionResult> {
   const statusFn = onStatus ?? (() => {});
 
-  const tmpDir = path.join(path.dirname(tarPath), `pilot_${Date.now()}`);
-  fs.mkdirSync(tmpDir, { recursive: true });
+  const tmpDir = makeContainerWritableDir(path.join(path.dirname(tarPath), `pilot_${Date.now()}`));
 
   if (chartNumber) {
     conversionProgress[chartNumber] = {

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -922,9 +922,20 @@ async function runPerBandPipeline(
     fs.mkdirSync(bandEncDir, { recursive: true });
     fs.mkdirSync(bandGeojsonDir, { recursive: true });
     // Container runs as UID 1001 (toolbox user); host-created dirs default
-    // to 0o755 owned by the host process UID. Chmod to 0o777 so the container
-    // can write GeoJSON output and error logs.
-    fs.chmodSync(bandGeojsonDir, 0o777);
+    // to 0o755 owned by the host process UID. Transfer ownership to the
+    // container user if possible, otherwise fall back to world-writable.
+    try {
+      fs.chownSync(bandGeojsonDir, 1001, -1);
+      fs.chmodSync(bandGeojsonDir, 0o755);
+    } catch (err) {
+      // Host process lacks CAP_CHOWN; fall back to world-writable so
+      // the container can still write output.
+      if ((err as NodeJS.ErrnoException).code === 'EPERM') {
+        fs.chmodSync(bandGeojsonDir, 0o777);
+      } else {
+        throw err;
+      }
+    }
 
     // Hardlink each cell into the band-scoped dir so the export
     // script (which walks `find <inDir> -name '*.000'`) only sees
@@ -980,9 +991,21 @@ async function runPerBandPipeline(
     fs.mkdirSync(unbandedEncDir, { recursive: true });
     fs.mkdirSync(unbandedGeojsonDir, { recursive: true });
     // Container runs as UID 1001 (toolbox user); host-created dirs default
-    // to 0o755 owned by the host process UID. Chmod to 0o777 so the container
-    // can write GeoJSON output and error logs.
-    fs.chmodSync(unbandedGeojsonDir, 0o777);
+    // to 0o755 owned by the host process UID. Transfer ownership to the
+    // container user if possible, otherwise fall back to world-writable.
+    try {
+      fs.chownSync(unbandedGeojsonDir, 1001, -1);
+      fs.chmodSync(unbandedGeojsonDir, 0o755);
+    } catch (err) {
+      // Host process lacks CAP_CHOWN; fall back to world-writable so
+      // the container can still write output.
+      if ((err as NodeJS.ErrnoException).code === 'EPERM') {
+        fs.chmodSync(unbandedGeojsonDir, 0o777);
+      } else {
+        throw err;
+      }
+    }
+
     // Hardlink (not symlink) — see the band-loop above for the
     // why: bind-mounted absolute symlink targets don't resolve
     // inside the helper container.
@@ -1056,9 +1079,20 @@ export async function processS57Zip(
   fs.mkdirSync(encDir, { recursive: true });
   fs.mkdirSync(geojsonDir, { recursive: true });
   // Container runs as UID 1001 (toolbox user); host-created dirs default
-  // to 0o755 owned by the host process UID. Chmod to 0o777 so the container
-  // can write GeoJSON output and error logs.
-  fs.chmodSync(geojsonDir, 0o777);
+  // to 0o755 owned by the host process UID. Transfer ownership to the
+  // container user if possible, otherwise fall back to world-writable.
+  try {
+    fs.chownSync(geojsonDir, 1001, -1);
+    fs.chmodSync(geojsonDir, 0o755);
+  } catch (err) {
+    // Host process lacks CAP_CHOWN; fall back to world-writable so
+    // the container can still write output.
+    if ((err as NodeJS.ErrnoException).code === 'EPERM') {
+      fs.chmodSync(geojsonDir, 0o777);
+    } else {
+      throw err;
+    }
+  }
 
   if (chartNumber) {
     conversionProgress[chartNumber] = {

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -1,8 +1,17 @@
-import https from 'https';
 import fs from 'fs';
-import path from 'path';
+import https from 'https';
 import { DatabaseSync } from 'node:sqlite';
+import path from 'path';
 import unzipper from 'unzipper';
+import type {
+  ConversionProgress,
+  ConversionProgressMap,
+  DebugFunction,
+  S57ConversionOptions,
+  S57ConversionResult,
+  StatusCallback
+} from '../types.js';
+import { sanitizeChartFilename } from './catalog-title.js';
 import { getCpuBudget } from './concurrency.js';
 import { CHARTS_TOOLBOX_IMAGE } from './container-images.js';
 import {
@@ -11,6 +20,7 @@ import {
   runJob as runContainerJob
 } from './container-jobs.js';
 import { getContainerManager } from './container-manager.js';
+import { patchS57Mbtiles, setMbtilesDisplayName } from './mbtiles-metadata.js';
 import {
   BAND_MAX_ZOOM,
   BAND_MIN_ZOOM,
@@ -18,16 +28,6 @@ import {
   groupCellsByBand,
   highestBandForFiles
 } from './s57-band.js';
-import { patchS57Mbtiles, setMbtilesDisplayName } from './mbtiles-metadata.js';
-import { sanitizeChartFilename } from './catalog-title.js';
-import type {
-  ConversionProgress,
-  ConversionProgressMap,
-  S57ConversionResult,
-  S57ConversionOptions,
-  StatusCallback,
-  DebugFunction
-} from '../types.js';
 
 const conversionProgress: ConversionProgressMap = {};
 const MAX_LOG_LINES = 100;
@@ -235,7 +235,7 @@ export function buildExportScript(opts: ExportScriptOptions): string {
   if (parallel === 1) {
     return `
 set -e
-: > ${errLog}
+: > "${errLog}" 2>/dev/null || true
 count=$(find ${inDir} -name '*.000' ! -name '._*' -type f | wc -l)
 i=0
 find ${inDir} -name '*.000' ! -name '._*' -type f -print0 | while IFS= read -r -d '' enc; do
@@ -264,7 +264,7 @@ echo "PROGRESS: Export complete"
   const multiArg = opts.multiFile ? '1' : '0';
   return `
 set -e
-: > ${errLog}
+: > "${errLog}" 2>/dev/null || true
 count=$(find ${inDir} -name '*.000' ! -name '._*' -type f | wc -l)
 i=0
 find ${inDir} -name '*.000' ! -name '._*' -type f -print0 | while IFS= read -r -d '' enc; do
@@ -921,6 +921,10 @@ async function runPerBandPipeline(
     const bandGeojsonDir = path.join(tmpDir, `geojson-band-${band}`);
     fs.mkdirSync(bandEncDir, { recursive: true });
     fs.mkdirSync(bandGeojsonDir, { recursive: true });
+    // Container runs as UID 1001 (toolbox user); host-created dirs default
+    // to 0o755 owned by the host process UID. Chmod to 0o777 so the container
+    // can write GeoJSON output and error logs.
+    fs.chmodSync(bandGeojsonDir, 0o777);
 
     // Hardlink each cell into the band-scoped dir so the export
     // script (which walks `find <inDir> -name '*.000'`) only sees
@@ -975,6 +979,10 @@ async function runPerBandPipeline(
     const unbandedGeojsonDir = path.join(tmpDir, 'geojson-unbanded');
     fs.mkdirSync(unbandedEncDir, { recursive: true });
     fs.mkdirSync(unbandedGeojsonDir, { recursive: true });
+    // Container runs as UID 1001 (toolbox user); host-created dirs default
+    // to 0o755 owned by the host process UID. Chmod to 0o777 so the container
+    // can write GeoJSON output and error logs.
+    fs.chmodSync(unbandedGeojsonDir, 0o777);
     // Hardlink (not symlink) — see the band-loop above for the
     // why: bind-mounted absolute symlink targets don't resolve
     // inside the helper container.
@@ -1047,6 +1055,10 @@ export async function processS57Zip(
   const geojsonDir = path.join(tmpDir, 'geojson');
   fs.mkdirSync(encDir, { recursive: true });
   fs.mkdirSync(geojsonDir, { recursive: true });
+  // Container runs as UID 1001 (toolbox user); host-created dirs default
+  // to 0o755 owned by the host process UID. Chmod to 0o777 so the container
+  // can write GeoJSON output and error logs.
+  fs.chmodSync(geojsonDir, 0o777);
 
   if (chartNumber) {
     conversionProgress[chartNumber] = {

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -235,7 +235,7 @@ export function buildExportScript(opts: ExportScriptOptions): string {
   if (parallel === 1) {
     return `
 set -e
-: > "${errLog}" 2>/dev/null || true
+: > ${errLog}
 count=$(find ${inDir} -name '*.000' ! -name '._*' -type f | wc -l)
 i=0
 find ${inDir} -name '*.000' ! -name '._*' -type f -print0 | while IFS= read -r -d '' enc; do
@@ -264,7 +264,7 @@ echo "PROGRESS: Export complete"
   const multiArg = opts.multiFile ? '1' : '0';
   return `
 set -e
-: > "${errLog}" 2>/dev/null || true
+: > ${errLog}
 count=$(find ${inDir} -name '*.000' ! -name '._*' -type f | wc -l)
 i=0
 find ${inDir} -name '*.000' ! -name '._*' -type f -print0 | while IFS= read -r -d '' enc; do

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -13,6 +13,7 @@ import type {
 } from '../types.js';
 import { sanitizeChartFilename } from './catalog-title.js';
 import { getCpuBudget } from './concurrency.js';
+import { makeContainerWritable, makeContainerWritableDir } from './container-fs.js';
 import { CHARTS_TOOLBOX_IMAGE } from './container-images.js';
 import {
   ensureImage as ensureContainerImage,
@@ -921,21 +922,7 @@ async function runPerBandPipeline(
     const bandGeojsonDir = path.join(tmpDir, `geojson-band-${band}`);
     fs.mkdirSync(bandEncDir, { recursive: true });
     fs.mkdirSync(bandGeojsonDir, { recursive: true });
-    // Container runs as UID 1001 (toolbox user); host-created dirs default
-    // to 0o755 owned by the host process UID. Transfer ownership to the
-    // container user if possible, otherwise fall back to world-writable.
-    try {
-      fs.chownSync(bandGeojsonDir, 1001, -1);
-      fs.chmodSync(bandGeojsonDir, 0o755);
-    } catch (err) {
-      // Host process lacks CAP_CHOWN; fall back to world-writable so
-      // the container can still write output.
-      if ((err as NodeJS.ErrnoException).code === 'EPERM') {
-        fs.chmodSync(bandGeojsonDir, 0o777);
-      } else {
-        throw err;
-      }
-    }
+    makeContainerWritable(bandGeojsonDir);
 
     // Hardlink each cell into the band-scoped dir so the export
     // script (which walks `find <inDir> -name '*.000'`) only sees
@@ -990,21 +977,7 @@ async function runPerBandPipeline(
     const unbandedGeojsonDir = path.join(tmpDir, 'geojson-unbanded');
     fs.mkdirSync(unbandedEncDir, { recursive: true });
     fs.mkdirSync(unbandedGeojsonDir, { recursive: true });
-    // Container runs as UID 1001 (toolbox user); host-created dirs default
-    // to 0o755 owned by the host process UID. Transfer ownership to the
-    // container user if possible, otherwise fall back to world-writable.
-    try {
-      fs.chownSync(unbandedGeojsonDir, 1001, -1);
-      fs.chmodSync(unbandedGeojsonDir, 0o755);
-    } catch (err) {
-      // Host process lacks CAP_CHOWN; fall back to world-writable so
-      // the container can still write output.
-      if ((err as NodeJS.ErrnoException).code === 'EPERM') {
-        fs.chmodSync(unbandedGeojsonDir, 0o777);
-      } else {
-        throw err;
-      }
-    }
+    makeContainerWritable(unbandedGeojsonDir);
 
     // Hardlink (not symlink) — see the band-loop above for the
     // why: bind-mounted absolute symlink targets don't resolve
@@ -1078,21 +1051,11 @@ export async function processS57Zip(
   const geojsonDir = path.join(tmpDir, 'geojson');
   fs.mkdirSync(encDir, { recursive: true });
   fs.mkdirSync(geojsonDir, { recursive: true });
-  // Container runs as UID 1001 (toolbox user); host-created dirs default
-  // to 0o755 owned by the host process UID. Transfer ownership to the
-  // container user if possible, otherwise fall back to world-writable.
-  try {
-    fs.chownSync(geojsonDir, 1001, -1);
-    fs.chmodSync(geojsonDir, 0o755);
-  } catch (err) {
-    // Host process lacks CAP_CHOWN; fall back to world-writable so
-    // the container can still write output.
-    if ((err as NodeJS.ErrnoException).code === 'EPERM') {
-      fs.chmodSync(geojsonDir, 0o777);
-    } else {
-      throw err;
-    }
-  }
+  // The multi-band pipeline has tippecanoe write its intermediate
+  // `band-*.mbtiles` directly into tmpDir (its `/output`), so tmpDir itself
+  // must be container-writable, not just the geojson export dir.
+  makeContainerWritable(tmpDir);
+  makeContainerWritable(geojsonDir);
 
   if (chartNumber) {
     conversionProgress[chartNumber] = {
@@ -1546,8 +1509,9 @@ export async function processShpBasemap(
   onStatus: StatusCallback | null
 ): Promise<S57ConversionResult> {
   const statusFn = onStatus ?? (() => {});
-  const tmpDir = path.join(path.dirname(tarPath), `shpbasemap_${Date.now()}`);
-  fs.mkdirSync(tmpDir, { recursive: true });
+  const tmpDir = makeContainerWritableDir(
+    path.join(path.dirname(tarPath), `shpbasemap_${Date.now()}`)
+  );
 
   if (chartNumber) {
     conversionProgress[chartNumber] = {


### PR DESCRIPTION
addressing issue #117 IENC files not being processed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Make container-bound output directories writable for rootless/containerized environments by centralizing chown/chmod logic into a shared helper and applying it across multiple conversion code paths; revert a breaking error-log initialization change so tests remain green.

## Changes

- Add src/utils/container-fs.ts
  - Introduces makeContainerWritableDir(dir: string): string and makeContainerWritable(dir: string): void.
  - Attempts chown to toolbox UID (1001) and sets mode 0o755; on EPERM falls back to chmod 0o777.

- Apply container-writable helper across converters
  - src/utils/quarantine.ts
    - Call makeContainerWritable(dir) after creating the quarantine directory for <dataDir>/in-progress/<chartNumber>/ so conversion outputs (e.g., .mbtiles) are writable by the container runtime.
  - src/utils/s57-converter.ts
    - Call makeContainerWritable on per-band GeoJSON directories, unbanded GeoJSON dir, tmpDir, and geojsonDir so intermediate outputs and error logs are writable.
    - Reorganize imports for clarity (no public API changes).
  - src/utils/rnc-converter.ts
    - Create tmpDir via makeContainerWritableDir(...) in processPilotTar; cleanup behavior unchanged.

- Revert error-log initialization change
  - Keep error-log initialization as the original `: > ${errLog}` (avoid `: > "${errLog}" 2>/dev/null || true`) because making it non-fatal caused CI test failures (tests expect stderr routing and an unquoted init string).

## Rationale

- Fixes permission-denied failures (UID-1001/rootless container scenarios) that prevented processing of IENC and other chart artifacts by making container-bound directories writable.
- Centralizing the logic reduces duplication and ensures all seven relevant processing sites make their output directories writable.
- Reverting the error-log change preserves test expectations and ensures permission errors on unwritable /output remain visible to tests and operators.

## Impact

- No exported/public function signatures (outside the new helper APIs).
- Behavior: directory permission handling improves in container/rootless runs; error-log initialization behavior remains as before to avoid breaking tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->