### PR TITLE
chore(release): 2.2.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.1.0",
+  "version": "2.2.0-beta.1",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Beta release bundling the chart-download/conversion fixes merged since 2.1.0.

## Included since 2.1.0
- **fix(convert): container output dirs writable** — resolves `Permission denied` (`/output/.export-errors.log`) for rootless containers (#117). Covers S-57 export, multi-band tippecanoe, quarantine, and Pilot/SHP/GSHHG paths. (#119 + follow-up)
- **fix(Dockerfile): xz-utils in the toolbox image** — `.tar.xz` extraction (Pilot Charts, GSHHG, Shapefiles) now works in-container; image published as `charts-toolbox:1.1.0` and pinned. (#124)
- **fix(catalog): updates panel** — completed updates clear from the panel live; failed updates surface an error instead of being silently skipped; queue re-entrancy + dismiss wiring. (#122, #123)
- **fix(catalog): install record durability** — a failed *update* no longer wipes the still-installed old version's record, and an update interrupted by a restart is recovered on load so the update prompt persists. (#123, #128)
- **fix(download): retry transient failures** — network/timeout/5xx are retried; 4xx/404 fail fast; a cancel mid-retry is honored. (#126)
- **fix(catalog): CSS** — queue-waiting indicator no longer dimmed to near-invisible. (#125)

Publishes to npm under the `beta` tag (the `v2.2.0-beta.1` tag triggers `publish.yml` with `--tag beta`).

## Tested
Full unit/e2e suite green. Chart conversion verified live on Signal K 2.28-beta2 with rootless podman: real S-57 ENC conversion succeeds with zero `Permission denied`, `charts-toolbox:1.1.0` ships `xz 5.8.3`, and a plugin restart mid-update recovers the prior version with the update prompt intact.
