### PR TITLE
Mid-job cancel + live merge progress for NOAA chart sets

### DIFF
--- a/public/js/noaa-chart-selector.ts
+++ b/public/js/noaa-chart-selector.ts
@@ -539,11 +539,9 @@ function renderProgress(): void {
   let cancelHtml = '';
   if (ccBusy && d?.phase === 'cancelling') {
     cancelHtml = `<span class="cc-cancel-pending">Cancelling…</span>`;
-  } else if (ccBusy && d?.phase === 'joining') {
-    // The tile-join container job can't be interrupted (signalk-container's
-    // runJob has no abort), so don't offer a Cancel that wouldn't work.
-    cancelHtml = `<span class="cc-cancel-pending">Can't be interrupted</span>`;
   } else if (ccBusy) {
+    // Every phase — including the combine — is now cancellable: the cancel
+    // route aborts the in-flight container job (signalk-container >= 1.16.0).
     cancelHtml = `<button class="cc-btn cc-btn-danger cc-cancel-btn" data-cc-action="cancel">Cancel</button>`;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ import {
   isCatalogCancelRequested,
   isValidCatalogId,
   listCustomCatalogs,
+  registerCatalogAbort,
   requestCatalogCancel,
   saveCustomCatalog,
   setCatalogBusy,
@@ -2554,8 +2555,15 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       }
       requestCatalogCancel(id);
       setCatalogProgress(id, 'cancelling', 'Cancelling…');
-      // Downloads stop between charts immediately; a conversion stops at the
-      // next band boundary (the in-flight container job can't be force-killed).
+      // Reflect it in the structured detail immediately so the next /status
+      // poll shows "Cancelling…" rather than the last conversion frame.
+      setCatalogDetail(id, {
+        phase: 'cancelling',
+        sectionLabel: 'Cancelling…',
+        sectionPercent: -1
+      });
+      // Aborts the in-flight container job on signalk-container >= 1.16.0;
+      // downloads stop between charts; older containers stop at a band boundary.
       res.json({ success: true, message: 'Cancellation requested' });
     });
 
@@ -3105,6 +3113,9 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         boxStates: {}
       };
     }
+    const mbtilesPresent =
+      catalog.convertedChartPath !== null &&
+      fs.existsSync(path.join(chartPath, catalog.convertedChartPath));
     const freshness = evaluateFreshness(catalog, index, (rel) =>
       fs.existsSync(path.join(chartPath, rel))
     );
@@ -3113,9 +3124,10 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       effectiveStatus: freshness.effectiveStatus,
       includedCount: freshness.recomputed.includedChartIds.length,
       updateReasons: freshness.reasons,
-      // Per-box freshness by NOAA edition (independent of whether the source
-      // ZIPs still exist on disk — they're cleaned up after conversion).
-      boxStates: boxStatesForCatalog(catalog, index)
+      // Per-box freshness by NOAA edition. A box is green only when the set is
+      // cleanly converted and its MBTiles exists — a cancelled/failed build or
+      // a deleted output shows red, matching the catalog-level status.
+      boxStates: boxStatesForCatalog(catalog, index, mbtilesPresent)
     };
   }
 
@@ -3138,6 +3150,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       downloadedChartIds: []
     });
     const stagedSoFar: string[] = [];
+
+    // Abort controller for mid-job cancel: requestCatalogCancel(id) aborts it,
+    // which kills the in-flight container job on signalk-container >= 1.16.0.
+    const abortController = new AbortController();
+    registerCatalogAbort(id, abortController);
 
     const stagingRoot = path.join(app.getDataDirPath(), `custom-catalog-${Date.now()}`);
     const encDir = path.join(stagingRoot, 'enc');
@@ -3264,31 +3281,52 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             displayName: catalog.name,
             displayDescription: `Custom catalog: ${catalog.name}`,
             isAborted: () => isCatalogCancelRequested(id),
+            // Overall (convert-only) bar treats the per-band tippecanoe passes
+            // plus the final combine as equal slices, so it rises monotonically
+            // through the whole conversion. The combine now reports its own %
+            // (derived from tile-join's tile-coordinate output), so its section
+            // bar is determinate too.
             onProgress: (p) => {
-              // Overall bar is convert-only: each bucket is an equal slice,
-              // advanced by that bucket's tippecanoe %. Join sits near 100%.
-              const tilePct = p.bucketPercent >= 0 ? p.bucketPercent : 0;
-              const overall =
-                p.stage === 'join'
-                  ? 99
-                  : p.bucketCount > 0
-                    ? Math.round(((p.bucketIndex - 1 + tilePct / 100) / p.bucketCount) * 100)
-                    : 0;
+              // Once cancel is requested, the in-flight job is being killed but
+              // may emit a few more progress lines before it dies. Don't let
+              // those overwrite the "Cancelling…" state — otherwise the UI
+              // flips back to "running" until the job actually unwinds.
+              if (isCatalogCancelRequested(id)) {
+                setCatalogDetail(id, {
+                  phase: 'cancelling',
+                  sectionLabel: 'Cancelling…',
+                  sectionPercent: -1
+                });
+                return;
+              }
+              const hasJoin = p.bucketCount >= 2;
+              const denom = p.bucketCount + (hasJoin ? 1 : 0);
+              const pct = p.bucketPercent >= 0 ? p.bucketPercent : 0;
+              let overall: number;
               let sectionLabel: string;
+              let sectionPercent: number;
               if (p.stage === 'join') {
-                sectionLabel = `Combining ${p.bucketCount} tile sets — this can take a while and can't be interrupted`;
+                overall = denom > 0 ? Math.round(((p.bucketCount + pct / 100) / denom) * 100) : 99;
+                sectionLabel = `Combining ${p.bucketCount} tile sets`;
+                sectionPercent = p.bucketPercent;
               } else if (p.stage === 'export') {
+                overall = denom > 0 ? Math.round(((p.bucketIndex - 1) / denom) * 100) : 0;
                 sectionLabel = `${p.bucketLabel} — reading charts (${p.bucketIndex} of ${p.bucketCount})`;
+                sectionPercent = -1;
               } else {
+                overall =
+                  denom > 0 ? Math.round(((p.bucketIndex - 1 + pct / 100) / denom) * 100) : 0;
                 sectionLabel = `${p.bucketLabel} — generating tiles (${p.bucketIndex} of ${p.bucketCount})`;
+                sectionPercent = Math.round(pct);
               }
               setCatalogDetail(id, {
                 phase: p.stage === 'join' ? 'joining' : 'converting',
                 overallPercent: overall,
                 sectionLabel,
-                sectionPercent: p.stage === 'tiles' ? Math.round(tilePct) : -1
+                sectionPercent
               });
-            }
+            },
+            signal: abortController.signal
           },
           stagingRoot
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -3306,7 +3306,13 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
               let sectionLabel: string;
               let sectionPercent: number;
               if (p.stage === 'join') {
-                overall = denom > 0 ? Math.round(((p.bucketCount + pct / 100) / denom) * 100) : 99;
+                // Clamp: with a single bucket (no dedicated join slot) the
+                // join collapses to a file move and emits 100%, which would
+                // otherwise compute >100 here.
+                overall =
+                  denom > 0
+                    ? Math.min(100, Math.round(((p.bucketCount + pct / 100) / denom) * 100))
+                    : 99;
                 sectionLabel = `Combining ${p.bucketCount} tile sets`;
                 sectionPercent = p.bucketPercent;
               } else if (p.stage === 'export') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -311,11 +311,16 @@ export interface S57ConversionOptions {
   onProgress?: (progress: S57BucketProgress) => void;
   /**
    * Optional cooperative-cancel check. Polled between buckets (and before
-   * tile-join); when it returns true the pipeline throws to stop at the next
-   * boundary. An in-flight container job can't be force-killed, so cancel
-   * takes effect at the next stage boundary, not instantly.
+   * tile-join) to stop the pipeline at the next boundary — a complement to
+   * `signal`, and the only cancel path on signalk-container < 1.16.0.
    */
   isAborted?: () => boolean;
+  /**
+   * Optional abort signal threaded into every container job. On
+   * signalk-container >= 1.16.0 this kills the in-flight job (GDAL,
+   * tippecanoe, or tile-join) immediately rather than waiting for a boundary.
+   */
+  signal?: AbortSignal;
 }
 
 export interface ContainerRuntimeStatus {

--- a/src/utils/container-jobs.ts
+++ b/src/utils/container-jobs.ts
@@ -82,6 +82,12 @@ export interface JobRunOptions {
    * Available in signalk-container >= 1.4.0.
    */
   user?: { inImageUid?: number; inImageGid?: number } | false;
+  /**
+   * Abort the running container job. signalk-container >= 1.16.0 kills the
+   * container on abort and resolves with `status: 'cancelled'`; older
+   * versions ignore it (boundary cancel still applies).
+   */
+  signal?: AbortSignal;
 }
 
 export interface JobRunResult {
@@ -171,6 +177,7 @@ export async function runJob(opts: JobRunOptions): Promise<JobRunResult> {
     onStdoutLine: opts.onStdoutLine,
     onStderrLine: opts.onStderrLine,
     resources: opts.resources,
+    signal: opts.signal,
     // Required by signalk-container 1.3.0+ for cleanupOrphanedJobs to
     // find and reap our containers after a Signal K crash. Single
     // source of truth for the owner id; all of this plugin's helper

--- a/src/utils/container-manager.ts
+++ b/src/utils/container-manager.ts
@@ -82,6 +82,14 @@ export interface ContainerJobConfig {
    * Available in signalk-container >= 1.4.0.
    */
   user?: { inImageUid?: number; inImageGid?: number } | false;
+  /**
+   * Abort a running job. When the signal fires, signalk-container
+   * force-removes the container and the job resolves with
+   * `status: 'cancelled'`. Available in signalk-container >= 1.16.0;
+   * older versions ignore the field, so the caller falls back to
+   * boundary-level cancel (stop dispatching the next job).
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -102,7 +110,8 @@ export interface CleanupOrphansResult {
 }
 
 export interface ContainerJobResult {
-  status: 'pending' | 'pulling' | 'running' | 'completed' | 'failed';
+  // 'cancelled' added in signalk-container >= 1.16.0 (abort signal).
+  status: 'pending' | 'pulling' | 'running' | 'completed' | 'failed' | 'cancelled';
   exitCode?: number;
   log: string[];
   error?: string;

--- a/src/utils/custom-catalog-manager.ts
+++ b/src/utils/custom-catalog-manager.ts
@@ -369,22 +369,28 @@ export type BoxState = 'up_to_date' | 'needs_refresh';
  * the built MBTiles still matches the current NOAA editions for that box's
  * charts (its band-4 cell + the band-5 cells nested in it).
  *
- * `needs_refresh` when: the catalog was never built; a chart in the box's
- * current coverage has a newer `enc_ed_up` than the snapshot taken at build
- * time; or NOAA has added a new cell to the box since the build. `up_to_date`
- * only when every covered chart matches the baked snapshot.
+ * A box is `up_to_date` only when the chart set is cleanly converted, its
+ * MBTiles is present on disk, AND every covered chart matches the baked
+ * edition snapshot. It is `needs_refresh` otherwise — never built, a cancelled
+ * or failed build (status no longer `converted`), the output file missing, a
+ * drifted edition, or NOAA having added a new cell to the box.
  *
- * This is driven entirely by the edition snapshot persisted in the chart-set
- * JSON, so it is independent of whether the downloaded source ZIPs still exist
- * on disk (they are cleaned up after conversion by design).
+ * Edition-driven, so it doesn't depend on the downloaded *source* ZIPs still
+ * being on disk (those are cleaned up after conversion). It does require the
+ * built *output* MBTiles, since a missing chart genuinely needs a rebuild.
  */
 export function boxStatesForCatalog(
   catalog: CustomCatalog,
-  index: FootprintIndex
+  index: FootprintIndex,
+  mbtilesPresent: boolean
 ): Record<string, BoxState> {
   const coverage = coverageByBox(index.all, catalog.selectedBand4ChartIds);
   const baked = catalog.chartVersions;
-  const built = catalog.convertedChartPath !== null;
+  // `chartVersions` is also written at download time (before conversion), so on
+  // a cancelled/failed run it can claim current editions that aren't actually
+  // baked in. Gating on a clean 'converted' status + a present output file
+  // ensures those runs show red, not a false green.
+  const built = catalog.status === 'converted' && mbtilesPresent;
 
   const result: Record<string, BoxState> = {};
   for (const boxId of catalog.selectedBand4ChartIds) {
@@ -492,12 +498,26 @@ export function setCatalogDetail(id: string, detail: Partial<CustomCatalogProgre
 
 // ---- Cancellation ----
 
+// Per-run abort controller. The flow registers one at start; cancel aborts it
+// to kill the in-flight container job (signalk-container >= 1.16.0). The
+// cancelRequested flag remains the boundary-cancel signal and the way the flow
+// distinguishes a cancel from a genuine failure.
+const abortControllers = new Map<string, AbortController>();
+
+/** Register the run's abort controller so a cancel can fire its signal. */
+export function registerCatalogAbort(id: string, controller: AbortController): void {
+  abortControllers.set(id, controller);
+}
+
 /** Request cancellation of an in-flight run; no-op when not busy. */
 export function requestCatalogCancel(id: string): boolean {
   if (!busyCatalogs.has(id)) {
     return false;
   }
   cancelRequested.add(id);
+  // Kill the in-flight container job immediately where supported; the boundary
+  // check (isCatalogCancelRequested) covers older signalk-container.
+  abortControllers.get(id)?.abort();
   return true;
 }
 
@@ -507,4 +527,5 @@ export function isCatalogCancelRequested(id: string): boolean {
 
 export function clearCatalogCancel(id: string): void {
   cancelRequested.delete(id);
+  abortControllers.delete(id);
 }

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -795,6 +795,11 @@ async function runTileJoin(
     // place so the rest of the pipeline doesn't have to special-case.
     // Fall back to copy+unlink across filesystems (chartPath on a USB
     // mount is the realistic case where rename returns EXDEV).
+    // Honor cancellation here too, so this branch behaves like the
+    // multi-input path's post-job throwIfJobCancelled check.
+    if (signal?.aborted) {
+      throw new Error(CONVERSION_ABORTED_MESSAGE);
+    }
     try {
       fs.renameSync(inputMbtiles[0], outputMbtiles);
     } catch (err) {
@@ -804,6 +809,9 @@ async function runTileJoin(
       fs.copyFileSync(inputMbtiles[0], outputMbtiles);
       fs.unlinkSync(inputMbtiles[0]);
     }
+    // Mirror the multi-input path's completion so the "Combining" bar
+    // reaches 100% even when the join collapsed to a single file move.
+    onPercent?.(100);
     return;
   }
 

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -13,10 +13,21 @@ import type {
   StatusCallback
 } from '../types.js';
 
-// Message thrown when an in-progress conversion is cancelled at a bucket
-// boundary. Callers (the Custom Catalogs flow) detect cancellation via their
-// own flag, so this is just a recognizable stop signal.
+// Message thrown when an in-progress conversion is cancelled — either at a
+// bucket boundary (isAborted) or mid-job when signalk-container kills the
+// container on abort and returns `status: 'cancelled'`. Callers (the Custom
+// Catalogs flow) detect cancellation via their own flag, so this is just a
+// recognizable stop signal.
 export const CONVERSION_ABORTED_MESSAGE = 'Conversion cancelled';
+
+// Stop the pipeline when a container job was killed by an abort signal
+// (signalk-container >= 1.16.0). Checked before the exit-code check, since a
+// killed job's exit code is meaningless.
+function throwIfJobCancelled(result: { status?: string }): void {
+  if (result.status === 'cancelled') {
+    throw new Error(CONVERSION_ABORTED_MESSAGE);
+  }
+}
 import { sanitizeChartFilename } from './catalog-title.js';
 import { getCpuBudget } from './concurrency.js';
 import { makeContainerWritable, makeContainerWritableDir } from './container-fs.js';
@@ -303,7 +314,8 @@ async function exportAllLayersToGeoJSON(
   encDir: string,
   encFiles: string[],
   geojsonDir: string,
-  chartNumber: string
+  chartNumber: string,
+  signal?: AbortSignal
 ): Promise<void> {
   const skipLayers = ['DSID', 'C_AGGR', 'C_ASSO', 'Generic'];
   const multiFile = encFiles.length > 1;
@@ -364,6 +376,7 @@ async function exportAllLayersToGeoJSON(
     // pass to xargs, so this just enforces the same ceiling at the
     // kernel cgroup level.
     resources: { cpus: parallelism },
+    signal,
     onStdoutLine: (line) => {
       appendLog(chartNumber, line);
       const match = line.match(/PROGRESS: Processing (\S+)/);
@@ -373,6 +386,8 @@ async function exportAllLayersToGeoJSON(
     },
     onStderrLine: (line) => appendLog(chartNumber, line)
   });
+
+  throwIfJobCancelled(result);
 
   if (result.exitCode !== 0) {
     // A structural export failure (find/ogrinfo/bash) may still have written
@@ -733,10 +748,12 @@ async function runTippecanoe(
     // scheduler still gives each worker its own core, so on a multi-
     // core box "half" budget feels indistinguishable from "all".
     resources: { cpus: tippecanoeThreads },
+    signal: options.signal,
     onStdoutLine: handleTippecanoeLine,
     onStderrLine: handleTippecanoeLine
   });
 
+  throwIfJobCancelled(result);
   if (result.exitCode !== 0) {
     throwJobFailure(result, 'tippecanoe', (t) => appendLog(chartNumber, t));
   }
@@ -764,7 +781,9 @@ async function runTippecanoe(
 async function runTileJoin(
   inputMbtiles: readonly string[],
   outputMbtiles: string,
-  chartNumber: string
+  chartNumber: string,
+  onPercent?: (pct: number) => void,
+  signal?: AbortSignal
 ): Promise<void> {
   if (inputMbtiles.length === 0) {
     throw new Error('runTileJoin called with no inputs');
@@ -825,36 +844,86 @@ async function runTileJoin(
 
   appendLog(
     chartNumber,
-    `Joining ${inputMbtiles.length} per-band tile sets into ${path.basename(outputMbtiles)}...`
+    `Combining ${inputMbtiles.length} per-band tile sets into ${path.basename(outputMbtiles)}...`
   );
   debug(`Running tile-join on ${inputMbtiles.length} inputs`);
 
+  // tile-join gives us no usable streaming progress. Its only output is the
+  // current tile coordinate (`z/x/y`, no percentage), and it block-buffers
+  // that to stderr — flushing the entire ~30-line sample at process exit — so
+  // parsing stdout would leave the bar at 0% then snap to 100% at the very end
+  // (confirmed: a CPU-throttled join emits 0 bytes for its whole runtime, even
+  // under stdbuf or a PTY). Instead we watch the REAL signal: the output
+  // MBTiles grows on disk (a host-mounted path) as tiles are inserted, and its
+  // final size is ~the sum of the inputs (per-band intermediates have disjoint
+  // zoom ranges, so almost nothing dedupes). So currentSize / expectedSize
+  // tracks the merge smoothly and monotonically. Cap at 99%; snap to 100 once
+  // the job exits.
+  const expectedBytes = inputMbtiles.reduce((sum, f) => {
+    try {
+      return sum + fs.statSync(f).size;
+    } catch {
+      return sum;
+    }
+  }, 0);
+  let lastPct = 0;
+  const pollOutputSize = (): void => {
+    if (!onPercent || expectedBytes <= 0) {
+      return;
+    }
+    let size = 0;
+    try {
+      size = fs.statSync(outputMbtiles).size;
+    } catch {
+      return; // output not created yet
+    }
+    const pct = Math.min(99, Math.round((size / expectedBytes) * 100));
+    if (pct > lastPct) {
+      lastPct = pct;
+      onPercent(pct);
+    }
+  };
+  const sizeTimer = setInterval(pollOutputSize, 1000);
+
+  // tile-join's coordinate lines all arrive in one burst at exit; keep them out
+  // of the conversion log, but surface anything else (e.g. errors).
+  const tileLineRe = /^\s*\d+\/\d+\/\d+/;
   const handleTileJoinLine = (line: string): void => {
-    appendLog(chartNumber, line);
+    if (!tileLineRe.test(line)) {
+      appendLog(chartNumber, line);
+    }
   };
 
-  const result = await runContainerJob({
-    image: CHARTS_TOOLBOX_IMAGE,
-    label: `tile-join-${chartNumber}`,
-    command: [
-      'tile-join',
-      '-o',
-      `${outputPrefix}/${path.basename(outputMbtiles)}`,
-      '--no-tile-size-limit',
-      '--force',
-      ...inputArgs
-    ],
-    inputs: { '/input': resolved['/input'].source },
-    outputs: { '/output': resolved['/output'].source },
-    env: { TIPPECANOE_MAX_THREADS: String(tippecanoeThreads) },
-    resources: { cpus: tippecanoeThreads },
-    onStdoutLine: handleTileJoinLine,
-    onStderrLine: handleTileJoinLine
-  });
+  let result: Awaited<ReturnType<typeof runContainerJob>>;
+  try {
+    result = await runContainerJob({
+      image: CHARTS_TOOLBOX_IMAGE,
+      label: `tile-join-${chartNumber}`,
+      command: [
+        'tile-join',
+        '-o',
+        `${outputPrefix}/${path.basename(outputMbtiles)}`,
+        '--no-tile-size-limit',
+        '--force',
+        ...inputArgs
+      ],
+      inputs: { '/input': resolved['/input'].source },
+      outputs: { '/output': resolved['/output'].source },
+      env: { TIPPECANOE_MAX_THREADS: String(tippecanoeThreads) },
+      resources: { cpus: tippecanoeThreads },
+      signal,
+      onStdoutLine: handleTileJoinLine,
+      onStderrLine: handleTileJoinLine
+    });
+  } finally {
+    clearInterval(sizeTimer);
+  }
 
+  throwIfJobCancelled(result);
   if (result.exitCode !== 0) {
     throwJobFailure(result, 'tile-join', (t) => appendLog(chartNumber, t));
   }
+  onPercent?.(100);
 }
 
 /**
@@ -996,7 +1065,7 @@ async function runPerBandPipeline(
       `${bucketProgressPrefix} Exporting ${cells.length} cell(s) to GeoJSON...`
     );
     emitBucket('export', bucketLabel, -1);
-    await exportAllLayersToGeoJSON(bandEncDir, cells, bandGeojsonDir, chartNumber);
+    await exportAllLayersToGeoJSON(bandEncDir, cells, bandGeojsonDir, chartNumber, options.signal);
 
     setProgress(
       chartNumber,
@@ -1055,7 +1124,8 @@ async function runPerBandPipeline(
       unbandedEncDir,
       grouping.unbanded,
       unbandedGeojsonDir,
-      chartNumber
+      chartNumber,
+      options.signal
     );
 
     setProgress(
@@ -1086,15 +1156,17 @@ async function runPerBandPipeline(
   }
 
   abortIfRequested();
-  setProgress(chartNumber, 'converting', 'Joining per-band tile sets...');
-  options.onProgress?.({
-    stage: 'join',
-    bucketIndex: totalBuckets,
-    bucketCount: totalBuckets,
-    bucketLabel: 'Joining',
-    bucketPercent: -1
-  });
-  await runTileJoin(intermediates, outputMbtiles, chartNumber);
+  setProgress(chartNumber, 'converting', 'Combining per-band tile sets...');
+  const emitJoin = (bucketPercent: number): void =>
+    options.onProgress?.({
+      stage: 'join',
+      bucketIndex: totalBuckets,
+      bucketCount: totalBuckets,
+      bucketLabel: 'Combining',
+      bucketPercent
+    });
+  emitJoin(0);
+  await runTileJoin(intermediates, outputMbtiles, chartNumber, emitJoin, options.signal);
 }
 
 /**
@@ -1205,7 +1277,7 @@ export async function processS57Directory(
         bucketLabel: 'Charts',
         bucketPercent: -1
       });
-      await exportAllLayersToGeoJSON(encDir, encFiles, geojsonDir, chartNumber);
+      await exportAllLayersToGeoJSON(encDir, encFiles, geojsonDir, chartNumber, options.signal);
 
       statusFn('converting', 'Generating vector tiles...');
       setProgress(chartNumber, 'converting', 'Generating vector tiles with tippecanoe...');

--- a/test/custom-catalog-manager.test.ts
+++ b/test/custom-catalog-manager.test.ts
@@ -230,20 +230,36 @@ describe('boxStatesForCatalog', () => {
     };
   }
 
-  it('up_to_date when baked editions still match current NOAA', () => {
-    const r = boxStatesForCatalog(builtCatalog(), indexWith('ED1', 'ED1'));
+  it('up_to_date when converted, present, and editions match current NOAA', () => {
+    const r = boxStatesForCatalog(builtCatalog(), indexWith('ED1', 'ED1'), true);
     assert.strictEqual(r['US4BOXA0'], 'up_to_date');
   });
 
   it('needs_refresh when a nested band-5 cell has a newer edition', () => {
-    const r = boxStatesForCatalog(builtCatalog(), indexWith('ED1', 'ED2'));
+    const r = boxStatesForCatalog(builtCatalog(), indexWith('ED1', 'ED2'), true);
     assert.strictEqual(r['US4BOXA0'], 'needs_refresh');
   });
 
   it('needs_refresh when the catalog was never built', () => {
     const r = boxStatesForCatalog(
-      { ...builtCatalog(), convertedChartPath: null },
-      indexWith('ED1', 'ED1')
+      { ...builtCatalog(), convertedChartPath: null, status: 'out_of_date' },
+      indexWith('ED1', 'ED1'),
+      false
+    );
+    assert.strictEqual(r['US4BOXA0'], 'needs_refresh');
+  });
+
+  it('needs_refresh when the output MBTiles is missing (e.g. after a cancel)', () => {
+    // Converted + editions match, but the file is gone — must not show green.
+    const r = boxStatesForCatalog(builtCatalog(), indexWith('ED1', 'ED1'), false);
+    assert.strictEqual(r['US4BOXA0'], 'needs_refresh');
+  });
+
+  it('needs_refresh when the status is no longer converted (cancelled/failed run)', () => {
+    const r = boxStatesForCatalog(
+      { ...builtCatalog(), status: 'out_of_date' },
+      indexWith('ED1', 'ED1'),
+      true
     );
     assert.strictEqual(r['US4BOXA0'], 'needs_refresh');
   });
@@ -254,14 +270,14 @@ describe('boxStatesForCatalog', () => {
       { encEdUp: 'US5NEST00_ED1', band: 5, ring: square(1, 1, 1) },
       { encEdUp: 'US5NEW000_ED1', band: 5, ring: square(2, 2, 1) } // new cell in the box
     ]);
-    const r = boxStatesForCatalog(builtCatalog(), idx);
+    const r = boxStatesForCatalog(builtCatalog(), idx, true);
     assert.strictEqual(r['US4BOXA0'], 'needs_refresh');
   });
 
-  // Edition-driven, so it does NOT depend on source files still being on disk
-  // (the chartFileExists check used by evaluateFreshness is irrelevant here).
-  it('is independent of on-disk source/output files', () => {
-    const r = boxStatesForCatalog(builtCatalog(), indexWith('ED1', 'ED1'));
+  // Edition-driven: doesn't depend on the downloaded source ZIPs (cleaned up
+  // after conversion), only on the built output existing.
+  it('is independent of the downloaded source ZIPs', () => {
+    const r = boxStatesForCatalog(builtCatalog(), indexWith('ED1', 'ED1'), true);
     assert.strictEqual(r['US4BOXA0'], 'up_to_date');
   });
 });


### PR DESCRIPTION
Two follow-ups to the NOAA Charts tab (#135). Both are contained entirely in this plugin — they consume the existing `signalk-container` API (cancel uses the abort support added in 1.16.0) and require **no changes** to `signalk-container`.

## Mid-job cancel
Previously the Cancel button could only stop a job at a band boundary. Now it aborts the running container:

- An `AbortSignal` is threaded from the `/custom-catalogs/:id/cancel` route through `processS57Directory` into the GDAL / tippecanoe / tile-join container jobs. On `signalk-container >= 1.16.0` this kills the in-flight container and resolves the job as `cancelled`; older versions still degrade gracefully to stopping at a band boundary.
- The converter's `onProgress` is now gated on the cancel flag, and the route sets a `Cancelling…` detail immediately. This fixes a race where in-flight job output kept overwriting the "cancelling" state and bounced the UI back to "running" (it took multiple clicks to take).
- After a successful cancel, box colors revert correctly: a box is only shown "up to date" when `status === 'converted'` **and** the output MBTiles is actually present on disk.

## Live merge progress
The final `tile-join` step previously showed no progress at all (bar stuck at 0%, then done).

Root cause: `tile-join` emits no percentage — only bare `z/x/y` tile coordinates — and it **block-buffers** that output to stderr, flushing the entire sample only at process exit. So there is no usable streaming progress signal from its output (verified: a CPU-throttled join emits 0 bytes for its whole runtime, and this is unchanged under `stdbuf` or a PTY).

Instead this tracks the real signal: the output MBTiles **grows on disk** as tiles are inserted, and its final size is approximately the sum of the per-band intermediates (which have disjoint zoom ranges, so dedup is negligible). `runTileJoin` now polls the output file size and reports `size / expectedSize`, capped at 99% and snapped to 100% on exit — producing a smooth "Combining N tile sets" progress bar.

## Testing
- `npm run format && npm run lint && npm run build && npm test` — all green (352 tests).
- Manually exercised end-to-end against a live Signal K server with `signalk-container` 1.16.0: cancel aborts a running conversion cleanly and box colors revert; the combine bar climbs steadily through the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds cancellation support and live merge progress reporting for NOAA chart set conversions.

### Cancellation

Threads an `AbortSignal` from the `/custom-catalogs/:id/cancel` route through the S-57 conversion pipeline (GDAL, tippecanoe, tile-join) into container jobs. On signalk-container >= 1.16.0, the in-flight container is killed immediately and the job resolves with `status: 'cancelled'`. Earlier versions fall back to cooperative cancellation that checks between band conversions. The progress handler is gated by the cancel flag, and the cancel route immediately sets the UI detail to "Cancelling…" to prevent race conditions where in-flight output would overwrite the cancelling state. A new `registerCatalogAbort` function manages per-run abort controllers, and `requestCatalogCancel` now aborts the registered controller to terminate the container job.

### Live Merge Progress

Since tile-join provides no usable streaming percentage, progress is derived by polling the output MBTiles file size. Progress is reported as `size / expectedSize`, capped at 99% during runtime and snapped to 100% on completion, producing a smooth "Combining N tile sets" progress bar.

### Box State Freshness

Boxes are marked "up to date" only when both the catalog status is `'converted'` AND the output MBTiles file actually exists on disk, rather than relying solely on a non-null path reference. This ensures box colors revert correctly after cancellation.

### UI

The cancellation control is now shown for all phases, including the join/combine step, replacing the previous "can't be interrupted" message.

### Type Updates

- `S57ConversionOptions` now includes optional `signal?: AbortSignal` for immediate job termination (>= 1.16.0) and clarifies `isAborted` callback semantics for older versions
- `ContainerJobConfig` and `JobRunOptions` now support the optional `signal` field
- `ContainerJobResult.status` union expanded to include `'cancelled'`
- `boxStatesForCatalog` now takes an `mbtilesPresent` boolean parameter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->