### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.2.0-beta.1",
+  "version": "2.2.0",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Promote the 2.2.0 line from beta to stable.

Since 2.1.0 (and the 2.2.0-beta.1 line), 2.2.0 ships:
- Chart catalog **Refresh button** with accurate GitHub rate-limit messaging (#130) — re-fetch the catalog index on demand; rate-limited shows the reset time as a warning instead of a misleading 'offline', and a failed refresh keeps cached catalogs.
- The earlier beta fixes: UID-1001 container permissions, xz-utils in the toolbox image, download retry/backoff, failed-update record preservation, and load-time recovery of interrupted updates.

Tagging `v2.2.0` publishes to npm under `latest` (promoting the beta work to stable).