### PR TITLE
chore(release): 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Minor release — two new features since 2.2.1.

## Highlights

- **NOAA Charts tab (#135)** — build a named ENC chart set by selecting NOAA band-4 coverage areas on a map; the overlapping band-3/5 cells are pulled in and converted in a single pass into one vector MBTiles. Per-box freshness is driven by NOAA edition comparison.
- **Mid-job cancel + live merge progress (#136)** — Cancel now aborts the running container (via signalk-container 1.16.0 abort support; older versions still degrade to band-boundary cancel), and the tile-join "combine" step shows a real progress bar derived from output file growth.

Bumps `package.json` to 2.3.0. Tagging `v2.3.0` after merge triggers `publish.yml`.