### PR TITLE
fix(catalog): recover interrupted updates at load, not via orphan-reap

### DIFF
--- a/src/utils/catalog-manager.ts
+++ b/src/utils/catalog-manager.ts
@@ -148,6 +148,7 @@ function loadInstalls(): void {
       const parsed = safeParse(CatalogInstallsMapSchema, raw);
       if (parsed) {
         installs = parsed;
+        recoverInFlightUpdates();
       } else {
         console.error('Discarding catalog installs file — shape did not match schema');
         installs = {};
@@ -156,6 +157,35 @@ function loadInstalls(): void {
   } catch (error) {
     console.error('Error loading catalog installs:', error);
     installs = {};
+  }
+}
+
+/**
+ * On load, any record still carrying a `previousVersion` marker is an update
+ * that was interrupted before it committed (a clean success clears the marker
+ * via setInstallFilename). Since we are loading fresh from disk in a new
+ * process, that conversion is by definition not running here — so roll each one
+ * back to its prior version (issue #120 restart window). This makes recovery
+ * independent of the orphan-reap path, which only fires for leaked containers
+ * and never runs when the restart happened during the download phase.
+ */
+function recoverInFlightUpdates(): void {
+  let changed = false;
+  for (const [chartNumber, install] of Object.entries(installs)) {
+    if (!('previousVersion' in install)) {
+      continue;
+    }
+    const prior = install.previousVersion ?? null;
+    if (prior) {
+      installs[chartNumber] = prior; // restore the old version (UPDATE)
+    } else {
+      delete installs[chartNumber]; // drop the pending record (FRESH install)
+    }
+    changed = true;
+    console.log(`[charts-provider] Recovered interrupted update for ${chartNumber} on load`);
+  }
+  if (changed) {
+    saveInstalls();
   }
 }
 
@@ -684,6 +714,13 @@ export function pruneStaleInstalls(chartIdentifiers: string[]): void {
   let pruned = false;
 
   for (const [key, install] of Object.entries(installs)) {
+    // An in-flight update (carries the previousVersion marker) is not stale —
+    // its new file isn't on disk yet, but the old one still is. recoverInFlight-
+    // Updates() rolls these back at load, so prune normally never sees one;
+    // this guard keeps prune from destroying the snapshot if ordering changes.
+    if ('previousVersion' in install) {
+      continue;
+    }
     // Authoritative path: if we recorded the on-disk filename at
     // conversion/move/rename time, the install key should match the
     // chart whose chartId is the basename-without-extension. Anything

--- a/test/catalog-manager.test.ts
+++ b/test/catalog-manager.test.ts
@@ -19,7 +19,8 @@ import {
   getInstalledCatalogCharts,
   checkForUpdates,
   getCatalogsWithInstalledCharts,
-  getCachedCatalog
+  getCachedCatalog,
+  pruneStaleInstalls
 } from '../dist/utils/catalog-manager.js';
 import type { CatalogInstall } from '../dist/types.js';
 
@@ -492,23 +493,23 @@ describe('CatalogManager', () => {
       removeInstall('p');
     });
 
-    it('survives a restart mid-update: snapshot reloads and rolls back to prior', () => {
+    it('survives a restart mid-update: load auto-rolls-back to prior (no reap needed)', () => {
       seedCache('rst', '2024-06-10T00:00:00Z');
       trackInstall('rst', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/old.mbtiles');
       setInstallFilename('rst', 'rst.mbtiles'); // committed old
       trackInstall('rst', CATALOG, '2024-06-10T00:00:00Z', 'https://example.com/new.mbtiles'); // begin update, NOT committed
 
       // Simulate a Signal K restart: drop module memory, reload from disk.
+      // Recovery is automatic in loadInstalls() — NO manual rollbackInstall,
+      // because orphan-reap does not fire for a download-phase restart.
       initCatalogManager(TEST_DATA_DIR, () => {});
-      // The orphan-reap recovery path (what index.ts now calls):
-      rollbackInstall('rst');
 
       const rec = getInstalledCatalogCharts()['rst'];
       assert.ok(rec, 'prior version must survive the restart');
       assert.strictEqual(rec.zipfile_datetime_iso8601, '2024-01-01T00:00:00Z');
       assert.strictEqual(rec.zipfile_location, 'https://example.com/old.mbtiles');
       assert.strictEqual(rec.installedFilename, 'rst.mbtiles');
-      assert.ok(!('previousVersion' in rec), 'rollback must clear the snapshot marker');
+      assert.ok(!('previousVersion' in rec), 'recovery must clear the snapshot marker');
 
       const u = checkForUpdates().find((x) => x.chartNumber === 'rst');
       assert.ok(u, 'the still-pending update must keep surfacing after a restart');
@@ -517,10 +518,32 @@ describe('CatalogManager', () => {
       removeInstall('rst');
     });
 
-    it('survives a restart mid-fresh-install: pending record is dropped on reap', () => {
+    it('survives a restart mid-update even when pruneStaleInstalls runs', () => {
+      // Reproduces the live finding: prune runs at startup before any reap and
+      // must NOT delete an in-flight record (the new file isn't on disk yet, so
+      // its chartId is absent from the scanned set). With load-time recovery the
+      // record is already rolled back to the prior version by the time prune
+      // runs; prune must leave that prior record intact.
+      seedCache('prn', '2024-06-10T00:00:00Z');
+      trackInstall('prn', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/old.mbtiles');
+      setInstallFilename('prn', 'old-prn.mbtiles'); // committed old → chartId 'old-prn'
+      trackInstall('prn', CATALOG, '2024-06-10T00:00:00Z', 'https://example.com/new.mbtiles'); // begin update
+
+      initCatalogManager(TEST_DATA_DIR, () => {}); // restart → load auto-rolls-back to old-prn
+      // Startup then scans charts and prunes. The old file IS on disk, so its
+      // chartId is present; pass it so prune keeps the recovered record.
+      pruneStaleInstalls(['old-prn']);
+
+      const rec = getInstalledCatalogCharts()['prn'];
+      assert.ok(rec, 'recovered prior record must survive prune');
+      assert.strictEqual(rec.zipfile_datetime_iso8601, '2024-01-01T00:00:00Z');
+      assert.strictEqual(rec.installedFilename, 'old-prn.mbtiles');
+      removeInstall('prn');
+    });
+
+    it('survives a restart mid-fresh-install: pending record dropped on load', () => {
       trackInstall('frsh', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/a.mbtiles');
-      initCatalogManager(TEST_DATA_DIR, () => {}); // restart
-      rollbackInstall('frsh'); // orphan-reap recovery
+      initCatalogManager(TEST_DATA_DIR, () => {}); // restart → load drops the never-committed fresh record
       assert.strictEqual(getInstalledCatalogCharts()['frsh'], undefined);
     });
 


### PR DESCRIPTION
## Problem

Follow-up to #127. **Live testing** (real plugin hot-restart mid-update, the scenario #127 was meant to protect) showed the persisted rollback snapshot still got lost, for two reasons the #127 design and its unit test missed:

1. **`pruneStaleInstalls` runs at startup *before* orphan-reap and deleted the in-flight record.** The in-flight update record has the new date + `previousVersion` snapshot but **no top-level `installedFilename`** (that lives only in the snapshot), so prune's authoritative branch doesn't protect it and the legacy fuzzy branch drops it. Log: `Pruning stale catalog install: 269`.
2. **Orphan-reap — the intended snapshot consumer — never fires for a download-phase restart.** The conversion container is spawned only *after* the download completes; a restart at, say, 37% download leaves nothing to reap, so `rollbackInstall` is never called. And mid-conversion, prune (1) would delete the record first anyway.

The #127 unit test passed because it simulated a restart by calling `rollbackInstall()` directly — it never ran the real `loadInstalls` → `pruneStaleInstalls` startup path.

## Fix

Recover at **load time**, independent of orphan-reap:

- `loadInstalls()` now calls `recoverInFlightUpdates()`, which rolls back any record still carrying a `previousVersion` marker (a never-committed update — a clean success clears the marker via `setInstallFilename`) to its prior version, or drops a pending fresh install. Because we're loading fresh from disk in a new process, that conversion is by definition not running, so auto-rollback is safe.
- Belt-and-suspenders: `pruneStaleInstalls()` now skips records with a `previousVersion` marker, so prune can never destroy an in-flight snapshot even if ordering changes.

## Verified live

Real config-save restart mid-update: the record is restored to the prior version, the update prompt resurfaces, and the log shows `Recovered interrupted update for 269 on load` (instead of pruning). Confirmed the old file stays tracked and `checkForUpdates` re-flags the update.

## Tested

`test/catalog-manager.test.ts` — tests now exercise the **real startup path** (`initCatalogManager` load + `pruneStaleInstalls`), not a direct `rollbackInstall` call:
- restart mid-update auto-recovers to the prior version (no reap needed)
- recovered record survives a following `pruneStaleInstalls`
- mid-fresh-install pending record is dropped on load

All three fail without the fix. Full chain: `format`, `build`, `lint`, `test` (290 pass).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Recovers interrupted catalog updates at process startup rather than relying on orphan cleanup to restore state. This addresses cases where in-flight records are lost during restarts that occur before the conversion container is created.

## Changes

**src/utils/catalog-manager.ts**
- `loadInstalls()` now invokes a new `recoverInFlightUpdates()` step immediately after loading and validating the installs metadata, restoring any interrupted updates (marked with `previousVersion`) back to their prior committed version or removing them if the prior snapshot is absent
- `recoverInFlightUpdates()` rolls back all uncommitted in-flight updates and persists corrections to disk when changes occur
- `pruneStaleInstalls()` now preserves installs carrying the `previousVersion` marker during cleanup, preventing removal of the rollback snapshot needed for restart recovery

**test/catalog-manager.test.ts**
- Updated to exercise the real startup path with `initCatalogManager` and `pruneStaleInstalls`
- "restart mid-update" test now validates automatic load-time recovery without explicit rollback calls, verifying the prior version is restored and snapshot markers cleared
- New test verifies that recovered installs survive subsequent pruning operations
- "restart mid-fresh-install" test updated to assert that uncommitted fresh-install pending records are dropped during load

## Impact
- No changes to exported or public declarations
- Fixes lost in-flight state during restarts that occur before download completion
- Test coverage expanded from unit-only to include realistic startup scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->