### PR TITLE
fix(convert): surface container log on job failure

### DIFF
--- a/src/utils/container-jobs.ts
+++ b/src/utils/container-jobs.ts
@@ -19,7 +19,11 @@
  */
 
 import { getContainerManager } from './container-manager.js';
-import type { ContainerManagerApi, ContainerResourceLimits } from './container-manager.js';
+import type {
+  ContainerJobResult,
+  ContainerManagerApi,
+  ContainerResourceLimits
+} from './container-manager.js';
 
 function requireManager(): ContainerManagerApi {
   const manager = getContainerManager();
@@ -91,7 +95,7 @@ export interface JobRunResult {
    */
   error?: string;
   /** Terminal job status from signalk-container (`completed` / `failed` / …). */
-  status?: string;
+  status?: ContainerJobResult['status'];
 }
 
 /**

--- a/src/utils/container-jobs.ts
+++ b/src/utils/container-jobs.ts
@@ -84,6 +84,14 @@ export interface JobRunResult {
   exitCode: number;
   /** Combined stdout+stderr lines, in the order they were emitted. */
   log: string[];
+  /**
+   * signalk-container's failure reason, when it set one — e.g. the
+   * exception text when `container.wait()` threw. Distinct from a non-zero
+   * GDAL exit captured in `log`; surfaced so the two are distinguishable.
+   */
+  error?: string;
+  /** Terminal job status from signalk-container (`completed` / `failed` / …). */
+  status?: string;
 }
 
 /**
@@ -171,7 +179,9 @@ export async function runJob(opts: JobRunOptions): Promise<JobRunResult> {
   });
   return {
     exitCode: result.exitCode ?? 1,
-    log: result.log
+    log: result.log,
+    error: result.error,
+    status: result.status
   };
 }
 

--- a/src/utils/job-failure.ts
+++ b/src/utils/job-failure.ts
@@ -1,0 +1,52 @@
+// Number of trailing container-log lines to surface on a job failure. A
+// failing helper container's death signature (a `set -e` abort, a GDAL
+// stderr dump) is always at the END of the log, so we tail rather than head.
+const JOB_LOG_TAIL_LINES = 10;
+
+interface FailedJobResult {
+  exitCode: number;
+  log: string[];
+  error?: string;
+  status?: string;
+}
+
+/**
+ * Surface a helper container's own output, plus signalk-container's error
+ * string, into the conversion log before throwing. The converter's exit-code
+ * checks used to throw a bare `exit code N` and discard both `result.log` and
+ * `result.error`, which made three distinct failures indistinguishable in the
+ * UI: a real non-zero GDAL/tippecanoe exit, a synthetic `1` from a thrown
+ * `container.wait()`, and an `undefined` exit code coerced to `1` by the
+ * runJob wrapper. With the log tail and the runtime error surfaced, the user's
+ * conversion log shows which one actually happened.
+ *
+ * `append` is the caller's per-chart log sink (each converter owns its own
+ * `appendLog`). The thrown message is unchanged from the old call sites so any
+ * caller matching on it still behaves the same.
+ */
+export function throwJobFailure(
+  result: FailedJobResult,
+  label: string,
+  append: (text: string) => void
+): never {
+  if (result.error) {
+    append(`${label}: container runtime reported: ${result.error}`);
+  }
+  const log = result.log ?? [];
+  if (log.length === 0) {
+    const status = result.status ? `, status ${result.status}` : '';
+    append(
+      `${label}: container produced no output (exit ${result.exitCode}${status}). ` +
+        'The helper container likely failed to start or exited before any log was captured.'
+    );
+  } else {
+    const tail = log.slice(-JOB_LOG_TAIL_LINES);
+    append(
+      `${label}: exit ${result.exitCode}. Last ${tail.length} of ${log.length} container log line(s):`
+    );
+    for (const line of tail) {
+      append(`  ${line}`);
+    }
+  }
+  throw new Error(`${label} failed with exit code ${result.exitCode}`);
+}

--- a/src/utils/job-failure.ts
+++ b/src/utils/job-failure.ts
@@ -3,7 +3,7 @@
 // stderr dump) is always at the END of the log, so we tail rather than head.
 const JOB_LOG_TAIL_LINES = 10;
 
-interface FailedJobResult {
+export interface FailedJobResult {
   exitCode: number;
   log: string[];
   error?: string;

--- a/src/utils/rnc-converter.ts
+++ b/src/utils/rnc-converter.ts
@@ -9,6 +9,7 @@ import {
   runJob as runContainerJob
 } from './container-jobs.js';
 import { getContainerManager } from './container-manager.js';
+import { throwJobFailure } from './job-failure.js';
 import { setMbtilesType } from './mbtiles-metadata.js';
 import type {
   ConversionProgress,
@@ -145,7 +146,7 @@ export async function convertKapToMbtiles(
   });
 
   if (result.exitCode !== 0) {
-    throw new Error(`gdal_translate failed (exit ${result.exitCode})`);
+    throwJobFailure(result, 'gdal_translate', (t) => appendLog(chartNumber, t));
   }
   if (!fs.existsSync(outputFile)) {
     throw new Error(`gdal_translate succeeded but output file not found: ${outputFile}`);
@@ -452,7 +453,7 @@ export async function processPilotTar(
       onStderrLine: (line) => appendLog(chartNumber, line)
     });
     if (tarResult.exitCode !== 0) {
-      throw new Error(`tar extraction failed (exit ${tarResult.exitCode})`);
+      throwJobFailure(tarResult, 'tar extraction', (t) => appendLog(chartNumber, t));
     }
 
     const kapFiles: string[] = [];

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -21,6 +21,7 @@ import {
   runJob as runContainerJob
 } from './container-jobs.js';
 import { getContainerManager } from './container-manager.js';
+import { throwJobFailure } from './job-failure.js';
 import { patchS57Mbtiles, setMbtilesDisplayName } from './mbtiles-metadata.js';
 import {
   BAND_MAX_ZOOM,
@@ -368,7 +369,12 @@ async function exportAllLayersToGeoJSON(
   });
 
   if (result.exitCode !== 0) {
-    throw new Error(`GDAL export failed with exit code ${result.exitCode}`);
+    // A structural export failure (find/ogrinfo/bash) may still have written
+    // per-file ogr2ogr stderr before dying; surface that alongside the
+    // container log tail so an empty /input and a per-chart parse error are
+    // distinguishable.
+    surfaceExportErrorsIfEmpty(geojsonDir, chartNumber);
+    throwJobFailure(result, `gdal-export-${chartNumber}`, (t) => appendLog(chartNumber, t));
   }
 
   // The export script swallows non-zero exits from per-file ogr2ogr calls
@@ -722,7 +728,7 @@ async function runTippecanoe(
   });
 
   if (result.exitCode !== 0) {
-    throw new Error(`tippecanoe failed with exit code ${result.exitCode}`);
+    throwJobFailure(result, 'tippecanoe', (t) => appendLog(chartNumber, t));
   }
 
   // Best-effort cleanup of the merged dir.
@@ -837,7 +843,7 @@ async function runTileJoin(
   });
 
   if (result.exitCode !== 0) {
-    throw new Error(`tile-join failed with exit code ${result.exitCode}`);
+    throwJobFailure(result, 'tile-join', (t) => appendLog(chartNumber, t));
   }
 }
 
@@ -1419,7 +1425,7 @@ export async function processGshhg(
     onStderrLine: (line) => appendLog(chartNumber, line)
   });
   if (rasterizeResult.exitCode !== 0) {
-    throw new Error(`gdal_rasterize failed (exit ${rasterizeResult.exitCode})`);
+    throwJobFailure(rasterizeResult, 'gdal_rasterize', (t) => appendLog(chartNumber, t));
   }
 
   setProgress(chartNumber, 'converting', 'Creating MBTiles...');
@@ -1444,7 +1450,7 @@ export async function processGshhg(
     onStderrLine: (line) => appendLog(chartNumber, line)
   });
   if (translateResult.exitCode !== 0) {
-    throw new Error(`gdal_translate failed (exit ${translateResult.exitCode})`);
+    throwJobFailure(translateResult, 'gdal_translate', (t) => appendLog(chartNumber, t));
   }
 
   setProgress(chartNumber, 'converting', 'Adding zoom levels...');
@@ -1473,7 +1479,7 @@ export async function processGshhg(
     onStderrLine: (line) => appendLog(chartNumber, line)
   });
   if (overviewResult.exitCode !== 0) {
-    throw new Error(`gdaladdo failed (exit ${overviewResult.exitCode})`);
+    throwJobFailure(overviewResult, 'gdaladdo', (t) => appendLog(chartNumber, t));
   }
 
   try {
@@ -1573,7 +1579,7 @@ export async function processShpBasemap(
       onStderrLine: (line) => appendLog(chartNumber, line)
     });
     if (tarResult.exitCode !== 0) {
-      throw new Error(`tar extraction failed (exit ${tarResult.exitCode})`);
+      throwJobFailure(tarResult, 'tar extraction', (t) => appendLog(chartNumber, t));
     }
 
     const findShp = (dir: string, prefix: string | null): string | null => {
@@ -1690,7 +1696,7 @@ export async function processShpBasemap(
       onStderrLine: (line) => appendLog(chartNumber, line)
     });
     if (rasterizeResult.exitCode !== 0) {
-      throw new Error(`gdal_rasterize failed (exit ${rasterizeResult.exitCode})`);
+      throwJobFailure(rasterizeResult, 'gdal_rasterize', (t) => appendLog(chartNumber, t));
     }
 
     appendLog(chartNumber, 'Creating MBTiles...');
@@ -1714,7 +1720,7 @@ export async function processShpBasemap(
       onStderrLine: (line) => appendLog(chartNumber, line)
     });
     if (translateResult.exitCode !== 0) {
-      throw new Error(`gdal_translate failed (exit ${translateResult.exitCode})`);
+      throwJobFailure(translateResult, 'gdal_translate', (t) => appendLog(chartNumber, t));
     }
 
     appendLog(chartNumber, 'Adding zoom levels...');
@@ -1742,7 +1748,7 @@ export async function processShpBasemap(
       onStderrLine: (line) => appendLog(chartNumber, line)
     });
     if (overviewResult.exitCode !== 0) {
-      throw new Error(`gdaladdo failed (exit ${overviewResult.exitCode})`);
+      throwJobFailure(overviewResult, 'gdaladdo', (t) => appendLog(chartNumber, t));
     }
 
     try {

--- a/test/job-failure.test.ts
+++ b/test/job-failure.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { throwJobFailure } from '../dist/utils/job-failure.js';
+
+// Collect the lines the helper would surface, and capture whether it threw and
+// with what message. throwJobFailure always throws, so every case asserts that.
+function run(result: { exitCode: number; log: string[]; error?: string; status?: string }): {
+  lines: string[];
+  message: string;
+} {
+  const lines: string[] = [];
+  try {
+    throwJobFailure(result, 'gdal-export', (t) => lines.push(t));
+  } catch (err) {
+    return { lines, message: err instanceof Error ? err.message : String(err) };
+  }
+  assert.fail('throwJobFailure did not throw');
+}
+
+describe('throwJobFailure', () => {
+  it('surfaces a tail of the container log and throws the labelled exit message', () => {
+    const log = Array.from({ length: 25 }, (_, i) => `line ${i + 1}`);
+    const { lines, message } = run({ exitCode: 1, log });
+
+    assert.strictEqual(message, 'gdal-export failed with exit code 1');
+    // Headline names the count, then the last 10 lines verbatim.
+    assert.match(lines[0], /exit 1\. Last 10 of 25 container log line\(s\):/);
+    assert.deepStrictEqual(
+      lines.slice(1),
+      log.slice(-10).map((l) => `  ${l}`)
+    );
+  });
+
+  it('surfaces the runtime error line followed by the log tail when both are set', () => {
+    const { lines, message } = run({
+      exitCode: 1,
+      log: ['some output'],
+      error: 'Container exited with code 137'
+    });
+
+    assert.strictEqual(message, 'gdal-export failed with exit code 1');
+    assert.deepStrictEqual(lines, [
+      'gdal-export: container runtime reported: Container exited with code 137',
+      'gdal-export: exit 1. Last 1 of 1 container log line(s):',
+      '  some output'
+    ]);
+  });
+
+  it('reports a no-output container with its status', () => {
+    const { lines, message } = run({ exitCode: 1, log: [], status: 'failed' });
+
+    assert.strictEqual(message, 'gdal-export failed with exit code 1');
+    assert.match(lines[0], /container produced no output \(exit 1, status failed\)/);
+  });
+
+  it('reports a no-output container without a status when none is given', () => {
+    const { lines } = run({ exitCode: 1, log: [] });
+
+    assert.match(lines[0], /container produced no output \(exit 1\)\./);
+    assert.doesNotMatch(lines[0], /status/);
+  });
+});

--- a/test/job-failure.test.ts
+++ b/test/job-failure.test.ts
@@ -1,11 +1,11 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
-import { throwJobFailure } from '../dist/utils/job-failure.js';
+import { throwJobFailure, type FailedJobResult } from '../dist/utils/job-failure.js';
 
 // Collect the lines the helper would surface, and capture whether it threw and
 // with what message. throwJobFailure always throws, so every case asserts that.
-function run(result: { exitCode: number; log: string[]; error?: string; status?: string }): {
+function run(result: FailedJobResult): {
   lines: string[];
   message: string;
 } {


### PR DESCRIPTION
## Why

Issue #132 reports ENC (S-57) conversion failing with `GDAL export failed with exit code 1` at the end of the run, with no further detail. The converter's exit-code checks threw a bare `<tool> failed with exit code N` and discarded both `result.log` (the helper container's own output) and signalk-container's `result.error`. That made three different failures indistinguishable from the UI:

- a real non-zero GDAL/tippecanoe exit (cause visible only in the container log),
- a synthetic `1` from a thrown `container.wait()` in signalk-container (cause only in `result.error`),
- an `undefined` exit code coerced to `1` by the `runJob` wrapper.

This does not pick a root cause for #132 — it makes the failure self-describing so the actual cause can be read from the conversion log.

## Approach

- Add `src/utils/job-failure.ts` with a shared `throwJobFailure(result, label, append)` helper: it logs signalk-container's error (when set) and a tail of the container output, then throws the same-shaped `Error` the call sites threw before (so behaviour for any caller matching on the message is unchanged).
- Route every hard-fail exit-code site in `s57-converter.ts` and `rnc-converter.ts` through it. The non-fatal `gdaladdo` warn-and-continue sites and the per-file skip (`continue`) sites are intentionally left as-is.
- Thread `error` and `status` through the `runJob` wrapper (`container-jobs.ts`) so the helper can surface them.
- On the GDAL export path specifically, also surface the per-file `.export-errors.log` on failure, not only on a clean exit.

## Tested

- `npm run format` / `npm run format:check` — clean
- `npm run build` — clean (tsc strict + strictTypeChecked)
- `npm run test` — 305 pass, 0 fail (new `test/job-failure.test.ts` covers the log-tail, runtime-error, and no-output branches)
- `cr review --plain` — two test-coverage nitpicks, both addressed

Refs #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Surface detailed container logs and runtime errors when ENC (S-57) and RNC conversions fail, replacing indistinguishable generic exit-code errors with diagnostic information from container output.

## Changes

**Shared failure handler**

Add src/utils/job-failure.ts exporting throwJobFailure(result, label, append) and the FailedJobResult type. The helper appends container runtime errors when present, reports when a job produced no output (including exitCode and optional status), or tails the last 10 log lines and appends a summary (exitCode and tailed line count). It then throws an Error with the same outward message shape used previously for compatibility.

**Container output threading**

Extend JobRunResult in src/utils/container-jobs.ts to include optional error?: string and status?: ContainerJobResult['status'], and pass these through from signalk-container in runJob so throwJobFailure can surface container-level diagnostics.

**Converter updates**

Route all hard-fail exit-code paths in src/utils/s57-converter.ts and src/utils/rnc-converter.ts through throwJobFailure instead of throwing generic Errors. On GDAL export failures, also surface per-file .export-errors.log content (previously only surfaced on success). Non-fatal gdaladdo warnings and per-file skips remain unchanged.

**Tests and tooling**

Add test/job-failure.test.ts covering log-tail, runtime-error, and no-output branches (four assertions). npm run format, build, and test are clean: formatting OK, TypeScript strict build OK, and tests pass (305 passing, 0 failing). Small API/type adjustments: narrow JobRunResult.status to ContainerJobResult['status'] and export FailedJobResult for use in tests.

## References

Addresses issue `#132`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->