### PR TITLE
fix(catalog): stop queue-waiting opacity from compounding to ~0.18

### DIFF
--- a/public/css/chart-catalog.css
+++ b/public/css/chart-catalog.css
@@ -461,9 +461,10 @@ option.catalog-folder-option-new {
     color: var(--md-sys-color-on-surface-variant);
 }
 
-.catalog-queue-waiting {
-    opacity: 0.6;
-}
+/* No own opacity: a queued row always carries .catalog-update-row.updating
+ * (0.6), which already dims it. Stacking another 0.6 here — plus the
+ * spinner's former inline opacity — compounded down to ~0.18, making the
+ * waiting indicator nearly invisible. */
 
 .catalog-download-progress .progress-bar {
     width: 80px;

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -553,7 +553,7 @@ function renderUpdatesSection(): void {
       } else if (isWaiting) {
         actionHtml = `
           <div class="catalog-queue-waiting">
-            <div class="spinner" style="width:16px;height:16px;border-width:2px;opacity:0.5;"></div>
+            <div class="spinner" style="width:16px;height:16px;border-width:2px;"></div>
             <span>Waiting in queue (position ${queuePosition})...</span>
           </div>`;
       } else if (isDownloading) {


### PR DESCRIPTION
## Problem

In the catalog Updates panel, a row that is **waiting in the queue** (an "Update All" item not yet started) was rendered almost invisible.

## Cause

Opacity compounded three times for a queued row:

- `.catalog-update-row.updating` — `opacity: 0.6` (a queued row always carries `.updating`)
- `.catalog-queue-waiting` inside it — `opacity: 0.6` → 0.36
- the spinner's inline `opacity: 0.5` → **~0.18**

## Fix

Remove the redundant `.catalog-queue-waiting` opacity and the inline spinner opacity. The parent `.catalog-update-row.updating` already dims the whole row, so a single 0.6 is applied instead of compounding to ~0.18.

This is a follow-up to the catalog-updates work in #118 (flagged during review).

## Tested

`npm run format`, `build`, `build:e2e`, `lint`, `test` (290 pass), `playwright test catalog` (5 pass). No logic change — CSS + one inline style only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Removes redundant opacity declarations that caused compounding opacity to render queue-waiting indicators nearly invisible.

**chart-catalog.css** removes the `.catalog-queue-waiting { opacity: 0.6; }` rule and adds a comment explaining that queued rows already inherit dimming from `.catalog-update-row.updating` (opacity 0.6), so stacking additional opacity values was unnecessarily compounding the visual opacity.

**chart-catalog.ts** removes the inline `opacity: 0.5` style from the spinner element in the "Waiting in queue" UI, allowing the spinner to inherit only the parent row's dimming.

The changes ensure that queue-waiting indicators display at the intended 0.6 opacity rather than the previous compounded ~0.18 opacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->