### PR TITLE
fix(catalog): refresh updates list when an update completes

### DIFF
--- a/e2e/catalog.spec.ts
+++ b/e2e/catalog.spec.ts
@@ -165,4 +165,53 @@ test.describe('Chart Catalog tab', () => {
     await row.locator('[data-catalog-dismiss="1"]').click();
     await expect(row.locator('.conversion-error-text')).toHaveCount(0);
   });
+
+  test('a completed update drops out of the panel without re-opening the tab (issue #121)', async ({
+    page
+  }) => {
+    // Regression for #121: after a conversion finishes, the in-memory
+    // catalogUpdates was never re-fetched, so the row kept showing
+    // "update available" until the user left and re-entered the tab.
+    // pollConversions must call refreshUpdateBadge() on a just-finished
+    // conversion so the row clears live.
+    await page.goto('/plugins/signalk-charts-provider-simple/');
+    await setMockState(page, {
+      registry: [
+        {
+          file: 'NL_IENC.xml',
+          label: 'NL IENC',
+          category: 'ienc',
+          chartCount: 1,
+          cachedAt: '2026-05-07T10:00:00Z'
+        }
+      ],
+      catalogUpdates: [
+        {
+          chartNumber: '1',
+          catalogFile: 'NL_IENC.xml',
+          title: 'Waddenzee',
+          installedDate: '2024-01-01T00:00:00Z',
+          availableDate: '2026-05-01T00:00:00Z',
+          downloadUrl: 'https://example.com/wadd.zip',
+          installedFolder: '/'
+        }
+      ],
+      // The chart is mid-conversion: the panel shows it as updating.
+      converting: { '1': true }
+    });
+
+    await page.getByRole('button', { name: /Chart Catalog/i }).click();
+
+    const row = page.locator('.catalog-update-row[data-chart-number="1"]');
+    await expect(row).toBeVisible();
+    await expect(row).toHaveClass(/updating/);
+
+    // The conversion finishes: no longer converting, and the backend no
+    // longer reports it as an available update (its install date caught up).
+    await patchMockState(page, { converting: {}, catalogUpdates: [] });
+
+    // pollConversions (every 3s) must detect the just-finished conversion
+    // and refresh the updates list, removing the row live — no tab reload.
+    await expect(row).toHaveCount(0, { timeout: 10_000 });
+  });
 });

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -1187,7 +1187,11 @@ async function pollCatalogDownloads(): Promise<void> {
           }
         }
         renderCatalogList();
-        renderUpdatesSection();
+        // Re-fetch the updates list so the just-updated chart drops out of
+        // the panel/badge; the in-memory catalogUpdates is otherwise stale
+        // and the row keeps showing "update available" until the tab is
+        // re-opened. refreshUpdateBadge() re-renders the section itself.
+        void refreshUpdateBadge();
       } else if (job.status === 'failed') {
         delete catalogDownloadJobs[chartNumber];
         if (progressEl) {
@@ -1344,6 +1348,11 @@ async function pollConversions(): Promise<void> {
             }
           })
         );
+        // A finished conversion means the chart is now up to date — re-fetch
+        // the updates list so it drops out of the panel/badge. Without this
+        // the in-memory catalogUpdates stays stale and the row keeps showing
+        // "update available" until the tab is re-opened.
+        await refreshUpdateBadge();
       }
     }
 


### PR DESCRIPTION
## Problem

Fixes #121. After a chart update finishes, the "Update" button (and the catalog badge) keep showing **"update available"** for the chart that was just updated. Leaving the Chart Catalog tab and returning corrects the state.

## Root cause

The backend already drops a chart from `/catalog-updates` once its install date catches up to the catalog date (which happens at the start of the download via `trackInstall`). But the frontend never **re-fetched** that list after a completion — it kept rendering from the stale in-memory `catalogUpdates` array. The completion handlers re-fetched catalog *chart data* and re-rendered, but never refreshed the updates list itself, so the row kept its "update available" action until `loadCatalogTab` ran again on tab re-entry.

## Fix

Call `refreshUpdateBadge()` (which re-fetches `/catalog-updates` and re-renders the panel) from both completion paths:

- the direct-download `job.status === 'completed'` handler in `pollCatalogDownloads`
- the just-finished-conversion branch in `pollConversions`

## Tested

- New e2e regression test (`e2e/catalog.spec.ts`): a chart shown as updating, then flipped to finished with an empty `/catalog-updates`, drops out of the panel live within the poll window — no tab reload.
- Full local chain: `npm run format`, `build`, `build:e2e`, `lint`, `test` (282 pass), `playwright test catalog` (5 pass).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fixes

Refreshes the updates list immediately when a chart update completes, ensuring the frontend UI reflects the updated state without requiring a tab reload.

## Changes

**public/js/chart-catalog.ts**
- `pollCatalogDownloads()` calls `refreshUpdateBadge()` immediately after a successful download completes, so the just-updated chart drops out of the updates panel live.
- `pollConversions()` calls `refreshUpdateBadge()` after detecting finished conversions, removing charts from the stale "update available" state without a tab reload.

**e2e/catalog.spec.ts**
- Adds a regression test verifying that a chart shown as updating is removed from the updates panel live when `/catalog-updates` becomes empty, without requiring a tab reload.

## Testing

- All existing tests pass (282 unit tests, 5 playwright catalog tests).
- Format, build, lint, and e2e checks all pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->