### PR TITLE
fix(catalog): persist update rollback snapshot so a restart can't lose it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -406,7 +406,14 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             );
             if (chartNumber) {
               setConvertingState(chartNumber, false);
-              removeInstall(chartNumber);
+              // A restart/crash can land here mid-update. rollbackInstall
+              // restores the prior on-disk version (UPDATE) or drops the
+              // pending record (FRESH), reading the snapshot trackInstall
+              // persisted in the record — so a still-pending update keeps
+              // surfacing in checkForUpdates(). For a committed record (no
+              // snapshot marker) it's a no-op, so a spurious reap of an
+              // already-installed chart doesn't delete it.
+              rollbackInstall(chartNumber);
             }
           }
           if (cleanup.reaped.length > 0) {

--- a/src/utils/catalog-manager.ts
+++ b/src/utils/catalog-manager.ts
@@ -55,14 +55,6 @@ let dataDir = '';
 let cacheDir = '';
 let installsFilePath = '';
 let installs: CatalogInstallsMap = {};
-// In-memory snapshot of the install record that trackInstall() is about to
-// overwrite, keyed by chartNumber. A failed conversion calls rollbackInstall()
-// to restore the prior record (a failed UPDATE — issue #120) or drop it (a
-// failed FRESH install, snapshot === null). Intentionally NOT persisted: it
-// only needs to live from the up-front trackInstall to that same attempt's
-// failure branch. A crash mid-conversion is handled by the orphan-reap path,
-// which removeInstall()s unconditionally.
-const installSnapshots = new Map<string, CatalogInstall | null>();
 const converting: Record<string, true> = {};
 let debug: DebugFunction = () => {};
 
@@ -469,39 +461,52 @@ export function trackInstall(
   zipfileDatetime: string,
   url: string
 ): void {
-  // Snapshot whatever is currently recorded BEFORE overwriting it, so a
-  // failed UPDATE can restore the still-on-disk old version (issue #120).
-  // A fresh install snapshots null, which rollbackInstall() treats as
-  // "delete the record" — same as the old removeInstall cleanup.
+  // Snapshot the prior record INSIDE the new record (persisted to disk via
+  // saveInstalls) so a restart mid-update can still roll back to the
+  // still-on-disk old version (issue #120 restart window). An in-memory-only
+  // snapshot would be lost on a plugin hot-restart (every config save) or a
+  // Signal K restart. The presence of `previousVersion` marks the install as
+  // in-flight; a FRESH install records `null` ("delete on rollback").
+  // Strip any nested previousVersion so snapshots never stack across
+  // sequential failed updates — the snapshot always points at the last
+  // committed version.
+  let snapshot: CatalogInstall | null = null;
   const prior = installs[chartNumber];
-  installSnapshots.set(chartNumber, prior ? { ...prior } : null);
+  if (prior) {
+    // Omit the prior's own previousVersion key entirely (not set it to
+    // undefined) so the snapshot is exactly one level deep and never carries a
+    // dangling key.
+    const { previousVersion: _nested, ...flat } = prior;
+    snapshot = flat;
+  }
   installs[chartNumber] = {
     catalogFile,
     zipfile_datetime_iso8601: zipfileDatetime,
     installedAt: new Date().toISOString(),
-    zipfile_location: url
+    zipfile_location: url,
+    previousVersion: snapshot
   };
   saveInstalls();
 }
 
 /**
- * Undo the most recent trackInstall() for a chart after its conversion or
- * download FAILS (issue #120). Restores the record trackInstall snapshotted:
- *   - prior record existed (an UPDATE)  → restore it, so checkForUpdates
+ * Undo an in-flight trackInstall() after its conversion/download FAILS, or
+ * when the orphan-reap path recovers a job interrupted by a restart (issue
+ * #120). Reads the snapshot persisted in the record by trackInstall():
+ *   - previousVersion is an object (an UPDATE) → restore it, so checkForUpdates
  *     keeps flagging the update (the old version is still on disk).
- *   - prior record was null (a FRESH install) → delete it, so there's no
- *     stale record for a chart that isn't installed.
- *   - no snapshot at all (defensive)    → fall back to removeInstall so an
- *     in-flight record is still cleaned up.
- * Always clears the snapshot afterwards.
+ *   - previousVersion is null (a FRESH install) → delete the pending record.
+ *   - no `previousVersion` key (a COMMITTED record, or one from an older
+ *     plugin build) → no-op: never delete a settled install. This matters
+ *     because the orphan-reap site calls rollbackInstall for every reaped
+ *     chart, including spurious reaps of already-committed installs.
  */
 export function rollbackInstall(chartNumber: string): void {
-  if (!installSnapshots.has(chartNumber)) {
-    removeInstall(chartNumber);
+  const current = installs[chartNumber];
+  if (!current || !('previousVersion' in current)) {
     return;
   }
-  const prior = installSnapshots.get(chartNumber) ?? null;
-  installSnapshots.delete(chartNumber);
+  const prior = current.previousVersion ?? null;
   if (prior) {
     installs[chartNumber] = prior;
   } else {
@@ -513,9 +518,6 @@ export function rollbackInstall(chartNumber: string): void {
 export function removeInstall(chartNumber: string): void {
   if (installs[chartNumber]) {
     delete installs[chartNumber];
-    // A genuine removal supersedes any pending rollback snapshot for this
-    // exact key, so a later rollbackInstall can't resurrect the record.
-    installSnapshots.delete(chartNumber);
     saveInstalls();
     return;
   }
@@ -551,9 +553,11 @@ export function setInstallFilename(chartNumber: string, filename: string): void 
     return;
   }
   install.installedFilename = filename;
-  // Conversion succeeded — the new record stands. Drop the prior-version
-  // snapshot so a later rollbackInstall can't resurrect the old record.
-  installSnapshots.delete(chartNumber);
+  // Conversion succeeded — commit. Drop the previousVersion marker so the
+  // record is "settled": a later stray rollbackInstall (or an orphan-reap
+  // recovery after a restart) can't resurrect the old version or re-treat it
+  // as in-flight.
+  delete install.previousVersion;
   saveInstalls();
 }
 

--- a/src/utils/catalog-schemas.ts
+++ b/src/utils/catalog-schemas.ts
@@ -57,17 +57,26 @@ export const CatalogDataSchema = Type.Object({
   charts: Type.Array(CatalogChartSchema)
 });
 
-export const CatalogInstallSchema = Type.Object({
-  catalogFile: Type.String(),
-  zipfile_datetime_iso8601: Type.String(),
-  installedAt: Type.String(),
-  zipfile_location: Type.String(),
-  // Relative path of the produced .mbtiles under chartPath. Optional
-  // because the install is recorded before the conversion finishes;
-  // the converter calls setInstallFilename() once the file is on disk
-  // so the delete flow can find this record by filename.
-  installedFilename: Type.Optional(Type.String())
-});
+export const CatalogInstallSchema = Type.Recursive((Self) =>
+  Type.Object({
+    catalogFile: Type.String(),
+    zipfile_datetime_iso8601: Type.String(),
+    installedAt: Type.String(),
+    zipfile_location: Type.String(),
+    // Relative path of the produced .mbtiles under chartPath. Optional
+    // because the install is recorded before the conversion finishes;
+    // the converter calls setInstallFilename() once the file is on disk
+    // so the delete flow can find this record by filename.
+    installedFilename: Type.Optional(Type.String()),
+    // Snapshot of the prior record, captured up-front by trackInstall() so a
+    // restart mid-update can roll back to the still-on-disk old version
+    // (issue #120 restart window). `null` marks a pending FRESH install
+    // ("delete on rollback"). Cleared by setInstallFilename() on success, so
+    // its presence means "this install is in-flight". One level deep only —
+    // trackInstall strips any nested snapshot.
+    previousVersion: Type.Optional(Type.Union([Self, Type.Null()]))
+  })
+);
 
 export const CatalogInstallsMapSchema = Type.Record(Type.String(), CatalogInstallSchema);
 

--- a/test/catalog-manager.test.ts
+++ b/test/catalog-manager.test.ts
@@ -21,6 +21,7 @@ import {
   getCatalogsWithInstalledCharts,
   getCachedCatalog
 } from '../dist/utils/catalog-manager.js';
+import type { CatalogInstall } from '../dist/types.js';
 
 // ESM equivalent of CJS `__dirname`.
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -424,10 +425,16 @@ describe('CatalogManager', () => {
       trackInstall('s', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/v1.mbtiles');
       setInstallFilename('s', 'v1.mbtiles');
       trackInstall('s', CATALOG, '2024-06-10T00:00:00Z', 'https://example.com/v2.mbtiles');
-      setInstallFilename('s', 'v2.mbtiles'); // success clears the snapshot
-      // A stray rollback now must NOT restore v1 (snapshot is gone → removeInstall).
+      setInstallFilename('s', 'v2.mbtiles'); // success commits, clears the marker
+      // A stray rollback on a committed record is a no-op — it must neither
+      // restore v1 nor delete the settled install.
       rollbackInstall('s');
-      assert.strictEqual(getInstalledCatalogCharts()['s'], undefined);
+      const rec = getInstalledCatalogCharts()['s'];
+      assert.ok(rec, 'a committed record must survive a stray rollback');
+      assert.strictEqual(rec.zipfile_datetime_iso8601, '2024-06-10T00:00:00Z');
+      assert.strictEqual(rec.installedFilename, 'v2.mbtiles');
+      assert.ok(!('previousVersion' in rec), 'commit must clear the snapshot marker');
+      removeInstall('s');
     });
 
     it('restores the original across sequential failed updates', () => {
@@ -443,7 +450,7 @@ describe('CatalogManager', () => {
       removeInstall('seq');
     });
 
-    it('falls back to removeInstall when there is no snapshot', () => {
+    it('is a no-op for a chart that was never tracked', () => {
       assert.doesNotThrow(() => {
         rollbackInstall('never-tracked');
       });
@@ -459,14 +466,70 @@ describe('CatalogManager', () => {
       removeInstall('2');
     });
 
-    it('removeInstall clears a pending snapshot so a later rollback cannot resurrect it', () => {
+    it('removeInstall drops the whole record (incl. snapshot) so a later rollback cannot resurrect it', () => {
       trackInstall('d', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/old.mbtiles');
       setInstallFilename('d', 'd.mbtiles');
-      trackInstall('d', CATALOG, '2024-06-10T00:00:00Z', 'https://example.com/new.mbtiles'); // snapshot = old
-      removeInstall('d'); // genuine removal must drop the snapshot
-      trackInstall('d', CATALOG, '2024-09-01T00:00:00Z', 'https://example.com/newer.mbtiles');
-      rollbackInstall('d'); // snapshot here is null (fresh after removeInstall) → deletes
+      trackInstall('d', CATALOG, '2024-06-10T00:00:00Z', 'https://example.com/new.mbtiles'); // previousVersion = old
+      removeInstall('d'); // deletes the whole record, snapshot and all
+      trackInstall('d', CATALOG, '2024-09-01T00:00:00Z', 'https://example.com/newer.mbtiles'); // fresh → previousVersion null
+      rollbackInstall('d'); // fresh pending → deletes
       assert.strictEqual(getInstalledCatalogCharts()['d'], undefined);
+    });
+
+    it('persists the prior version inside the on-disk record (restart-safe)', () => {
+      trackInstall('p', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/v1.mbtiles');
+      setInstallFilename('p', 'v1.mbtiles'); // committed v1
+      trackInstall('p', CATALOG, '2024-06-10T00:00:00Z', 'https://example.com/v2.mbtiles'); // begin update
+      const raw = JSON.parse(
+        fs.readFileSync(path.join(TEST_DATA_DIR, 'catalog-installs.json'), 'utf-8')
+      ) as Record<string, CatalogInstall>;
+      assert.strictEqual(raw['p']!.zipfile_datetime_iso8601, '2024-06-10T00:00:00Z');
+      const snap = raw['p']!.previousVersion;
+      assert.ok(snap, 'snapshot must be persisted on disk');
+      assert.strictEqual(snap.zipfile_datetime_iso8601, '2024-01-01T00:00:00Z');
+      assert.strictEqual(snap.installedFilename, 'v1.mbtiles');
+      assert.ok(!('previousVersion' in snap), 'snapshot must not nest');
+      removeInstall('p');
+    });
+
+    it('survives a restart mid-update: snapshot reloads and rolls back to prior', () => {
+      seedCache('rst', '2024-06-10T00:00:00Z');
+      trackInstall('rst', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/old.mbtiles');
+      setInstallFilename('rst', 'rst.mbtiles'); // committed old
+      trackInstall('rst', CATALOG, '2024-06-10T00:00:00Z', 'https://example.com/new.mbtiles'); // begin update, NOT committed
+
+      // Simulate a Signal K restart: drop module memory, reload from disk.
+      initCatalogManager(TEST_DATA_DIR, () => {});
+      // The orphan-reap recovery path (what index.ts now calls):
+      rollbackInstall('rst');
+
+      const rec = getInstalledCatalogCharts()['rst'];
+      assert.ok(rec, 'prior version must survive the restart');
+      assert.strictEqual(rec.zipfile_datetime_iso8601, '2024-01-01T00:00:00Z');
+      assert.strictEqual(rec.zipfile_location, 'https://example.com/old.mbtiles');
+      assert.strictEqual(rec.installedFilename, 'rst.mbtiles');
+      assert.ok(!('previousVersion' in rec), 'rollback must clear the snapshot marker');
+
+      const u = checkForUpdates().find((x) => x.chartNumber === 'rst');
+      assert.ok(u, 'the still-pending update must keep surfacing after a restart');
+      assert.strictEqual(u.installedDate, '2024-01-01T00:00:00Z');
+      assert.strictEqual(u.availableDate, '2024-06-10T00:00:00Z');
+      removeInstall('rst');
+    });
+
+    it('survives a restart mid-fresh-install: pending record is dropped on reap', () => {
+      trackInstall('frsh', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/a.mbtiles');
+      initCatalogManager(TEST_DATA_DIR, () => {}); // restart
+      rollbackInstall('frsh'); // orphan-reap recovery
+      assert.strictEqual(getInstalledCatalogCharts()['frsh'], undefined);
+    });
+
+    it('does not delete a committed record that has no snapshot marker', () => {
+      trackInstall('cm', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/v1.mbtiles');
+      setInstallFilename('cm', 'v1.mbtiles'); // committed, marker cleared
+      rollbackInstall('cm'); // spurious reap
+      assert.ok(getInstalledCatalogCharts()['cm'], 'committed record must not be deleted');
+      removeInstall('cm');
     });
   });
 


### PR DESCRIPTION
## Problem

Follow-up to #123 (issue #120), addressing CodeRabbit feedback raised on #126.

The #120 fix stored the pre-update rollback snapshot in an **in-memory `Map`**. `trackInstall()` writes the *new* catalog metadata to `catalog-installs.json` immediately, but the old record only lived in memory. So if Signal K restarts — or the plugin **hot-restarts**, which happens on *every* plugin config save — **during** an update, the snapshot is lost: on startup the new metadata stands against the still-present old chart file, and `checkForUpdates()` stops surfacing the still-pending update. That's the #120 symptom resurfacing in a restart window, and it violates the project guideline that state which must survive a config save belongs in the data dir, not module memory.

## Fix

Persist the snapshot **on disk inside the install record** instead of in memory:

- `CatalogInstall` gains an optional, recursive `previousVersion` field — a one-level snapshot of the prior record (or `null` for a pending fresh install). The schema change is **additive and optional**, so old files still parse and older plugin builds ignore it.
- `trackInstall` writes the snapshot into the new record (omitting any nested snapshot so it stays exactly one level deep); `setInstallFilename` clears it on success (commit); `rollbackInstall` reads it back from the record. The in-memory `installSnapshots` Map is removed.
- `rollbackInstall` is now a **no-op on a committed record** (one with no `previousVersion` key). This lets the orphan-reap site call it for every reaped chart — including spurious reaps of already-installed charts — without ever deleting settled data.
- Orphan-reap (`index.ts`) calls `rollbackInstall` instead of `removeInstall`, so a restart-interrupted update restores the prior version from disk and the update keeps surfacing.

## Tested

`test/catalog-manager.test.ts`:
- **restart mid-update** — re-init the manager from the on-disk file (simulating a restart that wipes module memory), then run the orphan-reap recovery: the prior version is restored and `checkForUpdates()` still flags the update.
- restart mid-fresh-install (pending record dropped), snapshot-persisted-on-disk (incl. no-nesting), no-op-on-committed, plus the adjusted existing #120 rollback suite.

Full local chain: `format`, `build`, `lint`, `test` (294 pass).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Persist update rollback snapshot to survive restarts

**Problem**
A prior fix stored a pre-update rollback snapshot in an in-memory Map. When `trackInstall()` wrote new catalog metadata to `catalog-installs.json` immediately, a Signal K restart or plugin hot-restart during an update could lose the in-memory snapshot. On restart, the new metadata could point to the old chart file and `checkForUpdates()` would stop surfacing the pending update. State that must survive a config save belongs in the data directory, not module memory.

**Solution**
Persist the rollback snapshot on disk inside the install record via a new optional `previousVersion` field on `CatalogInstall`:

- **Schema & Types** (`src/utils/catalog-schemas.ts`): Extended `CatalogInstall` with an optional, recursive `previousVersion` field (snapshot of prior install entry or `null` for pending fresh installs). The change is additive and backward compatible.

- **Snapshot Lifecycle** (`src/utils/catalog-manager.ts`):
  - `trackInstall` now writes the snapshot into the install record, stripping nested snapshots
  - `setInstallFilename` clears `previousVersion` on success to mark installs as committed
  - `rollbackInstall` reads `previousVersion` from the record (restores prior version or deletes record for fresh installs), then no-ops for committed records without a snapshot marker
  - Removed the in-memory `installSnapshots` Map

- **Orphan Cleanup** (`src/index.ts`): Changed to call `rollbackInstall` instead of `removeInstall` during startup orphan-reap. This allows restart-interrupted updates to restore the prior version from disk while keeping the update surfaced in `checkForUpdates()`.

**Tests**
Updated and added test coverage in `test/catalog-manager.test.ts` for:
- Restart mid-update: re-initialization from disk followed by orphan-reap restores prior version and `checkForUpdates()` still flags the update
- Restart mid-fresh-install: pending record is dropped on reap
- Snapshot persistence: no nested snapshots stored
- No-op on committed records: `rollbackInstall()` safely called for every reaped chart
- Adjusted existing rollback test suite to verify snapshot marker is cleared after successful updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->