### PR TITLE
fix(download): retry transient download failures (network/timeout/5xx)

### DIFF
--- a/src/utils/download-manager.ts
+++ b/src/utils/download-manager.ts
@@ -23,6 +23,12 @@ export class TransientDownloadError extends Error {
 const MAX_DOWNLOAD_ATTEMPTS = 3;
 const RETRY_BACKOFF_MS = 2000;
 
+// cancelJob() marks a job failed with this exact error and emits job-cancelled.
+const CANCELLED_ERROR = 'Cancelled by user';
+function isCancelled(job: DownloadJob): boolean {
+  return job.status === 'failed' && job.error === CANCELLED_ERROR;
+}
+
 interface DownloadManagerEvents {
   'job-created': [job: DownloadJob];
   'job-updated': [job: DownloadJob];
@@ -128,6 +134,10 @@ class DownloadManager extends EventEmitter {
   }
 
   private async processJob(job: DownloadJob): Promise<void> {
+    // Cancelled while still queued — don't resurrect it into 'downloading'.
+    if (isCancelled(job)) {
+      return;
+    }
     try {
       job.status = 'downloading';
       job.startedAt = Date.now();
@@ -140,6 +150,11 @@ class DownloadManager extends EventEmitter {
       job.completedAt = Date.now();
       this.emit('job-completed', job);
     } catch (error) {
+      // A cancelled job is already in its terminal state (cancelJob set it and
+      // emitted job-cancelled); don't overwrite or re-emit job-failed.
+      if (isCancelled(job)) {
+        return;
+      }
       job.status = 'failed';
       job.error = (error instanceof Error ? error.message : String(error)) || 'Download failed';
       job.completedAt = Date.now();
@@ -171,10 +186,20 @@ class DownloadManager extends EventEmitter {
   private async downloadWithRetry(job: DownloadJob): Promise<void> {
     const originalUrl = job.originalUrl ?? job.url;
     for (let attempt = 1; attempt <= MAX_DOWNLOAD_ATTEMPTS; attempt++) {
+      // cancelJob() marks the job failed/'Cancelled by user' but can't abort an
+      // in-flight attempt or the backoff timer. Bail before (re)starting so a
+      // cancel during a download or backoff isn't overwritten by a later
+      // success in processJob.
+      if (isCancelled(job)) {
+        throw new Error('Cancelled by user');
+      }
       try {
         await this.downloadAndExtract(job);
         return;
       } catch (error) {
+        if (isCancelled(job)) {
+          throw new Error('Cancelled by user');
+        }
         const transient = error instanceof TransientDownloadError;
         if (!transient || attempt === MAX_DOWNLOAD_ATTEMPTS) {
           throw error;
@@ -187,6 +212,10 @@ class DownloadManager extends EventEmitter {
         job.url = originalUrl;
         job.downloadedBytes = 0;
         job.progress = 0;
+        // A prior attempt may have flipped status to 'extracting' (zip ≥90%);
+        // the retry starts in the download phase again, so reset it or the UI
+        // shows "0% extracting".
+        job.status = 'downloading';
         // downloadAndExtract pushes onto these as files/zip-entries arrive, so
         // clear them (after cleanupPartialFiles has used targetFiles) — else a
         // retry of a partially-streamed download accumulates duplicate names.

--- a/src/utils/download-manager.ts
+++ b/src/utils/download-manager.ts
@@ -6,6 +6,23 @@ import unzipper from 'unzipper';
 import { EventEmitter } from 'events';
 import type { DownloadJob, DownloadJobOptions } from '../types.js';
 
+// A download failure worth retrying: a network error, a timeout, or a 5xx
+// server response. A 4xx (e.g. 404 for a moved/expired catalog link) is NOT
+// transient — retrying just delays a legitimate error — so it stays a plain
+// Error and fails fast.
+export class TransientDownloadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TransientDownloadError';
+  }
+}
+
+// Bounded retry for transient download failures. Three attempts total with a
+// short linear backoff handles a flaky upstream (the chart sources are
+// third-party government servers) without stalling on a genuinely-gone file.
+const MAX_DOWNLOAD_ATTEMPTS = 3;
+const RETRY_BACKOFF_MS = 2000;
+
 interface DownloadManagerEvents {
   'job-created': [job: DownloadJob];
   'job-updated': [job: DownloadJob];
@@ -116,7 +133,7 @@ class DownloadManager extends EventEmitter {
       job.startedAt = Date.now();
       this.emit('job-updated', job);
 
-      await this.downloadAndExtract(job);
+      await this.downloadWithRetry(job);
 
       job.status = 'completed';
       job.progress = 100;
@@ -127,18 +144,56 @@ class DownloadManager extends EventEmitter {
       job.error = (error instanceof Error ? error.message : String(error)) || 'Download failed';
       job.completedAt = Date.now();
 
-      for (const fileName of job.targetFiles) {
-        const filePath = path.join(job.targetDir, fileName);
-        try {
-          fs.unlinkSync(filePath);
-          console.log(`[${job.id}] Cleaned up partial file: ${fileName}`);
-        } catch {
-          // file may not exist yet
-        }
-      }
+      this.cleanupPartialFiles(job);
 
       this.emit('job-failed', job);
       console.error(`Download job ${job.id} failed:`, error);
+    }
+  }
+
+  private cleanupPartialFiles(job: DownloadJob): void {
+    for (const fileName of job.targetFiles) {
+      const filePath = path.join(job.targetDir, fileName);
+      try {
+        fs.unlinkSync(filePath);
+        console.log(`[${job.id}] Cleaned up partial file: ${fileName}`);
+      } catch {
+        // file may not exist yet
+      }
+    }
+  }
+
+  // Run downloadAndExtract with bounded retries on TRANSIENT failures only
+  // (network error, timeout, 5xx). A 4xx (e.g. 404 for an expired catalog
+  // link) throws immediately. Between attempts, partial files are removed and
+  // the URL is reset to the original (downloadAndExtract mutates job.url while
+  // following redirects).
+  private async downloadWithRetry(job: DownloadJob): Promise<void> {
+    const originalUrl = job.originalUrl ?? job.url;
+    for (let attempt = 1; attempt <= MAX_DOWNLOAD_ATTEMPTS; attempt++) {
+      try {
+        await this.downloadAndExtract(job);
+        return;
+      } catch (error) {
+        const transient = error instanceof TransientDownloadError;
+        if (!transient || attempt === MAX_DOWNLOAD_ATTEMPTS) {
+          throw error;
+        }
+        const msg = error instanceof Error ? error.message : String(error);
+        console.warn(
+          `[${job.id}] Transient download failure (attempt ${attempt}/${MAX_DOWNLOAD_ATTEMPTS}): ${msg}; retrying...`
+        );
+        this.cleanupPartialFiles(job);
+        job.url = originalUrl;
+        job.downloadedBytes = 0;
+        job.progress = 0;
+        // downloadAndExtract pushes onto these as files/zip-entries arrive, so
+        // clear them (after cleanupPartialFiles has used targetFiles) — else a
+        // retry of a partially-streamed download accumulates duplicate names.
+        job.targetFiles = [];
+        job.extractedFiles = [];
+        await new Promise((r) => setTimeout(r, RETRY_BACKOFF_MS * attempt));
+      }
     }
   }
 
@@ -165,7 +220,12 @@ class DownloadManager extends EventEmitter {
           }
 
           if (response.statusCode !== 200) {
-            reject(new Error(`HTTP ${response.statusCode}`));
+            const status = response.statusCode ?? 0;
+            response.resume(); // drain so the socket can be reused/freed
+            // 5xx = server-side hiccup, worth a retry; 4xx (incl. 404 for a
+            // moved/expired catalog link) is permanent — fail fast.
+            const msg = `HTTP ${status}`;
+            reject(status >= 500 ? new TransientDownloadError(msg) : new Error(msg));
             return;
           }
 
@@ -328,12 +388,13 @@ class DownloadManager extends EventEmitter {
         })
         .on('error', (error: Error) => {
           console.error(`[${job.id}] Download error:`, error);
-          reject(error);
+          // Connection reset / DNS / socket errors are transient — retry.
+          reject(new TransientDownloadError(error.message));
         });
 
       req.on('timeout', () => {
         req.destroy();
-        reject(new Error('Server not responding (no data received for 60s)'));
+        reject(new TransientDownloadError('Server not responding (no data received for 60s)'));
       });
     });
   }

--- a/test/download-manager.test.ts
+++ b/test/download-manager.test.ts
@@ -46,7 +46,8 @@ function startOrigin(handler: (hit: number, res: http.ServerResponse) => void): 
   });
 }
 
-// Resolve when the given job reaches a terminal state.
+// Resolve when the given job reaches a terminal state (completed / failed /
+// cancelled). A cancelled job is emitted via job-cancelled by cancelJob().
 function waitForTerminal(jobId: string): Promise<DownloadJob> {
   return new Promise((resolve) => {
     const check = (job: DownloadJob): void => {
@@ -56,11 +57,13 @@ function waitForTerminal(jobId: string): Promise<DownloadJob> {
       if (job.status === 'completed' || job.status === 'failed') {
         downloadManager.removeListener('job-completed', check);
         downloadManager.removeListener('job-failed', check);
+        downloadManager.removeListener('job-cancelled', check);
         resolve(job);
       }
     };
     downloadManager.on('job-completed', check);
     downloadManager.on('job-failed', check);
+    downloadManager.on('job-cancelled', check);
   });
 }
 
@@ -180,6 +183,48 @@ describe('DownloadManager retry', () => {
       assert.strictEqual(job.status, 'failed');
       assert.match(job.error ?? '', /500/);
       assert.strictEqual(origin.hits(), 3, 'should stop after MAX_DOWNLOAD_ATTEMPTS (3)');
+    } finally {
+      await origin.close();
+    }
+  });
+
+  it('does not retry (or complete) a job cancelled during backoff', async () => {
+    // First attempt 503 (→ enters backoff); cancel during the backoff window.
+    // The retry must NOT run a second attempt, and the job must stay cancelled
+    // — never overwritten by a later completion.
+    let secondAttempt = false;
+    const origin = await startOrigin((hit, res) => {
+      if (hit === 1) {
+        res.statusCode = 503;
+        res.end('busy');
+        return;
+      }
+      secondAttempt = true; // would only fire if a retry wrongly proceeded
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/octet-stream');
+      res.end('CHARTDATA');
+    });
+
+    try {
+      const jobId = downloadManager.createJob(origin.url, TMP, 'cancel-in-backoff', {
+        saveRaw: true
+      });
+      // Cancel mid-backoff: after the first 503 (a few hundred ms in) but well
+      // before the ~2s backoff elapses.
+      await new Promise((r) => setTimeout(r, 500));
+      const result = downloadManager.cancelJob(jobId);
+      assert.strictEqual(result.success, true, 'cancel should succeed mid-flight');
+
+      // Wait past the full backoff window so a (wrongly) resumed retry would
+      // have hit the origin and possibly completed the job by now.
+      await new Promise((r) => setTimeout(r, 3000));
+
+      const job = downloadManager.getJob(jobId);
+      assert.ok(job);
+      assert.strictEqual(job.status, 'failed');
+      assert.strictEqual(job.error, 'Cancelled by user', 'cancellation must not be overwritten');
+      assert.strictEqual(secondAttempt, false, 'must not start a retry after cancel');
+      assert.strictEqual(origin.hits(), 1, 'only the first (pre-cancel) attempt should hit');
     } finally {
       await origin.close();
     }

--- a/test/download-manager.test.ts
+++ b/test/download-manager.test.ts
@@ -193,8 +193,15 @@ describe('DownloadManager retry', () => {
     // The retry must NOT run a second attempt, and the job must stay cancelled
     // — never overwritten by a later completion.
     let secondAttempt = false;
+    // Resolve the moment the first attempt actually reaches the origin, so we
+    // cancel based on a real signal rather than a wall-clock guess (flaky CI).
+    let signalFirstHit: () => void = () => {};
+    const firstHit = new Promise<void>((resolve) => {
+      signalFirstHit = resolve;
+    });
     const origin = await startOrigin((hit, res) => {
       if (hit === 1) {
+        signalFirstHit();
         res.statusCode = 503;
         res.end('busy');
         return;
@@ -209,9 +216,9 @@ describe('DownloadManager retry', () => {
       const jobId = downloadManager.createJob(origin.url, TMP, 'cancel-in-backoff', {
         saveRaw: true
       });
-      // Cancel mid-backoff: after the first 503 (a few hundred ms in) but well
-      // before the ~2s backoff elapses.
-      await new Promise((r) => setTimeout(r, 500));
+      // Wait for the first attempt to land (deterministic), then cancel while
+      // the loop is in its ~2s backoff before the second attempt.
+      await firstHit;
       const result = downloadManager.cancelJob(jobId);
       assert.strictEqual(result.success, true, 'cancel should succeed mid-flight');
 

--- a/test/download-manager.test.ts
+++ b/test/download-manager.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the download manager's transient-failure retry behaviour.
+ * A small local HTTP server stands in for a flaky chart source.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { downloadManager } from '../dist/utils/download-manager.js';
+import type { DownloadJob } from '../dist/types.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TMP = path.join(__dirname, 'fixtures', 'download-test');
+
+// A controllable origin: `behaviour` decides the response per request and
+// records how many times it was hit.
+interface Origin {
+  url: string;
+  hits: () => number;
+  close: () => Promise<void>;
+}
+
+function startOrigin(handler: (hit: number, res: http.ServerResponse) => void): Promise<Origin> {
+  let hits = 0;
+  const server = http.createServer((_req, res) => {
+    hits += 1;
+    handler(hits, res);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      resolve({
+        url: `http://127.0.0.1:${port}/chart.bin`,
+        hits: () => hits,
+        close: () =>
+          new Promise<void>((r) => {
+            server.close(() => r());
+          })
+      });
+    });
+  });
+}
+
+// Resolve when the given job reaches a terminal state.
+function waitForTerminal(jobId: string): Promise<DownloadJob> {
+  return new Promise((resolve) => {
+    const check = (job: DownloadJob): void => {
+      if (job.id !== jobId) {
+        return;
+      }
+      if (job.status === 'completed' || job.status === 'failed') {
+        downloadManager.removeListener('job-completed', check);
+        downloadManager.removeListener('job-failed', check);
+        resolve(job);
+      }
+    };
+    downloadManager.on('job-completed', check);
+    downloadManager.on('job-failed', check);
+  });
+}
+
+describe('DownloadManager retry', () => {
+  before(() => {
+    fs.mkdirSync(TMP, { recursive: true });
+  });
+
+  beforeEach(() => {
+    downloadManager.removeAllListeners();
+  });
+
+  after(() => {
+    downloadManager.removeAllListeners();
+    fs.rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('retries a transient 5xx and then succeeds', async () => {
+    // Fail with 503 twice, then serve the file on the 3rd attempt.
+    const origin = await startOrigin((hit, res) => {
+      if (hit < 3) {
+        res.statusCode = 503;
+        res.end('busy');
+        return;
+      }
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/octet-stream');
+      res.end('CHARTDATA');
+    });
+
+    try {
+      const jobId = downloadManager.createJob(origin.url, TMP, 'retry-5xx', { saveRaw: true });
+      const terminal = waitForTerminal(jobId);
+      const job = await terminal;
+
+      assert.strictEqual(job.status, 'completed', `expected completed, got ${job.status}`);
+      assert.strictEqual(origin.hits(), 3, 'should have taken exactly 3 attempts');
+    } finally {
+      await origin.close();
+    }
+  });
+
+  it('clears file lists between retries so they cannot accumulate (issue: dup filenames)', async () => {
+    // downloadAndExtract pushes onto targetFiles/extractedFiles as files (raw)
+    // or zip entries arrive. If a partially-streamed attempt fails transiently
+    // and retries without clearing those lists, the names accumulate. Simulate
+    // a prior partial attempt by pre-seeding the lists, then drive a 503→200
+    // retry; the successful attempt must leave exactly one clean entry, not the
+    // stale one(s) plus the new push.
+    const origin = await startOrigin((hit, res) => {
+      if (hit === 1) {
+        res.statusCode = 503;
+        res.end('busy');
+        return;
+      }
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/octet-stream');
+      res.end('CHARTDATA');
+    });
+
+    try {
+      const jobId = downloadManager.createJob(origin.url, TMP, 'clears-lists', { saveRaw: true });
+      const job = downloadManager.getJob(jobId);
+      assert.ok(job);
+      // Stand in for a prior partial attempt's leftovers.
+      job.targetFiles.push('stale-from-prior-attempt.bin');
+      job.extractedFiles.push('stale-from-prior-attempt.bin');
+
+      const finished = await waitForTerminal(jobId);
+      assert.strictEqual(
+        finished.status,
+        'completed',
+        `expected completed, got ${finished.status}`
+      );
+      assert.strictEqual(origin.hits(), 2, 'should have retried once after the 503');
+      assert.ok(
+        !finished.targetFiles.includes('stale-from-prior-attempt.bin'),
+        `stale entry survived the retry: ${JSON.stringify(finished.targetFiles)}`
+      );
+      assert.ok(
+        !finished.extractedFiles.includes('stale-from-prior-attempt.bin'),
+        `stale extracted entry survived the retry: ${JSON.stringify(finished.extractedFiles)}`
+      );
+    } finally {
+      await origin.close();
+    }
+  });
+
+  it('fails fast on 404 without retrying', async () => {
+    const origin = await startOrigin((_hit, res) => {
+      res.statusCode = 404;
+      res.end('gone');
+    });
+
+    try {
+      const jobId = downloadManager.createJob(origin.url, TMP, 'no-retry-404', { saveRaw: true });
+      const job = await waitForTerminal(jobId);
+
+      assert.strictEqual(job.status, 'failed', 'a 404 must fail the job');
+      assert.match(job.error ?? '', /404/);
+      assert.strictEqual(origin.hits(), 1, 'a 404 must NOT be retried');
+    } finally {
+      await origin.close();
+    }
+  });
+
+  it('gives up after the max attempts on a persistent 5xx', async () => {
+    const origin = await startOrigin((_hit, res) => {
+      res.statusCode = 500;
+      res.end('always down');
+    });
+
+    try {
+      const jobId = downloadManager.createJob(origin.url, TMP, 'persistent-5xx', { saveRaw: true });
+      const job = await waitForTerminal(jobId);
+
+      assert.strictEqual(job.status, 'failed');
+      assert.match(job.error ?? '', /500/);
+      assert.strictEqual(origin.hits(), 3, 'should stop after MAX_DOWNLOAD_ATTEMPTS (3)');
+    } finally {
+      await origin.close();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Chart downloads are fetched from third-party government servers that occasionally blip. During manual testing, a download briefly returned **HTTP 404** from a URL that was otherwise reachable (it returned 200 on retry). The download manager had **no retry** — any non-200 (or a mid-stream network drop / timeout) failed the job on the first try.

## Fix

Classify download failures and retry only the **transient** ones:

- **Network errors, request timeout, and 5xx** → `TransientDownloadError`, retried up to 3 times with linear backoff. Between attempts the URL is reset to the original (redirects mutate `job.url`), partial files are removed, and the `targetFiles` / `extractedFiles` lists are cleared so a partially-streamed attempt doesn't accumulate duplicate filenames on retry.
- **4xx (incl. 404 for a moved/expired catalog link)** → plain `Error`, **fail fast**. Retrying a genuinely-missing file just delays a legitimate error (the user is pointed at the catalog issue tracker for outdated links).

## Tested

New `test/download-manager.test.ts` (local HTTP origin stands in for a flaky source):
- 5xx-then-200 retries and succeeds (exactly 3 attempts)
- a transient retry clears stale file-list entries (guards against duplicate-filename accumulation)
- 404 fails on the first hit (no retry)
- persistent 5xx gives up after 3 attempts

Full local chain: `format`, `build`, `lint`, `test` (294 pass).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Introduces bounded retry handling for transient download failures while failing fast on permanent errors.

- Adds exported TransientDownloadError to classify retryable failures (network/socket errors, request timeouts, and HTTP 5xx responses). HTTP 4xx responses (including 404) remain non-transient and fail immediately.
- Implements downloadWithRetry(job) around downloadAndExtract:
  - Retries only transient failures up to 3 attempts with linear backoff (RETRY_BACKOFF_MS × attempt).
  - Between attempts: removes partial files, resets job.url to the original, clears downloadedBytes/progress, clears targetFiles and extractedFiles, and resets job.status to 'downloading' so stale extraction progress is not shown.
  - Aborts retrying if the job is cancelled (isCancelled) before or after an attempt so cancellations during an in-flight download or backoff are not overwritten by later successes.
- Updates downloadAndExtract to wrap connection/timeouts and HTTP >=500 responses as TransientDownloadError (after draining) and to leave 4xx as plain Error.
- Ensures processJob does not resurrect a cancelled job or re-emit job-failed over an already-cancelled job; processJob uses downloadWithRetry and preserves cancellation terminal state.
- Adds cleanupPartialFiles used both on final failure and between retry attempts to remove partially written files.

Tests (test/download-manager.test.ts):
- Adds deterministic integration tests using a local controllable HTTP origin and waitForTerminal helper.
- Verifies:
  - 5xx→200 is retried and succeeds on the 3rd attempt.
  - File lists (targetFiles/extractedFiles) are cleared between retries to avoid duplicate filenames.
  - 404 fails fast with no retry.
  - Persistent 5xx gives up after 3 attempts and fails with the server error.
  - Cancelling a job during backoff prevents further attempts and preserves the cancellation error (regression test).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->