### PR TITLE
feat(catalog): add a Refresh button and clear GitHub rate-limit messaging

### DIFF
--- a/e2e/catalog.spec.ts
+++ b/e2e/catalog.spec.ts
@@ -215,4 +215,121 @@ test.describe('Chart Catalog tab', () => {
     // and refresh the updates list, removing the row live — no tab reload.
     await expect(row).toHaveCount(0, { timeout: 10_000 });
   });
+
+  test('shows a Refresh button in the catalog toolbar', async ({ page }) => {
+    await page.goto('/plugins/signalk-charts-provider-simple/');
+    await setMockState(page, { registry: [] });
+    await page.getByRole('button', { name: /Chart Catalog/i }).click();
+    await expect(page.locator('[data-catalog-refresh]')).toBeVisible();
+  });
+
+  test('rate-limited empty registry shows warning copy + reset time, not "offline"', async ({
+    page
+  }) => {
+    await page.goto('/plugins/signalk-charts-provider-simple/');
+    const resetAt = Date.now() + 42 * 60_000;
+    await setMockState(page, {
+      registry: [],
+      registryStatus: {
+        status: 'rate_limited',
+        isRateLimited: true,
+        remaining: 0,
+        resetAt,
+        retryAfter: 3600,
+        lastAttemptAt: Date.now(),
+        lastSuccessAt: null,
+        httpStatus: 403
+      }
+    });
+    await page.getByRole('button', { name: /Chart Catalog/i }).click();
+
+    const msg = page.locator('.catalog-error-rate-limit');
+    await expect(msg).toBeVisible();
+    await expect(msg).toContainText(/GitHub rate limit reached/i);
+    await expect(msg).not.toContainText(/offline/i);
+    await expect(msg).toContainText(/in about \d+ minutes?/);
+  });
+
+  test('a failed (rate-limited) refresh keeps the cached cards, shows a banner', async ({
+    page
+  }) => {
+    await page.goto('/plugins/signalk-charts-provider-simple/');
+    // Start populated; script the refresh to come back empty + rate-limited.
+    await setMockState(page, {
+      registry: [
+        {
+          file: 'DE_IENC.xml',
+          label: 'Germany Inland ENC',
+          category: 'ienc',
+          chartCount: 3,
+          cachedAt: '2026-05-07T10:00:00Z'
+        }
+      ],
+      refreshRegistry: [],
+      refreshStatus: {
+        status: 'rate_limited',
+        isRateLimited: true,
+        remaining: 0,
+        resetAt: Date.now() + 3_600_000,
+        retryAfter: 3600,
+        lastAttemptAt: Date.now(),
+        lastSuccessAt: null,
+        httpStatus: 403
+      }
+    });
+    await page.getByRole('button', { name: /Chart Catalog/i }).click();
+    await expect(page.locator('.catalog-card')).toHaveCount(1);
+
+    await page.locator('[data-catalog-refresh]').click();
+
+    // Cards must NOT be blanked; a non-destructive banner explains why.
+    await expect(page.locator('.catalog-card')).toHaveCount(1);
+    await expect(page.locator('#catalogRegistryBanner .catalog-banner-warning')).toContainText(
+      /cached catalogs/i
+    );
+  });
+
+  test('a successful refresh populates the list and clears any banner', async ({ page }) => {
+    await page.goto('/plugins/signalk-charts-provider-simple/');
+    await setMockState(page, {
+      registry: [],
+      registryStatus: {
+        status: 'error',
+        isRateLimited: false,
+        remaining: null,
+        resetAt: null,
+        retryAfter: null,
+        lastAttemptAt: Date.now(),
+        lastSuccessAt: null,
+        httpStatus: null
+      },
+      refreshRegistry: [
+        {
+          file: 'NL_IENC.xml',
+          label: 'Netherlands Inland ENC',
+          category: 'ienc',
+          chartCount: 5,
+          cachedAt: '2026-05-07T10:00:00Z'
+        }
+      ],
+      refreshStatus: {
+        status: 'ok',
+        isRateLimited: false,
+        remaining: 49,
+        resetAt: null,
+        retryAfter: null,
+        lastAttemptAt: Date.now(),
+        lastSuccessAt: Date.now(),
+        httpStatus: 200
+      }
+    });
+    await page.getByRole('button', { name: /Chart Catalog/i }).click();
+    // Empty + error first.
+    await expect(page.locator('.catalog-error')).toBeVisible();
+
+    await page.locator('[data-catalog-refresh]').click();
+
+    await expect(page.locator('.catalog-card')).toHaveCount(1);
+    await expect(page.locator('#catalogRegistryBanner')).toBeEmpty();
+  });
 });

--- a/e2e/catalog.spec.ts
+++ b/e2e/catalog.spec.ts
@@ -282,11 +282,41 @@ test.describe('Chart Catalog tab', () => {
 
     await page.locator('[data-catalog-refresh]').click();
 
-    // Cards must NOT be blanked; a non-destructive banner explains why.
+    // Cards must NOT be blanked; a non-destructive banner explains why,
+    // and a GitHub rate-limit blames GitHub (not the Signal K server).
     await expect(page.locator('.catalog-card')).toHaveCount(1);
-    await expect(page.locator('#catalogRegistryBanner .catalog-banner-warning')).toContainText(
-      /cached catalogs/i
-    );
+    const banner = page.locator('#catalogRegistryBanner .catalog-banner-warning');
+    await expect(banner).toContainText(/cached catalogs/i);
+    await expect(banner).toContainText(/GitHub rate limit/i);
+  });
+
+  test('a refresh that cannot reach the Signal K server blames the server, not GitHub', async ({
+    page
+  }) => {
+    await page.goto('/plugins/signalk-charts-provider-simple/');
+    await setMockState(page, {
+      registry: [
+        {
+          file: 'DE_IENC.xml',
+          label: 'Germany Inland ENC',
+          category: 'ienc',
+          chartCount: 3,
+          cachedAt: '2026-05-07T10:00:00Z'
+        }
+      ]
+    });
+    await page.getByRole('button', { name: /Chart Catalog/i }).click();
+    await expect(page.locator('.catalog-card')).toHaveCount(1);
+
+    // Make the refresh request to OUR endpoint fail at the transport level.
+    await page.route('**/catalog-registry/refresh', (r) => r.abort());
+    await page.locator('[data-catalog-refresh]').click();
+
+    const banner = page.locator('#catalogRegistryBanner .catalog-banner-warning');
+    await expect(banner).toContainText(/Signal K server/i);
+    await expect(banner).not.toContainText(/GitHub/i);
+    // Cards still present (never blanked on a transport failure).
+    await expect(page.locator('.catalog-card')).toHaveCount(1);
   });
 
   test('a successful refresh populates the list and clears any banner', async ({ page }) => {

--- a/e2e/mock-server.ts
+++ b/e2e/mock-server.ts
@@ -28,6 +28,17 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // Mock state.  Each top-level key is what the corresponding REST
 // endpoint returns.  Tests overwrite via PUT /__mock/state, partial
 // updates merge; full reset via POST /__mock/reset.
+interface RegistryStatusMock {
+  status: 'ok' | 'rate_limited' | 'error' | 'never';
+  isRateLimited: boolean;
+  remaining: number | null;
+  resetAt: number | null;
+  retryAfter: number | null;
+  lastAttemptAt: number | null;
+  lastSuccessAt: number | null;
+  httpStatus: number | null;
+}
+
 interface MockState {
   registry: {
     file: string;
@@ -36,6 +47,12 @@ interface MockState {
     chartCount: number | null;
     cachedAt: string | null;
   }[];
+  // Status surfaced with the registry; tests set this to drive rate-limit UI.
+  registryStatus: RegistryStatusMock;
+  // When set, POST /catalog-registry/refresh swaps the registry to this (and
+  // optionally a new status) — lets a test script a refresh outcome.
+  refreshRegistry: MockState['registry'] | null;
+  refreshStatus: RegistryStatusMock | null;
   installed: Record<
     string,
     { catalogFile: string; zipfile_datetime_iso8601: string; installedAt: string }
@@ -95,8 +112,22 @@ interface MockState {
   containerRuntimeEngine: string | null;
 }
 
+const okStatus: RegistryStatusMock = {
+  status: 'ok',
+  isRateLimited: false,
+  remaining: 50,
+  resetAt: null,
+  retryAfter: null,
+  lastAttemptAt: null,
+  lastSuccessAt: null,
+  httpStatus: 200
+};
+
 const initialState: MockState = {
   registry: [],
+  registryStatus: okStatus,
+  refreshRegistry: null,
+  refreshStatus: null,
   installed: {},
   converting: {},
   conversions: {},
@@ -163,7 +194,24 @@ export function startMockServer(
     res.json({
       registry: state.registry,
       installed: state.installed,
-      converting: state.converting
+      converting: state.converting,
+      registryStatus: state.registryStatus
+    });
+  });
+
+  router.post(`${PLUGIN_BASE}/catalog-registry/refresh`, (_req, res) => {
+    // Apply the scripted refresh outcome, if a test set one.
+    if (state.refreshRegistry !== null) {
+      state.registry = state.refreshRegistry;
+    }
+    if (state.refreshStatus !== null) {
+      state.registryStatus = state.refreshStatus;
+    }
+    res.json({
+      registry: state.registry,
+      installed: state.installed,
+      converting: state.converting,
+      registryStatus: state.registryStatus
     });
   });
 

--- a/public/css/chart-catalog.css
+++ b/public/css/chart-catalog.css
@@ -447,6 +447,65 @@ option.catalog-folder-option-new {
     font-size: 14px;
 }
 
+/* Rate-limit is a warning (tertiary), not an error (red): the device is
+ * online, just throttled by GitHub. */
+.catalog-error.catalog-error-rate-limit {
+    background: var(--md-sys-color-tertiary-container);
+    color: var(--md-sys-color-on-tertiary-container);
+}
+
+/* Catalog toolbar (Refresh button row) */
+.catalog-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: var(--md-sys-spacing-2);
+}
+
+.btn-catalog-refresh {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--md-sys-spacing-2);
+    padding: 8px 16px;
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-full);
+    background: var(--md-sys-color-surface-container);
+    color: var(--md-sys-color-on-surface);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all var(--md-sys-motion-duration-short2) var(--md-sys-motion-easing-standard);
+}
+
+.btn-catalog-refresh:hover:not(:disabled) {
+    background: var(--md-sys-color-surface-container-high);
+    border-color: var(--md-sys-color-outline);
+}
+
+.btn-catalog-refresh:disabled {
+    opacity: 0.38;
+    cursor: not-allowed;
+}
+
+.btn-catalog-refresh.loading {
+    background: var(--md-sys-color-surface-container-highest);
+    color: var(--md-sys-color-on-surface-variant);
+}
+
+/* Non-destructive banner above a populated list (refresh failed / rate-limited
+ * while cached catalogs are still shown). */
+.catalog-banner {
+    padding: var(--md-sys-spacing-2) var(--md-sys-spacing-4);
+    border-radius: var(--md-sys-shape-corner-medium);
+    margin-bottom: var(--md-sys-spacing-4);
+    font-size: 13px;
+}
+
+.catalog-banner-warning {
+    background: var(--md-sys-color-tertiary-container);
+    color: var(--md-sys-color-on-tertiary-container);
+}
+
 /* Inline download / conversion progress.  Same flex/typography for both
  * pills; conversion has no progress bar (just spinner + message), download
  * has a thin bar.  Two separate classes so pollConversions can update the

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -34,10 +34,24 @@ interface CatalogInstall {
   catalogFile: string;
 }
 
+type RegistryFetchStatus = 'ok' | 'rate_limited' | 'error' | 'never';
+
+interface RegistryStatus {
+  status: RegistryFetchStatus;
+  isRateLimited: boolean;
+  remaining: number | null;
+  resetAt: number | null; // epoch ms
+  retryAfter: number | null; // seconds
+  lastAttemptAt: number | null;
+  lastSuccessAt: number | null;
+  httpStatus: number | null;
+}
+
 interface CatalogRegistryResponse {
   registry?: CatalogRegistryEntry[];
   installed?: Record<string, CatalogInstall>;
   converting?: Record<string, boolean>;
+  registryStatus?: RegistryStatus;
 }
 
 interface LocalChartsResponse {
@@ -195,6 +209,12 @@ async function initCatalogTab(): Promise<void> {
       </div>
       <div id="catalogPodmanWarning"></div>
       <div id="catalogUpdatesSection"></div>
+      <div id="catalogToolbar" class="catalog-toolbar">
+        <button type="button" class="btn-catalog-refresh" data-catalog-refresh title="Re-fetch the catalog index from GitHub">
+          <span class="btn-catalog-refresh-label">Refresh catalog index</span>
+        </button>
+      </div>
+      <div id="catalogRegistryBanner"></div>
       <div id="catalogFilterBar"></div>
       <div id="catalogList">
         <div class="catalog-loading">
@@ -330,6 +350,13 @@ function wireCatalogClickHandlers(): void {
         return;
       }
 
+      // Refresh button - force a re-fetch of the catalog index from GitHub.
+      const refreshBtn = target.closest<HTMLButtonElement>('[data-catalog-refresh]');
+      if (refreshBtn) {
+        void doCatalogRefresh(refreshBtn);
+        return;
+      }
+
       // "Update All" button - queue updates for sequential processing
       const updateAll = target.closest<HTMLElement>('[data-catalog-update-all]');
       if (updateAll) {
@@ -413,39 +440,173 @@ function wireCatalogClickHandlers(): void {
   }
 }
 
+// Bumped by every registry load/refresh; a stale async result whose seq no
+// longer matches is ignored, so a slow initial load can't clobber a newer
+// refresh (or vice versa).
+let registryLoadSeq = 0;
+let catalogRefreshInFlight = false;
+// Last status from the registry endpoint, so renderCatalogList() can show an
+// accurate empty-state message (rate-limited / offline) instead of a generic
+// "No catalogs" that would clobber it on the next poll-driven re-render.
+let lastRegistryStatus: RegistryStatus | undefined;
+
+// Human-friendly "try again …" from the rate-limit reset time. Uses LOCAL
+// time (never UTC) plus a relative hint; falls back to retry-after / "shortly".
+function formatRateLimitReset(status: RegistryStatus): string {
+  const { resetAt, retryAfter } = status;
+  if (!resetAt) {
+    if (retryAfter) {
+      const mins = Math.max(1, Math.ceil(retryAfter / 60));
+      return `in about ${mins} minute${mins === 1 ? '' : 's'}`;
+    }
+    return 'shortly';
+  }
+  const local = new Date(resetAt).toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+  const mins = Math.max(0, Math.ceil((resetAt - Date.now()) / 60000));
+  return mins > 0
+    ? `at ${local} (in about ${mins} minute${mins === 1 ? '' : 's'})`
+    : `at ${local}`;
+}
+
+// HTML for the empty-list placeholder, classed so CSS tints rate-limit
+// (warning) vs offline/error differently. Crucially never says "offline" for
+// a rate-limit.
+function registryEmptyMessageHtml(status: RegistryStatus | undefined): string {
+  if (status?.isRateLimited) {
+    return `<div class="catalog-error catalog-error-rate-limit"><strong>GitHub rate limit reached.</strong> The chart catalog index is fetched from GitHub, which limits anonymous requests. Please try again ${formatRateLimitReset(status)}, then click Refresh.</div>`;
+  }
+  if (status?.status === 'error') {
+    return `<div class="catalog-error">Could not fetch the chart catalog index from GitHub. Check this device's internet connection, then click Refresh. Previously cached catalogs reappear once it succeeds.</div>`;
+  }
+  return `<div class="catalog-error">No catalogs available yet. Click Refresh to fetch the catalog index from GitHub.</div>`;
+}
+
+// Non-destructive banner shown ABOVE a populated list when a refresh failed —
+// so we never blank the cached cards just to report the failure.
+function showRegistryBanner(status: RegistryStatus | undefined): void {
+  const el = document.getElementById('catalogRegistryBanner');
+  if (!el) {
+    return;
+  }
+  const msg = status?.isRateLimited
+    ? `Showing cached catalogs. GitHub rate limit reached — try refresh again ${formatRateLimitReset(status)}.`
+    : 'Showing cached catalogs. Could not reach GitHub to refresh the index.';
+  el.innerHTML = `<div class="catalog-banner catalog-banner-warning">${msg}</div>`;
+}
+
+function clearRegistryBanner(): void {
+  const el = document.getElementById('catalogRegistryBanner');
+  if (el) {
+    el.innerHTML = '';
+  }
+}
+
+// Apply a registry response: never replace a populated list with an empty one
+// (keep cached cards + show a banner instead); render the accurate empty/error
+// placeholder only when there's nothing cached to show.
+function applyRegistryResponse(data: CatalogRegistryResponse): void {
+  const incoming = data.registry ?? [];
+  const status = data.registryStatus;
+  lastRegistryStatus = status;
+
+  if (incoming.length === 0 && catalogRegistry.length > 0) {
+    showRegistryBanner(status);
+    return;
+  }
+
+  catalogRegistry = incoming;
+  catalogInstalled = data.installed ?? {};
+  catalogConverting = data.converting ?? {};
+  renderFilterBar();
+  // renderCatalogList handles both the populated and empty-registry cases
+  // (the latter via registryEmptyMessageHtml + lastRegistryStatus), so a
+  // later poll-driven re-render keeps showing the right message.
+  renderCatalogList();
+}
+
 /**
- * Returns true on a successful registry refresh, false on network/HTTP
- * failure. Callers that chain follow-up renders need to skip them on
- * failure so the .catalog-error message this function writes into
- * #catalogList isn't overwritten with stale cards.
+ * Returns true on a successful registry load, false on network/HTTP failure
+ * to OUR endpoint. Callers that chain follow-up renders skip them on failure.
+ * Never blanks an already-populated list.
  */
 async function loadCatalogRegistry(): Promise<boolean> {
+  const seq = ++registryLoadSeq;
   try {
     const response = await fetch(`${CATALOG_API_BASE}/catalog-registry`);
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }
     const data = (await response.json()) as CatalogRegistryResponse;
-    catalogRegistry = data.registry ?? [];
-    catalogInstalled = data.installed ?? {};
-    catalogConverting = data.converting ?? {};
-    renderFilterBar();
-    if (catalogRegistry.length === 0) {
-      const listEl = document.getElementById('catalogList');
-      if (listEl) {
-        listEl.innerHTML = `<div class="catalog-error">No catalogs available. The catalog index could not be fetched — you may be offline. Previously cached catalogs will appear after reconnecting.</div>`;
-      }
-    } else {
-      renderCatalogList();
+    if (seq !== registryLoadSeq) {
+      return true; // a newer load/refresh superseded this one
     }
+    applyRegistryResponse(data);
     return true;
   } catch (error) {
     console.error('Failed to load catalog registry:', error);
-    const listEl = document.getElementById('catalogList');
-    if (listEl) {
-      listEl.innerHTML = `<div class="catalog-error">Failed to load catalog registry. You may be offline.</div>`;
+    if (seq !== registryLoadSeq) {
+      return false;
+    }
+    // Failure reaching OUR server (not GitHub). Keep a populated list.
+    if (catalogRegistry.length === 0) {
+      const listEl = document.getElementById('catalogList');
+      if (listEl) {
+        listEl.innerHTML = `<div class="catalog-error">Failed to load the catalog list from the Signal K server. Reload the page or click Refresh.</div>`;
+      }
+    } else {
+      showRegistryBanner(undefined);
     }
     return false;
+  }
+}
+
+// Refresh-button handler: force a GitHub re-fetch on demand, with a disabled/
+// spinner state and the same never-blank + stale-guard rules as the load path.
+async function doCatalogRefresh(btn: HTMLButtonElement): Promise<void> {
+  if (catalogRefreshInFlight) {
+    return;
+  }
+  catalogRefreshInFlight = true;
+  const seq = ++registryLoadSeq;
+  const label = btn.querySelector<HTMLElement>('.btn-catalog-refresh-label');
+  const prevText = label?.textContent ?? 'Refresh catalog index';
+  btn.disabled = true;
+  btn.classList.add('loading');
+  if (label) {
+    label.textContent = 'Refreshing…';
+  }
+  try {
+    const response = await fetch(`${CATALOG_API_BASE}/catalog-registry/refresh`, {
+      method: 'POST'
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const data = (await response.json()) as CatalogRegistryResponse;
+    if (seq !== registryLoadSeq) {
+      return;
+    }
+    applyRegistryResponse(data);
+  } catch (error) {
+    console.error('Catalog refresh failed:', error);
+    if (catalogRegistry.length > 0) {
+      showRegistryBanner(undefined);
+    } else {
+      const listEl = document.getElementById('catalogList');
+      if (listEl) {
+        listEl.innerHTML = `<div class="catalog-error">Refresh failed — could not reach the Signal K server.</div>`;
+      }
+    }
+  } finally {
+    catalogRefreshInFlight = false;
+    btn.disabled = false;
+    btn.classList.remove('loading');
+    if (label) {
+      label.textContent = prevText;
+    }
   }
 }
 
@@ -818,6 +979,17 @@ function renderCatalogList(): void {
   if (!listEl) {
     return;
   }
+  // Whole registry empty → show the status-aware reason (rate-limited /
+  // offline / "click Refresh"), not a generic line that would clobber the
+  // message a poll-driven re-render would otherwise wipe.
+  if (catalogRegistry.length === 0) {
+    listEl.innerHTML = registryEmptyMessageHtml(lastRegistryStatus);
+    return;
+  }
+
+  // A successful populated render means the registry is fine — drop any
+  // stale "showing cached catalogs" banner from a prior failed refresh.
+  clearRegistryBanner();
 
   const filtered =
     activeCategoryFilter === 'all'

--- a/public/js/chart-catalog.ts
+++ b/public/js/chart-catalog.ts
@@ -225,7 +225,7 @@ async function initCatalogTab(): Promise<void> {
     </div>
   `;
 
-  await loadCatalogRegistry();
+  const registryOk = await loadCatalogRegistry();
   await loadFolders();
   await checkS57Status();
   await refreshUpdateBadge();
@@ -239,7 +239,11 @@ async function initCatalogTab(): Promise<void> {
   // catalogDownloadJobs was still empty, so without this call the
   // user briefly sees "Download & Convert" on actively-downloading
   // rows until the first pollCatalogDownloads tick (~2s later).
-  renderCatalogList();
+  // Skip on a failed load so we don't clobber the server-error message
+  // loadCatalogRegistry wrote into #catalogList.
+  if (registryOk) {
+    renderCatalogList();
+  }
 
   // Wire delegated click handlers — every action that previously used
   // inline `onclick="X('${catalogEscapeAttr(value)}')"` now reads a data-*
@@ -350,7 +354,6 @@ function wireCatalogClickHandlers(): void {
         return;
       }
 
-      // Refresh button - force a re-fetch of the catalog index from GitHub.
       const refreshBtn = target.closest<HTMLButtonElement>('[data-catalog-refresh]');
       if (refreshBtn) {
         void doCatalogRefresh(refreshBtn);
@@ -486,14 +489,22 @@ function registryEmptyMessageHtml(status: RegistryStatus | undefined): string {
 
 // Non-destructive banner shown ABOVE a populated list when a refresh failed —
 // so we never blank the cached cards just to report the failure.
-function showRegistryBanner(status: RegistryStatus | undefined): void {
+function showRegistryBanner(
+  status: RegistryStatus | undefined,
+  source: 'github' | 'server' = 'github'
+): void {
   const el = document.getElementById('catalogRegistryBanner');
   if (!el) {
     return;
   }
-  const msg = status?.isRateLimited
-    ? `Showing cached catalogs. GitHub rate limit reached — try refresh again ${formatRateLimitReset(status)}.`
-    : 'Showing cached catalogs. Could not reach GitHub to refresh the index.';
+  let msg: string;
+  if (status?.isRateLimited) {
+    msg = `Showing cached catalogs. GitHub rate limit reached — try refresh again ${formatRateLimitReset(status)}.`;
+  } else if (source === 'server') {
+    msg = 'Showing cached catalogs. Could not reach the Signal K server to refresh the index.';
+  } else {
+    msg = 'Showing cached catalogs. Could not reach GitHub to refresh the index.';
+  }
   el.innerHTML = `<div class="catalog-banner catalog-banner-warning">${msg}</div>`;
 }
 
@@ -557,7 +568,7 @@ async function loadCatalogRegistry(): Promise<boolean> {
         listEl.innerHTML = `<div class="catalog-error">Failed to load the catalog list from the Signal K server. Reload the page or click Refresh.</div>`;
       }
     } else {
-      showRegistryBanner(undefined);
+      showRegistryBanner(undefined, 'server');
     }
     return false;
   }
@@ -592,8 +603,13 @@ async function doCatalogRefresh(btn: HTMLButtonElement): Promise<void> {
     applyRegistryResponse(data);
   } catch (error) {
     console.error('Catalog refresh failed:', error);
+    // A newer load/refresh already won — don't overwrite the fresh UI with
+    // this stale failure.
+    if (seq !== registryLoadSeq) {
+      return;
+    }
     if (catalogRegistry.length > 0) {
-      showRegistryBanner(undefined);
+      showRegistryBanner(undefined, 'server');
     } else {
       const listEl = document.getElementById('catalogList');
       if (listEl) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,12 +11,14 @@ import {
   checkForUpdates,
   classifyUrl,
   fetchCatalog,
+  fetchCatalogRegistry,
   getCachedCatalog,
   getCatalogRegistry,
   getCatalogsWithInstalledCharts,
   getConvertingCharts,
   getConvertingCount,
   getInstalledCatalogCharts,
+  getRegistryStatus,
   initCatalogManager,
   pruneStaleInstalls,
   removeInstall,
@@ -1791,11 +1793,41 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         const registry = getCatalogRegistry();
         const installed = getInstalledCatalogCharts();
         const convertingCharts = getConvertingCharts();
-        res.json({ registry, installed, converting: convertingCharts });
+        res.json({
+          registry,
+          installed,
+          converting: convertingCharts,
+          registryStatus: getRegistryStatus()
+        });
       } catch (error) {
         console.error('Error fetching catalog registry:', error);
         res.status(500).json({ error: 'Failed to fetch catalog registry' });
       }
+    });
+
+    // Force a re-fetch of the catalog index from GitHub (the Refresh button).
+    // Awaits the fetch so the response reflects the just-attempted result, but
+    // swallows the rejection — registryStatus carries the reason (rate-limited
+    // / offline / error) so the UI can message accurately.
+    router.post('/catalog-registry/refresh', (_req: Request, res: Response) => {
+      void (async () => {
+        try {
+          await fetchCatalogRegistry().catch((err: unknown) => {
+            app.debug(
+              `Catalog registry refresh failed: ${err instanceof Error ? err.message : String(err)}`
+            );
+          });
+          res.json({
+            registry: getCatalogRegistry(),
+            installed: getInstalledCatalogCharts(),
+            converting: getConvertingCharts(),
+            registryStatus: getRegistryStatus()
+          });
+        } catch (error) {
+          console.error('Error refreshing catalog registry:', error);
+          res.status(500).json({ error: 'Failed to refresh catalog registry' });
+        }
+      })();
     });
 
     router.get('/catalog-s57-status', (_req: Request, res: Response) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1824,8 +1824,10 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             registryStatus: getRegistryStatus()
           });
         } catch (error) {
-          console.error('Error refreshing catalog registry:', error);
-          res.status(500).json({ error: 'Failed to refresh catalog registry' });
+          // The refresh itself is awaited+swallowed above; this only fires if
+          // building the response throws.
+          console.error('Error building catalog refresh response:', error);
+          res.status(500).json({ error: 'Failed to build catalog refresh response' });
         }
       })();
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,6 +197,23 @@ export interface CatalogRegistryInfo extends CatalogRegistryEntry {
   cachedAt: string | null;
 }
 
+// Result of the last attempt to fetch the catalog index from GitHub. Drives
+// UI messaging when the registry is empty or a refresh fails — notably so a
+// GitHub rate-limit (HTTP 403, remaining 0) reads as "rate limited, retry at
+// X" instead of the wrong "you may be offline".
+export type RegistryFetchStatus = 'ok' | 'rate_limited' | 'error' | 'never';
+
+export interface RegistryStatus {
+  status: RegistryFetchStatus;
+  isRateLimited: boolean;
+  remaining: number | null; // x-ratelimit-remaining
+  resetAt: number | null; // x-ratelimit-reset, epoch ms
+  retryAfter: number | null; // retry-after header, seconds
+  lastAttemptAt: number | null;
+  lastSuccessAt: number | null;
+  httpStatus: number | null; // null for network/timeout errors
+}
+
 export type UrlFormat =
   | 'mbtiles'
   | 'zip'

--- a/src/utils/catalog-manager.ts
+++ b/src/utils/catalog-manager.ts
@@ -12,6 +12,7 @@ import type {
   CatalogRegistryInfo,
   CatalogUpdate,
   DebugFunction,
+  RegistryStatus,
   UrlClassification
 } from '../types.js';
 import {
@@ -48,6 +49,33 @@ const COUNTRY_CODES: Record<string, string> = {
 };
 
 let catalogRegistry: CatalogRegistryEntry[] = [];
+
+// Result of the last GitHub registry-fetch attempt — surfaced to the UI so an
+// empty/failed fetch can show an accurate reason (rate-limited vs offline vs
+// generic error) instead of a misleading "you may be offline".
+const registryStatus: RegistryStatus = {
+  status: 'never',
+  isRateLimited: false,
+  remaining: null,
+  resetAt: null,
+  retryAfter: null,
+  lastAttemptAt: null,
+  lastSuccessAt: null,
+  httpStatus: null
+};
+
+// Single-flight guard: the up-front fetch at init plus a Refresh-button click
+// (or two clicks) must not issue concurrent GitHub requests. A call while one
+// is in flight returns the in-progress promise.
+let inFlightRegistryFetch: Promise<CatalogRegistryEntry[]> | null = null;
+
+function parseHeaderInt(v: string | string[] | undefined): number | null {
+  if (v === undefined) {
+    return null;
+  }
+  const n = parseInt(Array.isArray(v) ? (v[0] ?? '') : v, 10);
+  return Number.isFinite(n) ? n : null;
+}
 
 const CACHE_MAX_AGE_MS = 60 * 60 * 1000;
 
@@ -306,13 +334,45 @@ export function initCatalogManager(dataDirPath: string, debugFn: DebugFunction):
 }
 
 export function fetchCatalogRegistry(): Promise<CatalogRegistryEntry[]> {
+  if (inFlightRegistryFetch) {
+    return inFlightRegistryFetch;
+  }
+  inFlightRegistryFetch = doFetchCatalogRegistry().finally(() => {
+    inFlightRegistryFetch = null;
+  });
+  return inFlightRegistryFetch;
+}
+
+function doFetchCatalogRegistry(): Promise<CatalogRegistryEntry[]> {
   return new Promise((resolve, reject) => {
+    registryStatus.lastAttemptAt = Date.now();
     const req = https
       .get(
         CATALOG_GITHUB_API,
         { headers: { 'User-Agent': 'signalk-charts-provider-simple' } },
         (response) => {
+          // Read rate-limit headers on EVERY response (success and failure),
+          // so `remaining` is current even on a 200.
+          const remaining = parseHeaderInt(response.headers['x-ratelimit-remaining']);
+          const resetSec = parseHeaderInt(response.headers['x-ratelimit-reset']);
+          const retryAfter = parseHeaderInt(response.headers['retry-after']);
+          if (remaining !== null) {
+            registryStatus.remaining = remaining;
+          }
+          if (resetSec !== null) {
+            registryStatus.resetAt = resetSec * 1000;
+          }
+          registryStatus.retryAfter = retryAfter;
+          registryStatus.httpStatus = response.statusCode ?? null;
+
           if (response.statusCode !== 200) {
+            // Only flag rate-limited when GitHub actually says so (403/429 with
+            // remaining 0); any other non-200 is a generic error.
+            const rateLimited =
+              (response.statusCode === 403 || response.statusCode === 429) &&
+              registryStatus.remaining === 0;
+            registryStatus.isRateLimited = rateLimited;
+            registryStatus.status = rateLimited ? 'rate_limited' : 'error';
             response.resume();
             reject(new Error(`GitHub API returned ${response.statusCode}`));
             return;
@@ -328,6 +388,7 @@ export function fetchCatalogRegistry(): Promise<CatalogRegistryEntry[]> {
               const raw: unknown = JSON.parse(data);
               const files = safeParse(GithubContentsListingSchema, raw);
               if (!files) {
+                registryStatus.status = 'error';
                 reject(new Error('GitHub API response did not match expected shape'));
                 return;
               }
@@ -344,18 +405,33 @@ export function fetchCatalogRegistry(): Promise<CatalogRegistryEntry[]> {
                 saveRegistryCache();
                 debug(`Catalog registry: ${xmlFiles.length} catalogs from GitHub`);
               }
+              registryStatus.isRateLimited = false;
+              registryStatus.status = 'ok';
+              registryStatus.lastSuccessAt = Date.now();
               resolve(xmlFiles);
             } catch (err) {
+              registryStatus.status = 'error';
               reject(err);
             }
           });
         }
       )
-      .on('error', reject);
+      .on('error', (err) => {
+        // Network/DNS failure or timeout — genuinely offline-ish, NOT a rate
+        // limit. httpStatus stays null so the UI shows the connectivity copy.
+        registryStatus.status = 'error';
+        registryStatus.isRateLimited = false;
+        registryStatus.httpStatus = null;
+        reject(err);
+      });
     req.setTimeout(15000, () => {
       req.destroy(new Error('GitHub API request timed out after 15s'));
     });
   });
+}
+
+export function getRegistryStatus(): RegistryStatus {
+  return { ...registryStatus };
 }
 
 export function getCatalogRegistry(): CatalogRegistryInfo[] {

--- a/src/utils/catalog-manager.ts
+++ b/src/utils/catalog-manager.ts
@@ -409,8 +409,14 @@ function doFetchCatalogRegistry(): Promise<CatalogRegistryEntry[]> {
                 saveRegistryCache();
                 debug(`Catalog registry: ${xmlFiles.length} catalogs from GitHub`);
               }
+              // A successful fetch means we are not rate-limited; clear the
+              // rate-limit metadata so a stale reset/retry time can't leak into
+              // the UI later (resetAt/retryAfter are only meaningful while
+              // isRateLimited).
               registryStatus.isRateLimited = false;
               registryStatus.status = 'ok';
+              registryStatus.resetAt = null;
+              registryStatus.retryAfter = null;
               registryStatus.lastSuccessAt = Date.now();
               resolve(xmlFiles);
             } catch (err) {

--- a/src/utils/catalog-manager.ts
+++ b/src/utils/catalog-manager.ts
@@ -366,11 +366,12 @@ function doFetchCatalogRegistry(): Promise<CatalogRegistryEntry[]> {
           registryStatus.httpStatus = response.statusCode ?? null;
 
           if (response.statusCode !== 200) {
-            // Only flag rate-limited when GitHub actually says so (403/429 with
-            // remaining 0); any other non-200 is a generic error.
+            // Classify off THIS response's header (the local `remaining`), not
+            // the persisted field — a 403/429 without an x-ratelimit-remaining
+            // header must not inherit a previous response's 0 and get
+            // mislabeled rate-limited.
             const rateLimited =
-              (response.statusCode === 403 || response.statusCode === 429) &&
-              registryStatus.remaining === 0;
+              (response.statusCode === 403 || response.statusCode === 429) && remaining === 0;
             registryStatus.isRateLimited = rateLimited;
             registryStatus.status = rateLimited ? 'rate_limited' : 'error';
             response.resume();
@@ -388,6 +389,9 @@ function doFetchCatalogRegistry(): Promise<CatalogRegistryEntry[]> {
               const raw: unknown = JSON.parse(data);
               const files = safeParse(GithubContentsListingSchema, raw);
               if (!files) {
+                // Reached GitHub (200) but the body was malformed — a generic
+                // error, definitively not a rate limit.
+                registryStatus.isRateLimited = false;
                 registryStatus.status = 'error';
                 reject(new Error('GitHub API response did not match expected shape'));
                 return;
@@ -410,6 +414,7 @@ function doFetchCatalogRegistry(): Promise<CatalogRegistryEntry[]> {
               registryStatus.lastSuccessAt = Date.now();
               resolve(xmlFiles);
             } catch (err) {
+              registryStatus.isRateLimited = false;
               registryStatus.status = 'error';
               reject(err);
             }

--- a/test/catalog-manager.test.ts
+++ b/test/catalog-manager.test.ts
@@ -2,9 +2,13 @@
  * Tests for the catalog manager module
  */
 
-import { describe, it, before, after } from 'node:test';
+import { describe, it, before, after, mock } from 'node:test';
 import assert from 'node:assert';
 import fs from 'node:fs';
+// NOTE: the module under test imports from 'https' (not 'node:https'); ESM
+// treats those as separate module instances, so we must mock the SAME
+// specifier for the stub to intercept the dist module's https.get.
+import https from 'https';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -20,7 +24,9 @@ import {
   checkForUpdates,
   getCatalogsWithInstalledCharts,
   getCachedCatalog,
-  pruneStaleInstalls
+  pruneStaleInstalls,
+  fetchCatalogRegistry,
+  getRegistryStatus
 } from '../dist/utils/catalog-manager.js';
 import type { CatalogInstall } from '../dist/types.js';
 
@@ -588,6 +594,159 @@ describe('CatalogManager', () => {
       assert.ok(result);
       assert.strictEqual(result.charts.length, 1);
       assert.strictEqual(result.charts[0]!.number, 'old1');
+    });
+  });
+
+  describe('fetchCatalogRegistry() rate-limit status', () => {
+    // Build a fake https.IncomingMessage and a fake ClientRequest, and stub
+    // https.get so fetchCatalogRegistry sees our scripted response.
+    interface FakeRes {
+      statusCode: number;
+      headers: Record<string, string>;
+      body?: string;
+    }
+    function stubHttps(res: FakeRes | { networkError: true }): void {
+      mock.method(https, 'get', (...args: unknown[]) => {
+        const cb = args[args.length - 1] as (r: unknown) => void;
+        const req = {
+          on(event: string, handler: (err: Error) => void) {
+            if ('networkError' in res && event === 'error') {
+              process.nextTick(() => handler(new Error('ENOTFOUND')));
+            }
+            return req;
+          },
+          setTimeout() {
+            return req;
+          },
+          destroy() {
+            /* no-op */
+          }
+        };
+        if (!('networkError' in res)) {
+          process.nextTick(() => {
+            const response = {
+              statusCode: res.statusCode,
+              headers: res.headers,
+              resume() {
+                /* drained */
+              },
+              on(event: string, handler: (chunk?: Buffer) => void) {
+                if (res.statusCode === 200) {
+                  if (event === 'data') {
+                    handler(Buffer.from(res.body ?? '[]'));
+                  }
+                  if (event === 'end') {
+                    handler();
+                  }
+                }
+                return response;
+              }
+            };
+            cb(response);
+          });
+        }
+        return req;
+      });
+    }
+
+    before(async () => {
+      // initCatalogManager (outer before) fired a real, fire-and-forget
+      // fetch; single-flight would hand that in-progress promise to our
+      // first stubbed test. Drain it so each test below starts clean.
+      await fetchCatalogRegistry().catch(() => undefined);
+    });
+
+    after(() => {
+      mock.restoreAll();
+    });
+
+    it('flags rate_limited and captures resetAt on a 403 with remaining 0', async () => {
+      stubHttps({
+        statusCode: 403,
+        headers: {
+          'x-ratelimit-remaining': '0',
+          'x-ratelimit-reset': '1749532800',
+          'retry-after': '3600'
+        }
+      });
+      await assert.rejects(fetchCatalogRegistry(), /GitHub API returned 403/);
+      const s = getRegistryStatus();
+      assert.strictEqual(s.status, 'rate_limited');
+      assert.strictEqual(s.isRateLimited, true);
+      assert.strictEqual(s.remaining, 0);
+      assert.strictEqual(s.resetAt, 1749532800 * 1000);
+      assert.strictEqual(s.retryAfter, 3600);
+      assert.strictEqual(s.httpStatus, 403);
+      mock.restoreAll();
+    });
+
+    it('a 403 WITHOUT remaining 0 is a generic error, not rate-limited', async () => {
+      stubHttps({ statusCode: 403, headers: { 'x-ratelimit-remaining': '12' } });
+      await assert.rejects(fetchCatalogRegistry());
+      const s = getRegistryStatus();
+      assert.strictEqual(s.isRateLimited, false);
+      assert.strictEqual(s.status, 'error');
+      mock.restoreAll();
+    });
+
+    it('a 200 clears the rate-limit flag and records remaining', async () => {
+      stubHttps({ statusCode: 200, headers: { 'x-ratelimit-remaining': '57' }, body: '[]' });
+      await fetchCatalogRegistry();
+      const s = getRegistryStatus();
+      assert.strictEqual(s.status, 'ok');
+      assert.strictEqual(s.isRateLimited, false);
+      assert.strictEqual(s.remaining, 57);
+      mock.restoreAll();
+    });
+
+    it('a network error is status error with null httpStatus (not rate-limited)', async () => {
+      stubHttps({ networkError: true });
+      await assert.rejects(fetchCatalogRegistry());
+      const s = getRegistryStatus();
+      assert.strictEqual(s.status, 'error');
+      assert.strictEqual(s.isRateLimited, false);
+      assert.strictEqual(s.httpStatus, null);
+      mock.restoreAll();
+    });
+
+    it('single-flight: two concurrent calls issue one https.get', async () => {
+      const getMock = mock.method(https, 'get', (...args: unknown[]) => {
+        const cb = args[args.length - 1] as (r: unknown) => void;
+        const req = {
+          on() {
+            return req;
+          },
+          setTimeout() {
+            return req;
+          },
+          destroy() {
+            /* no-op */
+          }
+        };
+        setTimeout(() => {
+          const response = {
+            statusCode: 200,
+            headers: {},
+            resume() {
+              /* drained */
+            },
+            on(event: string, handler: (chunk?: Buffer) => void) {
+              if (event === 'data') {
+                handler(Buffer.from('[]'));
+              }
+              if (event === 'end') {
+                handler();
+              }
+              return response;
+            }
+          };
+          cb(response);
+        }, 20);
+        return req;
+      });
+      await Promise.all([fetchCatalogRegistry(), fetchCatalogRegistry()]);
+      assert.strictEqual(getMock.mock.callCount(), 1);
+      mock.restoreAll();
     });
   });
 });

--- a/test/catalog-manager.test.ts
+++ b/test/catalog-manager.test.ts
@@ -39,13 +39,59 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // gets cleaned in the test's after hook so no commit-time leakage.
 const TEST_DATA_DIR = path.join(__dirname, 'fixtures', 'catalog-test-data');
 
+// Minimal https.get stub that resolves an empty 200 registry, so any fetch it
+// covers never touches the network. Shared by the outer init and the
+// rate-limit suite's drain so neither makes a live GitHub call.
+function stubHttpsEmpty200(): void {
+  mock.method(https, 'get', (...args: unknown[]) => {
+    const cb = args[args.length - 1] as (r: unknown) => void;
+    const req = {
+      on() {
+        return req;
+      },
+      setTimeout() {
+        return req;
+      },
+      destroy() {
+        /* no-op */
+      }
+    };
+    process.nextTick(() => {
+      const response = {
+        statusCode: 200,
+        headers: { 'x-ratelimit-remaining': '60' },
+        resume() {
+          /* drained */
+        },
+        on(event: string, handler: (chunk?: Buffer) => void) {
+          if (event === 'data') {
+            handler(Buffer.from('[]'));
+          }
+          if (event === 'end') {
+            handler();
+          }
+          return response;
+        }
+      };
+      cb(response);
+    });
+    return req;
+  });
+}
+
 describe('CatalogManager', () => {
-  before(() => {
+  before(async () => {
     // Clean up any previous test data
     if (fs.existsSync(TEST_DATA_DIR)) {
       fs.rmSync(TEST_DATA_DIR, { recursive: true });
     }
+    // initCatalogManager fires a fire-and-forget fetchCatalogRegistry(); stub
+    // https.get BEFORE the call so that init fetch never reaches GitHub, then
+    // drain the single pending request and restore so no live call leaks.
+    stubHttpsEmpty200();
     initCatalogManager(TEST_DATA_DIR, () => {});
+    await fetchCatalogRegistry().catch(() => undefined);
+    mock.restoreAll();
   });
 
   after(() => {
@@ -650,11 +696,10 @@ describe('CatalogManager', () => {
     }
 
     before(async () => {
-      // initCatalogManager (outer before) fired a real, fire-and-forget
-      // fetch; single-flight would hand that in-progress promise to our
-      // first stubbed test. Drain it — under a stub so this never makes a
-      // live GitHub call (offline/flaky-safe).
-      stubHttps({ statusCode: 200, headers: { 'x-ratelimit-remaining': '60' }, body: '[]' });
+      // The outer before already drained the init fetch under a stub; this is
+      // belt-and-suspenders in case any prior fetch is still in flight. Stubbed
+      // so it can never make a live GitHub call.
+      stubHttpsEmpty200();
       await fetchCatalogRegistry().catch(() => undefined);
       mock.restoreAll();
     });

--- a/test/catalog-manager.test.ts
+++ b/test/catalog-manager.test.ts
@@ -2,7 +2,7 @@
  * Tests for the catalog manager module
  */
 
-import { describe, it, before, after, mock } from 'node:test';
+import { describe, it, before, after, afterEach, mock } from 'node:test';
 import assert from 'node:assert';
 import fs from 'node:fs';
 // NOTE: the module under test imports from 'https' (not 'node:https'); ESM
@@ -652,11 +652,14 @@ describe('CatalogManager', () => {
     before(async () => {
       // initCatalogManager (outer before) fired a real, fire-and-forget
       // fetch; single-flight would hand that in-progress promise to our
-      // first stubbed test. Drain it so each test below starts clean.
+      // first stubbed test. Drain it — under a stub so this never makes a
+      // live GitHub call (offline/flaky-safe).
+      stubHttps({ statusCode: 200, headers: { 'x-ratelimit-remaining': '60' }, body: '[]' });
       await fetchCatalogRegistry().catch(() => undefined);
+      mock.restoreAll();
     });
 
-    after(() => {
+    afterEach(() => {
       mock.restoreAll();
     });
 
@@ -677,7 +680,6 @@ describe('CatalogManager', () => {
       assert.strictEqual(s.resetAt, 1749532800 * 1000);
       assert.strictEqual(s.retryAfter, 3600);
       assert.strictEqual(s.httpStatus, 403);
-      mock.restoreAll();
     });
 
     it('a 403 WITHOUT remaining 0 is a generic error, not rate-limited', async () => {
@@ -686,7 +688,6 @@ describe('CatalogManager', () => {
       const s = getRegistryStatus();
       assert.strictEqual(s.isRateLimited, false);
       assert.strictEqual(s.status, 'error');
-      mock.restoreAll();
     });
 
     it('a 200 clears the rate-limit flag and records remaining', async () => {
@@ -696,7 +697,6 @@ describe('CatalogManager', () => {
       assert.strictEqual(s.status, 'ok');
       assert.strictEqual(s.isRateLimited, false);
       assert.strictEqual(s.remaining, 57);
-      mock.restoreAll();
     });
 
     it('a network error is status error with null httpStatus (not rate-limited)', async () => {
@@ -706,7 +706,6 @@ describe('CatalogManager', () => {
       assert.strictEqual(s.status, 'error');
       assert.strictEqual(s.isRateLimited, false);
       assert.strictEqual(s.httpStatus, null);
-      mock.restoreAll();
     });
 
     it('single-flight: two concurrent calls issue one https.get', async () => {
@@ -746,7 +745,6 @@ describe('CatalogManager', () => {
       });
       await Promise.all([fetchCatalogRegistry(), fetchCatalogRegistry()]);
       assert.strictEqual(getMock.mock.callCount(), 1);
-      mock.restoreAll();
     });
   });
 });

--- a/test/catalog-manager.test.ts
+++ b/test/catalog-manager.test.ts
@@ -742,13 +742,31 @@ describe('CatalogManager', () => {
       assert.strictEqual(s.status, 'error');
     });
 
-    it('a 200 clears the rate-limit flag and records remaining', async () => {
+    it('a 200 clears the rate-limit flag, metadata, and records remaining', async () => {
+      // First a 403 that sets isRateLimited + resetAt + retryAfter...
+      stubHttps({
+        statusCode: 403,
+        headers: {
+          'x-ratelimit-remaining': '0',
+          'x-ratelimit-reset': '1749532800',
+          'retry-after': '3600'
+        }
+      });
+      await assert.rejects(fetchCatalogRegistry());
+      assert.strictEqual(getRegistryStatus().isRateLimited, true);
+      assert.strictEqual(getRegistryStatus().resetAt, 1749532800 * 1000);
+      mock.restoreAll();
+
+      // ...then a 200 must clear all of it, not just the flag, so a stale
+      // rate-limit banner can't slip through while status === 'ok'.
       stubHttps({ statusCode: 200, headers: { 'x-ratelimit-remaining': '57' }, body: '[]' });
       await fetchCatalogRegistry();
       const s = getRegistryStatus();
       assert.strictEqual(s.status, 'ok');
       assert.strictEqual(s.isRateLimited, false);
       assert.strictEqual(s.remaining, 57);
+      assert.strictEqual(s.resetAt, null, 'a success must clear the stale reset time');
+      assert.strictEqual(s.retryAfter, null, 'a success must clear the stale retry-after');
     });
 
     it('a network error is status error with null httpStatus (not rate-limited)', async () => {

--- a/test/catalog-manager.test.ts
+++ b/test/catalog-manager.test.ts
@@ -79,19 +79,26 @@ function stubHttpsEmpty200(): void {
   });
 }
 
+// Every initCatalogManager() fire-and-forgets fetchCatalogRegistry(), so any
+// call (suite setup AND each restart simulation) must run under a stub or it
+// makes a live GitHub call and leaks an in-flight request into later
+// assertions. This wraps init: stub https.get, init (its synchronous
+// loadInstalls/recovery runs here, before the await), drain the pending
+// fetch, restore.
+async function initCatalogManagerOffline(): Promise<void> {
+  stubHttpsEmpty200();
+  initCatalogManager(TEST_DATA_DIR, () => {});
+  await fetchCatalogRegistry().catch(() => undefined);
+  mock.restoreAll();
+}
+
 describe('CatalogManager', () => {
   before(async () => {
     // Clean up any previous test data
     if (fs.existsSync(TEST_DATA_DIR)) {
       fs.rmSync(TEST_DATA_DIR, { recursive: true });
     }
-    // initCatalogManager fires a fire-and-forget fetchCatalogRegistry(); stub
-    // https.get BEFORE the call so that init fetch never reaches GitHub, then
-    // drain the single pending request and restore so no live call leaks.
-    stubHttpsEmpty200();
-    initCatalogManager(TEST_DATA_DIR, () => {});
-    await fetchCatalogRegistry().catch(() => undefined);
-    mock.restoreAll();
+    await initCatalogManagerOffline();
   });
 
   after(() => {
@@ -545,7 +552,7 @@ describe('CatalogManager', () => {
       removeInstall('p');
     });
 
-    it('survives a restart mid-update: load auto-rolls-back to prior (no reap needed)', () => {
+    it('survives a restart mid-update: load auto-rolls-back to prior (no reap needed)', async () => {
       seedCache('rst', '2024-06-10T00:00:00Z');
       trackInstall('rst', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/old.mbtiles');
       setInstallFilename('rst', 'rst.mbtiles'); // committed old
@@ -554,7 +561,7 @@ describe('CatalogManager', () => {
       // Simulate a Signal K restart: drop module memory, reload from disk.
       // Recovery is automatic in loadInstalls() — NO manual rollbackInstall,
       // because orphan-reap does not fire for a download-phase restart.
-      initCatalogManager(TEST_DATA_DIR, () => {});
+      await initCatalogManagerOffline();
 
       const rec = getInstalledCatalogCharts()['rst'];
       assert.ok(rec, 'prior version must survive the restart');
@@ -570,7 +577,7 @@ describe('CatalogManager', () => {
       removeInstall('rst');
     });
 
-    it('survives a restart mid-update even when pruneStaleInstalls runs', () => {
+    it('survives a restart mid-update even when pruneStaleInstalls runs', async () => {
       // Reproduces the live finding: prune runs at startup before any reap and
       // must NOT delete an in-flight record (the new file isn't on disk yet, so
       // its chartId is absent from the scanned set). With load-time recovery the
@@ -581,7 +588,7 @@ describe('CatalogManager', () => {
       setInstallFilename('prn', 'old-prn.mbtiles'); // committed old → chartId 'old-prn'
       trackInstall('prn', CATALOG, '2024-06-10T00:00:00Z', 'https://example.com/new.mbtiles'); // begin update
 
-      initCatalogManager(TEST_DATA_DIR, () => {}); // restart → load auto-rolls-back to old-prn
+      await initCatalogManagerOffline(); // restart → load auto-rolls-back to old-prn
       // Startup then scans charts and prunes. The old file IS on disk, so its
       // chartId is present; pass it so prune keeps the recovered record.
       pruneStaleInstalls(['old-prn']);
@@ -593,9 +600,9 @@ describe('CatalogManager', () => {
       removeInstall('prn');
     });
 
-    it('survives a restart mid-fresh-install: pending record dropped on load', () => {
+    it('survives a restart mid-fresh-install: pending record dropped on load', async () => {
       trackInstall('frsh', CATALOG, '2024-01-01T00:00:00Z', 'https://example.com/a.mbtiles');
-      initCatalogManager(TEST_DATA_DIR, () => {}); // restart → load drops the never-committed fresh record
+      await initCatalogManagerOffline(); // restart → load drops the never-committed fresh record
       assert.strictEqual(getInstalledCatalogCharts()['frsh'], undefined);
     });
 


### PR DESCRIPTION
## Problem

The chart catalog index is fetched from GitHub **only at plugin start**, and GitHub rate-limits anonymous requests (60/hr/IP). On a boat running 2.2.0-beta.1 the catalog went **empty**: a rate-limited start (HTTP 403) left the registry blank, the only message said **"you may be offline"** (wrong — the device was online, just throttled), and the sole recovery was restarting the plugin (clicking Save in config). There was no way to re-fetch on demand and no accurate explanation.

## Fix

Add an on-demand **Refresh button** and **accurate rate-limit messaging**.

**Backend**
- `fetchCatalogRegistry` now reads GitHub's `x-ratelimit-remaining` / `x-ratelimit-reset` / `retry-after` headers on every response and records a `registryStatus` (`ok` / `rate_limited` / `error` / `never`), distinguishing a real 403-rate-limit (remaining 0) from other errors and from genuine network/offline failures.
- Single-flight guard so the init fetch and a Refresh click can't issue concurrent GitHub requests.
- `getRegistryStatus()` is surfaced on `GET /catalog-registry`; new `POST /catalog-registry/refresh` forces a re-fetch without a plugin restart.

**Frontend**
- A **Refresh catalog index** button in the catalog toolbar (disabled + "Refreshing…" while in flight).
- An empty registry now shows the real reason: **rate-limited** (with the *local* reset time, styled as a warning, never "offline"), genuine **offline/error** ("check internet connection"), or a neutral "click Refresh" — the misleading "offline" copy is gone.
- A failed/rate-limited refresh over a **populated** list keeps the cached cards and shows a non-destructive banner instead of blanking them. `renderCatalogList()` renders the status-aware empty message so poll-driven re-renders don't clobber it.

## Tested

- **Unit** (`catalog-manager`): rate-limit header capture + `resetAt`; 403-without-remaining-0 treated as generic error; a 200 clears the flag and records `remaining`; network error → `error` with null `httpStatus`; single-flight issues one request for two concurrent calls.
- **e2e** (`catalog.spec`): Refresh button present; rate-limited empty registry shows the warning copy + reset time and not "offline"; a failed refresh keeps the cached cards + shows a banner; a successful refresh populates the list and clears the banner.
- Verified live on a host Signal K server: `GET /catalog-registry` carries `registryStatus` with the real captured headers, `POST /catalog-registry/refresh` re-fetches, and the Refresh button renders/works in the catalog tab.
- Full chain: `format`, `build`, `build:e2e`, `lint`, `test` (305 pass), `playwright test catalog` (9 pass).

Surfaced by the empty-catalog incident on the 2.2.0-beta.1 boat (relates to #117).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds a catalog Refresh control and records precise GitHub rate-limit state so the catalog index can be re-fetched on demand and empty-state messaging is accurate.

Backend
- Types: adds RegistryFetchStatus ('ok' | 'rate_limited' | 'error' | 'never') and RegistryStatus capturing isRateLimited, remaining, resetAt, retryAfter, lastAttemptAt, lastSuccessAt, and httpStatus.
- Fetch logic: refactors fetchCatalogRegistry() to parse GitHub headers (x-ratelimit-remaining, x-ratelimit-reset, retry-after), update registryStatus, and classify outcomes as ok, rate_limited (403/429 with remaining === 0), or error. Schema/parse failures set status='error'. Network/timeouts set httpStatus=null and isRateLimited=false. Successful 200 responses clear rate-limit metadata (resetAt/retryAfter) so stale data does not leak into the UI.
- Concurrency: implements a single-flight guard so concurrent init + refresh callers share one in-flight promise instead of issuing parallel GitHub requests.
- Status API: exposes getRegistryStatus(), includes registryStatus on GET /catalog-registry, and adds POST /catalog-registry/refresh to trigger an async re-fetch (logs but does not propagate fetch errors; returns the latest registryStatus).

Frontend
- UI: adds a "Refresh catalog index" button in the catalog toolbar (disabled and showing "Refreshing…" while in flight) and a banner area for non-destructive messages.
- Empty/error states: renders status-accurate placeholders when the registry is empty — a rate-limit warning with a local reset-time message, a genuine offline/error prompt to check connectivity, or a neutral prompt to click Refresh; removes the misleading "you may be offline" copy.
- Non-destructive refresh: preserves populated catalog cards on failed or rate-limited refreshes and shows a non-destructive banner attributing the failure source (GitHub vs Signal K server). applyRegistryResponse() and renderCatalogList() become status-aware to avoid poll-driven clobbering.
- Ordering/locking: introduces registryLoadSeq and catalogRefreshInFlight guards so stale async responses cannot overwrite newer UI state; doCatalogRefresh() respects these guards and disables the refresh control while in flight.
- Banner attribution: showRegistryBanner differentiates banner source ('github' | 'server') for accurate messaging.

Testing
- Unit tests: cover header parsing and reset time capture, rate-limit vs generic-403 classification, 200 responses clearing flags and metadata, malformed-body handling, network errors setting httpStatus=null, and single-flight concurrency behavior.
- E2E tests & harness: extends Playwright tests and the mock server with registryStatus scripting. Adds tests for Refresh button presence, rate-limited empty-state with reset-time display, failed refresh preserving cached cards and showing a banner, transport-level failure attributing the banner to the Signal K server, and successful refresh populating the catalog. Test setup stubs https.get and provides initCatalogManagerOffline() to drain the fire-and-forget fetch so suites run without live GitHub access (verified under a blocked network namespace).

Build & verification
- GET /catalog-registry returns registryStatus with captured headers; POST /catalog-registry/refresh triggers a re-fetch. CI format/build/lint pass; unit tests and Playwright catalog tests run in CI (unit: 305 passing; e2e: catalog tests passing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->