### PR TITLE
fix(catalog): keep install record when an update fails

### DIFF
--- a/e2e/catalog.spec.ts
+++ b/e2e/catalog.spec.ts
@@ -160,8 +160,9 @@ test.describe('Chart Catalog tab', () => {
     await expect(errorText).toBeVisible();
     await expect(errorText).toContainText(/mock download failure/i);
 
-    // Dismiss must clear it from the panel (the Dismiss button under
-    // #catalogUpdatesSection is wired and re-renders the section).
+    // Dismiss must clear the error from the panel — the row itself stays in
+    // the DOM, only the error message is removed. The Dismiss button under
+    // #catalogUpdatesSection is wired and re-renders the section.
     await row.locator('[data-catalog-dismiss="1"]').click();
     await expect(row.locator('.conversion-error-text')).toHaveCount(0);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
   removeInstall,
   removeInstallByFilename,
   renameInstallFilename,
+  rollbackInstall,
   setConvertingState,
   setInstallFilename,
   trackInstall
@@ -2210,14 +2211,14 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             void (async () => {
               try {
                 if (!job.extractedFiles || job.extractedFiles.length === 0) {
-                  removeInstall(chartNumber);
+                  rollbackInstall(chartNumber);
                   app.debug(`Removed catalog tracking for ${chartNumber}: no .mbtiles extracted`);
                   return;
                 }
                 if (job.status !== 'completed') {
                   // Failed downloads leak nothing into the live target;
                   // the quarantine wipe in `finally` handles cleanup.
-                  removeInstall(chartNumber);
+                  rollbackInstall(chartNumber);
                   return;
                 }
                 try {
@@ -2228,7 +2229,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
                       promoteErr instanceof Error ? promoteErr.message : String(promoteErr)
                     }`
                   );
-                  removeInstall(chartNumber);
+                  rollbackInstall(chartNumber);
                   return;
                 }
                 // The global `job-completed` handler enables charts and
@@ -2332,7 +2333,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
       if (!zipPath || !fs.existsSync(zipPath)) {
         app.debug(`S-57: no ZIP file found after download for ${chartNumber}`);
-        removeInstall(chartNumber);
+        rollbackInstall(chartNumber);
         cleanupDir(tmpDownloadDir);
         return;
       }
@@ -2393,7 +2394,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         app.error(
           `S-57 conversion failed for ${chartNumber}: ${convError instanceof Error ? convError.message : String(convError)}`
         );
-        removeInstall(chartNumber);
+        rollbackInstall(chartNumber);
         setConvertingState(chartNumber, false);
         if (quarantineDir !== null) {
           cleanupQuarantineDir(quarantineDir);
@@ -2408,7 +2409,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       }
       downloadManager.removeListener('job-completed', s57Listener);
       downloadManager.removeListener('job-failed', s57FailListener);
-      removeInstall(chartNumber);
+      rollbackInstall(chartNumber);
       setConvertingState(chartNumber, false);
       setS57Failed(chartNumber, job.error ?? 'Download failed');
       cleanupDir(tmpDownloadDir);
@@ -2452,7 +2453,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
       if (!zipPath || !fs.existsSync(zipPath)) {
         app.debug(`RNC: no file found after download for ${chartNumber}`);
-        removeInstall(chartNumber);
+        rollbackInstall(chartNumber);
         cleanupDir(tmpDownloadDir);
         return;
       }
@@ -2507,7 +2508,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         app.error(
           `RNC conversion failed for ${chartNumber}: ${convError instanceof Error ? convError.message : String(convError)}`
         );
-        removeInstall(chartNumber);
+        rollbackInstall(chartNumber);
         setConvertingState(chartNumber, false);
         if (quarantineDir !== null) {
           cleanupQuarantineDir(quarantineDir);
@@ -2522,7 +2523,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       }
       downloadManager.removeListener('job-completed', rncListener);
       downloadManager.removeListener('job-failed', rncFailListener);
-      removeInstall(chartNumber);
+      rollbackInstall(chartNumber);
       setConvertingState(chartNumber, false);
       setRncFailed(chartNumber, job.error ?? 'Download failed');
       cleanupDir(tmpDownloadDir);
@@ -2565,7 +2566,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       const dlPath = dlFileName ? path.join(tmpDownloadDir, dlFileName) : null;
 
       if (!dlPath || !fs.existsSync(dlPath)) {
-        removeInstall(chartNumber);
+        rollbackInstall(chartNumber);
         cleanupDir(tmpDownloadDir);
         return;
       }
@@ -2608,7 +2609,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         app.error(
           `Pilot conversion failed: ${convError instanceof Error ? convError.message : String(convError)}`
         );
-        removeInstall(chartNumber);
+        rollbackInstall(chartNumber);
         setConvertingState(chartNumber, false);
         if (quarantineDir !== null) {
           cleanupQuarantineDir(quarantineDir);
@@ -2623,7 +2624,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       }
       downloadManager.removeListener('job-completed', pilotListener);
       downloadManager.removeListener('job-failed', pilotFailListener);
-      removeInstall(chartNumber);
+      rollbackInstall(chartNumber);
       setConvertingState(chartNumber, false);
       setRncFailed(chartNumber, job.error ?? 'Download failed');
       cleanupDir(tmpDownloadDir);
@@ -2666,7 +2667,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       const dlPath = dlFileName ? path.join(tmpDownloadDir, dlFileName) : null;
 
       if (!dlPath || !fs.existsSync(dlPath)) {
-        removeInstall(chartNumber);
+        rollbackInstall(chartNumber);
         cleanupDir(tmpDownloadDir);
         return;
       }
@@ -2706,7 +2707,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         app.error(
           `ShpBasemap conversion failed: ${convError instanceof Error ? convError.message : String(convError)}`
         );
-        removeInstall(chartNumber);
+        rollbackInstall(chartNumber);
         setConvertingState(chartNumber, false);
         if (quarantineDir !== null) {
           cleanupQuarantineDir(quarantineDir);
@@ -2721,7 +2722,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       }
       downloadManager.removeListener('job-completed', shpListener);
       downloadManager.removeListener('job-failed', shpFailListener);
-      removeInstall(chartNumber);
+      rollbackInstall(chartNumber);
       setConvertingState(chartNumber, false);
       cleanupDir(tmpDownloadDir);
     };
@@ -2780,7 +2781,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         app.error(
           `GSHHG conversion failed: ${error instanceof Error ? error.message : String(error)}`
         );
-        removeInstall(chartNumber);
+        rollbackInstall(chartNumber);
         setConvertingState(chartNumber, false);
         if (quarantineDir !== null) {
           cleanupQuarantineDir(quarantineDir);

--- a/src/utils/catalog-manager.ts
+++ b/src/utils/catalog-manager.ts
@@ -6,6 +6,7 @@ import type {
   CatalogCategory,
   CatalogChart,
   CatalogData,
+  CatalogInstall,
   CatalogInstallsMap,
   CatalogRegistryEntry,
   CatalogRegistryInfo,
@@ -54,6 +55,14 @@ let dataDir = '';
 let cacheDir = '';
 let installsFilePath = '';
 let installs: CatalogInstallsMap = {};
+// In-memory snapshot of the install record that trackInstall() is about to
+// overwrite, keyed by chartNumber. A failed conversion calls rollbackInstall()
+// to restore the prior record (a failed UPDATE — issue #120) or drop it (a
+// failed FRESH install, snapshot === null). Intentionally NOT persisted: it
+// only needs to live from the up-front trackInstall to that same attempt's
+// failure branch. A crash mid-conversion is handled by the orphan-reap path,
+// which removeInstall()s unconditionally.
+const installSnapshots = new Map<string, CatalogInstall | null>();
 const converting: Record<string, true> = {};
 let debug: DebugFunction = () => {};
 
@@ -460,6 +469,12 @@ export function trackInstall(
   zipfileDatetime: string,
   url: string
 ): void {
+  // Snapshot whatever is currently recorded BEFORE overwriting it, so a
+  // failed UPDATE can restore the still-on-disk old version (issue #120).
+  // A fresh install snapshots null, which rollbackInstall() treats as
+  // "delete the record" — same as the old removeInstall cleanup.
+  const prior = installs[chartNumber];
+  installSnapshots.set(chartNumber, prior ? { ...prior } : null);
   installs[chartNumber] = {
     catalogFile,
     zipfile_datetime_iso8601: zipfileDatetime,
@@ -469,9 +484,38 @@ export function trackInstall(
   saveInstalls();
 }
 
+/**
+ * Undo the most recent trackInstall() for a chart after its conversion or
+ * download FAILS (issue #120). Restores the record trackInstall snapshotted:
+ *   - prior record existed (an UPDATE)  → restore it, so checkForUpdates
+ *     keeps flagging the update (the old version is still on disk).
+ *   - prior record was null (a FRESH install) → delete it, so there's no
+ *     stale record for a chart that isn't installed.
+ *   - no snapshot at all (defensive)    → fall back to removeInstall so an
+ *     in-flight record is still cleaned up.
+ * Always clears the snapshot afterwards.
+ */
+export function rollbackInstall(chartNumber: string): void {
+  if (!installSnapshots.has(chartNumber)) {
+    removeInstall(chartNumber);
+    return;
+  }
+  const prior = installSnapshots.get(chartNumber) ?? null;
+  installSnapshots.delete(chartNumber);
+  if (prior) {
+    installs[chartNumber] = prior;
+  } else {
+    delete installs[chartNumber];
+  }
+  saveInstalls();
+}
+
 export function removeInstall(chartNumber: string): void {
   if (installs[chartNumber]) {
     delete installs[chartNumber];
+    // A genuine removal supersedes any pending rollback snapshot for this
+    // exact key, so a later rollbackInstall can't resurrect the record.
+    installSnapshots.delete(chartNumber);
     saveInstalls();
     return;
   }
@@ -507,6 +551,9 @@ export function setInstallFilename(chartNumber: string, filename: string): void 
     return;
   }
   install.installedFilename = filename;
+  // Conversion succeeded — the new record stands. Drop the prior-version
+  // snapshot so a later rollbackInstall can't resurrect the old record.
+  installSnapshots.delete(chartNumber);
   saveInstalls();
 }
 
@@ -589,14 +636,17 @@ export function checkForUpdates(): CatalogUpdate[] {
         // Windows) and take the directory portion with posix semantics.
         const normalized = install.installedFilename.replace(/\\/g, '/');
         const folder = path.posix.dirname(normalized);
-        // dirname returns '.' for a file in the root folder. Treat that,
-        // any traversal ('../foo'), and any absolute path (a malformed
-        // record) as root — installedFolder must stay chart-path-relative.
+        // dirname returns '.' for a file in the root folder. Treat that, any
+        // traversal segment ('../foo', 'a/../b'), a Windows drive prefix
+        // ('C:/…' after the backslash normalize), and any absolute path (all
+        // malformed records) as root — installedFolder must stay
+        // chart-path-relative.
         if (
           folder &&
           folder !== '.' &&
           folder !== '/' &&
-          !folder.startsWith('../') &&
+          !folder.split('/').includes('..') &&
+          !/^[a-zA-Z]:/.test(folder) &&
           !path.posix.isAbsolute(folder)
         ) {
           installedFolder = folder;

--- a/test/catalog-manager.test.ts
+++ b/test/catalog-manager.test.ts
@@ -15,6 +15,7 @@ import {
   trackInstall,
   setInstallFilename,
   removeInstall,
+  rollbackInstall,
   getInstalledCatalogCharts,
   checkForUpdates,
   getCatalogsWithInstalledCharts,
@@ -342,7 +343,130 @@ describe('CatalogManager', () => {
       setInstallFilename('folder_chart', '/var/charts/folder_chart.mbtiles');
       assert.strictEqual(checkForUpdates()[0]!.installedFolder, '/');
 
+      // An embedded traversal segment must collapse to root.
+      setInstallFilename('folder_chart', 'Europe/../../etc/folder_chart.mbtiles');
+      assert.strictEqual(checkForUpdates()[0]!.installedFolder, '/');
+
+      // A Windows drive-prefixed path must collapse to root.
+      setInstallFilename('folder_chart', 'C:\\charts\\folder_chart.mbtiles');
+      assert.strictEqual(checkForUpdates()[0]!.installedFolder, '/');
+
       removeInstall('folder_chart');
+    });
+  });
+
+  describe('rollbackInstall() / issue #120', () => {
+    const CACHE_FILE = 'NOAA_MBTiles_Catalog.json';
+    const CATALOG = 'NOAA_MBTiles_Catalog.xml';
+
+    // Write a cache that advertises `availableDate` for `chartNumber` so
+    // checkForUpdates() can compare against the tracked install date.
+    function seedCache(chartNumber: string, availableDate: string): void {
+      const cacheDir = path.join(TEST_DATA_DIR, 'catalog-cache');
+      fs.writeFileSync(
+        path.join(cacheDir, CACHE_FILE),
+        JSON.stringify({
+          fetchedAt: new Date().toISOString(),
+          catalogFile: CATALOG,
+          header: { title: 'Test' },
+          charts: [
+            {
+              number: chartNumber,
+              title: 'Test Chart',
+              format: 'MBTiles',
+              zipfile_location: 'https://example.com/test.mbtiles',
+              zipfile_datetime_iso8601: availableDate
+            }
+          ]
+        }),
+        'utf-8'
+      );
+    }
+
+    it('deletes the record on a failed FRESH install', () => {
+      trackInstall('fresh', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/a.mbtiles');
+      rollbackInstall('fresh');
+      assert.strictEqual(getInstalledCatalogCharts()['fresh'], undefined);
+    });
+
+    it('restores the prior record on a failed UPDATE', () => {
+      trackInstall('upd', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/old.mbtiles');
+      setInstallFilename('upd', 'Rotterdam.mbtiles');
+      // The update attempt overwrites with a newer date/url...
+      trackInstall('upd', CATALOG, '2024-06-10T00:00:00Z', 'https://example.com/new.mbtiles');
+      // ...then fails:
+      rollbackInstall('upd');
+
+      const rec = getInstalledCatalogCharts()['upd'];
+      assert.ok(rec, 'record must survive a failed update');
+      assert.strictEqual(rec.zipfile_datetime_iso8601, '2024-01-01T00:00:00Z');
+      assert.strictEqual(rec.zipfile_location, 'https://example.com/old.mbtiles');
+      assert.strictEqual(rec.installedFilename, 'Rotterdam.mbtiles');
+      removeInstall('upd');
+    });
+
+    it('keeps flagging the update after a failed update (the #120 symptom)', () => {
+      seedCache('enc1', '2024-06-10T00:00:00Z');
+      trackInstall('enc1', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/old.mbtiles');
+      setInstallFilename('enc1', 'enc1.mbtiles');
+      trackInstall('enc1', CATALOG, '2024-06-10T00:00:00Z', 'https://example.com/new.mbtiles');
+      rollbackInstall('enc1');
+
+      const updates = checkForUpdates();
+      const u = updates.find((x) => x.chartNumber === 'enc1');
+      assert.ok(u, 'a failed update must still appear as available');
+      assert.strictEqual(u.installedDate, '2024-01-01T00:00:00Z');
+      assert.strictEqual(u.availableDate, '2024-06-10T00:00:00Z');
+      removeInstall('enc1');
+    });
+
+    it('does not resurrect the old record after a successful update', () => {
+      trackInstall('s', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/v1.mbtiles');
+      setInstallFilename('s', 'v1.mbtiles');
+      trackInstall('s', CATALOG, '2024-06-10T00:00:00Z', 'https://example.com/v2.mbtiles');
+      setInstallFilename('s', 'v2.mbtiles'); // success clears the snapshot
+      // A stray rollback now must NOT restore v1 (snapshot is gone → removeInstall).
+      rollbackInstall('s');
+      assert.strictEqual(getInstalledCatalogCharts()['s'], undefined);
+    });
+
+    it('restores the original across sequential failed updates', () => {
+      trackInstall('seq', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/v1.mbtiles');
+      setInstallFilename('seq', 'v1.mbtiles');
+      for (const attempt of ['2024-03-01T00:00:00Z', '2024-06-10T00:00:00Z']) {
+        trackInstall('seq', CATALOG, attempt, 'https://example.com/x.mbtiles');
+        rollbackInstall('seq');
+        const rec = getInstalledCatalogCharts()['seq'];
+        assert.ok(rec);
+        assert.strictEqual(rec.zipfile_datetime_iso8601, '2024-01-01T00:00:00Z');
+      }
+      removeInstall('seq');
+    });
+
+    it('falls back to removeInstall when there is no snapshot', () => {
+      assert.doesNotThrow(() => {
+        rollbackInstall('never-tracked');
+      });
+      assert.strictEqual(getInstalledCatalogCharts()['never-tracked'], undefined);
+    });
+
+    it('is keyed exactly and does not fuzzy-match other charts', () => {
+      trackInstall('2', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/2.mbtiles');
+      trackInstall('20', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/20.mbtiles');
+      rollbackInstall('20'); // fresh → deletes '20' only
+      assert.ok(getInstalledCatalogCharts()['2'], "'2' must be untouched by rollback of '20'");
+      assert.strictEqual(getInstalledCatalogCharts()['20'], undefined);
+      removeInstall('2');
+    });
+
+    it('removeInstall clears a pending snapshot so a later rollback cannot resurrect it', () => {
+      trackInstall('d', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/old.mbtiles');
+      setInstallFilename('d', 'd.mbtiles');
+      trackInstall('d', CATALOG, '2024-06-10T00:00:00Z', 'https://example.com/new.mbtiles'); // snapshot = old
+      removeInstall('d'); // genuine removal must drop the snapshot
+      trackInstall('d', CATALOG, '2024-09-01T00:00:00Z', 'https://example.com/newer.mbtiles');
+      rollbackInstall('d'); // snapshot here is null (fresh after removeInstall) → deletes
+      assert.strictEqual(getInstalledCatalogCharts()['d'], undefined);
     });
   });
 


### PR DESCRIPTION
## Problem

Fixes #120. When a chart that is **already installed** is updated and the update fails (download or conversion error), its record in `catalog-installs.json` is wiped — even though the old version is still on disk. After that, `checkForUpdates()` has nothing to compare against, so the "update available" prompt never returns for that chart.

## Root cause

Every catalog conversion path calls `trackInstall()` **up front** (before the download) and `removeInstall()` on **every** failure branch:

- For a *fresh* install, that's correct cleanup.
- For an *update*, `trackInstall` first **overwrites** the existing record with the new attempt's date, and `removeInstall` then **deletes it entirely** — so the still-valid old record is lost.

## Fix

At the install-tracking layer, in-memory only, **zero schema change**:

- `trackInstall()` snapshots the prior record before overwriting it.
- New `rollbackInstall()` restores that snapshot on failure: a prior record (an UPDATE) is restored so the update stays flagged; a `null` snapshot (a FRESH install) is deleted, matching the old cleanup; with no snapshot it falls back to `removeInstall()`.
- The snapshot is cleared on success (`setInstallFilename`) and on a genuine exact-key `removeInstall`, so it can't later resurrect a superseded record.
- All 16 conversion/download failure branches in `index.ts` call `rollbackInstall()` instead of `removeInstall()`. **Orphan-reap (crash recovery) and the user-delete flow keep `removeInstall()` unchanged.**

The up-front `trackInstall` (relied on for the in-flight "Installing…" UI state and orphan-reap rollback) is preserved.

## Also included (cr follow-up from PR #118)

- `checkForUpdates()` `installedFolder` derivation now also rejects embedded `..` segments and Windows drive prefixes, not just leading `../` and absolute paths, so a malformed record can't leak a non-root folder.
- A test-comment wording fix in the e2e spec.

## Tested

- New `catalog-manager` unit tests: rollback of fresh vs update failures; the #120 regression (a failed update still appears as available); sequential failed updates; success clears the snapshot; exact-keying (no fuzzy match); fallback with no snapshot; `removeInstall` clears a pending snapshot. Plus hardened `installedFolder` cases (embedded `..`, `C:\` prefix).
- Full local chain: `npm run format`, `build`, `build:e2e`, `lint`, `test` (290 pass), `playwright test catalog` (5 pass).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Implements a snapshot-based rollback mechanism for install tracking to prevent loss of catalog records when chart updates fail, while also hardening path validation in the update-check logic.

## Changes

**src/utils/catalog-manager.ts**
- Introduces `installSnapshots` in-memory map to capture install record state before `trackInstall()` overwrites it
- Adds `rollbackInstall(chartNumber)` function to restore prior records on conversion/download failure (deletes if snapshot is null, restoring original behavior for fresh installs)
- Updates `removeInstall()` to clear pending snapshots, preventing rollback from resurrecting records after genuine deletion
- Updates `setInstallFilename()` to delete snapshots on successful conversion, preventing older records from being restored by rollback
- Hardens `installedFolder` derivation in `checkForUpdates()` to reject path traversal segments, Windows drive prefixes, and other malformed paths that could escape the chart directory

**src/index.ts**
- Replaces `removeInstall()` calls with `rollbackInstall()` across all catalog-download and conversion failure paths (including extraction errors, incomplete jobs, promotion failures, and S-57/RNC/Pilot/SHP/GSHHG conversion handlers)
- Adds `setInstallFilename()` call after successful direct download promotion to record the produced filename, enabling proper record cleanup in later delete flows

**test/catalog-manager.test.ts**
- Extends `installedFolder` normalization tests with path traversal and Windows drive prefix rejection cases
- Adds comprehensive `rollbackInstall()` test suite covering: fresh install deletion on failure, update restoration with metadata preservation, update availability detection after failed updates, snapshot clearing on success, sequential failure recovery, exact-key matching, and snapshot clearing by `removeInstall()`

**e2e/catalog.spec.ts**
- Updates test comments for the "failed update error in updates panel" case to clarify expected dismiss behavior (comment-only change)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->