### PR TITLE
chore(release): 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Patch release shipping the job-failure diagnostics from #133.

## Included since 2.2.0

- **fix(convert): surface container log on job failure** — the converter's exit-code checks now log the helper container's output tail and signalk-container's error before throwing, so a failure shows *why* it failed instead of a bare `exit code N`. Directly aids diagnosis of #132.
- **refactor(convert): narrow JobRunResult.status to the upstream union** — references `ContainerJobResult['status']` so the field tracks signalk-container's definition.
- **refactor(convert): export FailedJobResult** — makes the `throwJobFailure` contract explicit and shared with the test.

Bumps `package.json` to 2.2.1. Tagging `v2.2.1` after merge triggers `publish.yml`.