### PR TITLE
fix(convert): pass tippecanoe layers via a file, not a giant argv

### DIFF
--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -592,34 +592,69 @@ function withTippecanoeMinzoom(feature: unknown, minzoom: number): unknown {
   return { ...f, tippecanoe: { ...existing, minzoom } };
 }
 
-// Build tippecanoe `-L NAME:FILE` args (the simple form). Per-layer minzoom
-// is *not* settable via `-L` JSON — tippecanoe silently ignores `minzoom`
-// fields there. Per-band minzoom is therefore stamped onto each feature in
-// the consolidator (see `consolidateGeoJSONByLayer`), and tippecanoe honors
-// `feature.tippecanoe.minzoom` natively. This function is just the
-// container-relative path stitching.
-//
-// `inputPrefix` defaults to `/input` for backwards compat with existing
-// tests; it changes to `/input/<subPath>` when SignalK is on a named
-// volume that covers a parent dir of the merged-GeoJSON scratch.
-function buildLayerArgs(
+// tippecanoe takes its layers as `-L NAME:FILE` pairs (the simple form).
+// Per-layer minzoom is *not* settable via `-L` — tippecanoe silently ignores
+// `minzoom` fields there. Per-band minzoom is therefore stamped onto each
+// feature in the consolidator (see `consolidateGeoJSONByLayer`), and tippecanoe
+// honors `feature.tippecanoe.minzoom` natively.
+
+// Basename for the per-job layer manifest, written into the mounted /input
+// dir alongside the consolidated GeoJSON.
+const TIPPECANOE_LAYER_MANIFEST = '.tippecanoe-layers';
+
+// One `layerName:/input/file.geojson` line per consolidated layer — the same
+// pairs `-L` would take, as a newline-delimited file the container reads.
+// `inputPrefix` defaults to `/input`; it changes to `/input/<subPath>` when
+// SignalK is on a named volume that covers a parent dir of the scratch.
+function buildLayerManifest(
   layers: readonly ConsolidatedLayer[],
   inputPrefix: string = '/input'
+): string {
+  return (
+    layers
+      .map(({ file }) => {
+        const rel = path.basename(file);
+        const layer = path.basename(rel, '.geojson');
+        return `${layer}:${inputPrefix}/${rel}`;
+      })
+      .join('\n') + '\n'
+  );
+}
+
+// Build the tippecanoe invocation as a small `bash -c` script that reads the
+// `-L` layer pairs from the manifest at runtime, instead of inlining them into
+// argv. A large bundle has 100+ layers, so inlining produced a 200+ element
+// container `Cmd` (a multi-KB createContainer body) that old podman's
+// docker-compat socket rejects with `write EPIPE` (issue #132). Reading them
+// from a file keeps argv at a constant 3 elements regardless of layer count —
+// the same shape the GDAL export step already uses successfully.
+function buildTippecanoeCommand(
+  fixedArgs: readonly string[],
+  manifestContainerPath: string
 ): string[] {
-  const args: string[] = [];
-  for (const { file } of layers) {
-    const rel = path.basename(file);
-    const layer = path.basename(rel, '.geojson');
-    args.push('-L', `${layer}:${inputPrefix}/${rel}`);
-  }
-  return args;
+  // Single-quote for the shell so paths/flags with spaces survive
+  // word-splitting (the manifest path can carry a named-volume subPath, and
+  // chart dirs commonly contain spaces).
+  const sq = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
+  const quoted = fixedArgs.map(sq).join(' ');
+  const script = [
+    'set -e',
+    'layers=()',
+    `while IFS= read -r line; do`,
+    '  [ -n "$line" ] && layers+=(-L "$line")',
+    `done < ${sq(manifestContainerPath)}`,
+    `exec tippecanoe ${quoted} "\${layers[@]}"`
+  ].join('\n');
+  return ['bash', '-c', script];
 }
 
 export const _testInternals = {
   consolidateGeoJSONByLayer,
   buildExportScript,
   bandClampedMaxzoom,
-  buildLayerArgs,
+  buildLayerManifest,
+  buildTippecanoeCommand,
+  TIPPECANOE_LAYER_MANIFEST,
   surfaceExportErrorsIfEmpty
 };
 
@@ -668,7 +703,13 @@ async function runTippecanoe(
   const outputPrefix = resolved['/output'].subPath
     ? `/output/${resolved['/output'].subPath}`
     : '/output';
-  const layerArgs = buildLayerArgs(mergedLayers, inputPrefix);
+  // Write the layer list into the mounted /input dir; tippecanoe reads it at
+  // runtime so the container Cmd stays small (see buildTippecanoeCommand).
+  fs.writeFileSync(
+    path.join(mergedDir, TIPPECANOE_LAYER_MANIFEST),
+    buildLayerManifest(mergedLayers, inputPrefix)
+  );
+  const manifestContainerPath = `${inputPrefix}/${TIPPECANOE_LAYER_MANIFEST}`;
 
   // Log per-band layer breakdown so users can see why low-zoom features differ
   // by band. Counts plus a sample of layer names — full lists would be noisy
@@ -697,7 +738,7 @@ async function runTippecanoe(
 
   const tippecanoeThreads = getCpuBudget().tippecanoeThreadsPerJob;
   debug(
-    `Running tippecanoe with ${layerArgs.length / 2} consolidated layers, zoom ${minzoom}-${maxzoom}, ${tippecanoeThreads} threads`
+    `Running tippecanoe with ${mergedLayers.length} consolidated layers, zoom ${minzoom}-${maxzoom}, ${tippecanoeThreads} threads`
   );
 
   const handleTippecanoeLine = (line: string): void => {
@@ -715,31 +756,32 @@ async function runTippecanoe(
   const result = await runContainerJob({
     image: CHARTS_TOOLBOX_IMAGE,
     label: `tippecanoe-${chartNumber}`,
-    command: [
-      'tippecanoe',
-      '-o',
-      `${outputPrefix}/${path.basename(outputMbtiles)}`,
-      '-z',
-      String(maxzoom),
-      '-Z',
-      String(minzoom),
-      '--no-tile-size-limit',
-      '--no-feature-limit',
-      '--detect-shared-borders',
-      // Preserve coastline detail end-to-end. Tippecanoe's defaults aggressively
-      // simplify and drop tiny polygons at high zooms, which destroys the
-      // coastline indentations that define marina basins, inland lagoons, and
-      // narrow harbour features. Empirically the basin-as-land issue some NOAA
-      // bundles exhibit at z16 (Michigan City Outer Basin, Lake Worth) goes
-      // away when these defaults are off — the basin coastline is in the
-      // source data, simplification was destroying it. Larger tile buffer
-      // (80, default 5) keeps polygon edges that hug a tile boundary intact.
-      '--no-simplification',
-      '--no-tiny-polygon-reduction',
-      '--buffer=80',
-      '--force',
-      ...layerArgs
-    ],
+    command: buildTippecanoeCommand(
+      [
+        '-o',
+        `${outputPrefix}/${path.basename(outputMbtiles)}`,
+        '-z',
+        String(maxzoom),
+        '-Z',
+        String(minzoom),
+        '--no-tile-size-limit',
+        '--no-feature-limit',
+        '--detect-shared-borders',
+        // Preserve coastline detail end-to-end. Tippecanoe's defaults aggressively
+        // simplify and drop tiny polygons at high zooms, which destroys the
+        // coastline indentations that define marina basins, inland lagoons, and
+        // narrow harbour features. Empirically the basin-as-land issue some NOAA
+        // bundles exhibit at z16 (Michigan City Outer Basin, Lake Worth) goes
+        // away when these defaults are off — the basin coastline is in the
+        // source data, simplification was destroying it. Larger tile buffer
+        // (80, default 5) keeps polygon edges that hug a tile boundary intact.
+        '--no-simplification',
+        '--no-tiny-polygon-reduction',
+        '--buffer=80',
+        '--force'
+      ],
+      manifestContainerPath
+    ),
     inputs: { '/input': resolved['/input'].source },
     outputs: { '/output': resolved['/output'].source },
     env: { TIPPECANOE_MAX_THREADS: String(tippecanoeThreads) },

--- a/test/s57-converter.test.ts
+++ b/test/s57-converter.test.ts
@@ -15,7 +15,9 @@ const {
   consolidateGeoJSONByLayer,
   buildExportScript,
   bandClampedMaxzoom,
-  buildLayerArgs,
+  buildLayerManifest,
+  buildTippecanoeCommand,
+  TIPPECANOE_LAYER_MANIFEST,
   surfaceExportErrorsIfEmpty
 } = _testInternals;
 
@@ -432,35 +434,72 @@ describe('bandClampedMaxzoom (re-export from s57-converter._testInternals)', () 
   });
 });
 
-describe('buildLayerArgs (simple -L NAME:FILE form)', () => {
-  it('emits one -L LAYER:/input/LAYER.geojson pair per consolidated layer', () => {
+describe('buildLayerManifest (newline-delimited NAME:FILE form)', () => {
+  it('emits one LAYER:/input/LAYER.geojson line per consolidated layer', () => {
     const layers = [
       { file: '/some/host/path/HRBFAC.geojson', sourceFiles: ['HRBFAC_US5MA1SK.geojson'] },
       { file: '/some/host/path/LNDARE.geojson', sourceFiles: ['LNDARE_US3CO100.geojson'] }
     ];
-    const args = buildLayerArgs(layers);
-    assert.deepStrictEqual(args, [
-      '-L',
-      'HRBFAC:/input/HRBFAC.geojson',
-      '-L',
-      'LNDARE:/input/LNDARE.geojson'
-    ]);
+    assert.strictEqual(
+      buildLayerManifest(layers),
+      'HRBFAC:/input/HRBFAC.geojson\nLNDARE:/input/LNDARE.geojson\n'
+    );
   });
 
   it('uses the layer name from the merged file basename', () => {
     const layers = [{ file: '/anywhere/M_COVR.geojson', sourceFiles: ['M_COVR_US5MA1SK.geojson'] }];
-    assert.deepStrictEqual(buildLayerArgs(layers), ['-L', 'M_COVR:/input/M_COVR.geojson']);
+    assert.strictEqual(buildLayerManifest(layers), 'M_COVR:/input/M_COVR.geojson\n');
   });
 
   it('uses a custom inputPrefix for named-volume deployments', () => {
     // signalk-container resolves a named-volume mount: the whole volume is
     // mounted at /input and the consumer must navigate to the merged-GeoJSON
-    // dir via its subPath.  buildLayerArgs threads that into the -L args.
+    // dir via its subPath.  buildLayerManifest threads that into each line.
     const layers = [
       { file: '/some/host/path/HRBFAC.geojson', sourceFiles: ['HRBFAC_US5MA1SK.geojson'] }
     ];
-    const args = buildLayerArgs(layers, '/input/charts/scratch/.merged');
-    assert.deepStrictEqual(args, ['-L', 'HRBFAC:/input/charts/scratch/.merged/HRBFAC.geojson']);
+    assert.strictEqual(
+      buildLayerManifest(layers, '/input/charts/scratch/.merged'),
+      'HRBFAC:/input/charts/scratch/.merged/HRBFAC.geojson\n'
+    );
+  });
+});
+
+describe('buildTippecanoeCommand (argv stays small regardless of layer count)', () => {
+  it('returns a 3-element bash -c command that reads -L pairs from the manifest', () => {
+    const cmd = buildTippecanoeCommand(['-o', '/output/out.mbtiles', '-z', '14'], '/input/.layers');
+    assert.strictEqual(cmd.length, 3);
+    assert.strictEqual(cmd[0], 'bash');
+    assert.strictEqual(cmd[1], '-c');
+    // Reads the manifest (quoted), assembles -L args, execs tippecanoe.
+    assert.match(cmd[2], /< '\/input\/\.layers'/);
+    assert.match(cmd[2], /layers\+=\(-L "\$line"\)/);
+    assert.match(
+      cmd[2],
+      /exec tippecanoe '-o' '\/output\/out\.mbtiles' '-z' '14' "\$\{layers\[@\]\}"/
+    );
+  });
+
+  it('keeps argv length constant whether there are 2 or 200 layers', () => {
+    const small = buildTippecanoeCommand(['-o', '/output/out.mbtiles'], '/input/.layers');
+    // The manifest path is the only layer-derived input; the command is fixed.
+    assert.strictEqual(small.length, 3);
+  });
+
+  it('shell-quotes fixed args so paths with spaces survive', () => {
+    const cmd = buildTippecanoeCommand(['-o', '/out put/x.mbtiles'], '/input/.layers');
+    assert.match(cmd[2], /'\/out put\/x\.mbtiles'/);
+  });
+
+  it('quotes the manifest path so a named-volume subPath with spaces works', () => {
+    const cmd = buildTippecanoeCommand(['-o', '/output/out.mbtiles'], '/input/My Charts/.layers');
+    assert.match(cmd[2], /done < '\/input\/My Charts\/\.layers'/);
+  });
+
+  it('exports TIPPECANOE_LAYER_MANIFEST', () => {
+    assert.ok(
+      typeof TIPPECANOE_LAYER_MANIFEST === 'string' && TIPPECANOE_LAYER_MANIFEST.length > 0
+    );
   });
 });
 


### PR DESCRIPTION
## Why

A user converting a large inland-ENC bundle (20 cells → 104 layers) hit `tippecanoe: container runtime reported: write EPIPE`, with the conversion failing before tippecanoe ran (issue #132). The GDAL export step in the same job — same image, same socket, same CPU limit — succeeded.

Root cause: the 104 layers became 200+ inline `-L` args, producing a ~220-element container `Cmd` (a multi-KB `createContainer` body). Old podman (the reporter is on 4.3.1) resets the docker-compat socket on that request (`write EPIPE`) before the container is created. Current podman handles it, which is why it only reproduces on older hosts.

## Approach

Write the layer list to a `.tippecanoe-layers` manifest in the mounted `/input` dir and run tippecanoe via `bash -c`, reading the `-L` pairs from the file at runtime. The container `Cmd` is now a constant 3 elements regardless of layer count — the same shape the GDAL export step already uses successfully. The emitted tile output is unchanged.

The manifest path is shell-quoted so a named-volume subPath (or a chart dir with spaces) survives word-splitting.

## Tested

- `npm run format` / `npm run build` / `npm run test` — 357 tests pass (new `buildLayerManifest` / `buildTippecanoeCommand` cases, incl. a spaced-path manifest)
- Live-verified against a real podman + the toolbox image: the generated `bash -c` script reads the manifest and produces a real MBTiles, including with a manifest path containing spaces (`/input/My Charts/...`)
- `cr review --plain` — no findings

Refs #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Refactors tippecanoe layer invocation to pass layer specifications via a manifest file instead of inline command arguments, fixing compatibility issues with older podman versions that fail when handling large container commands.

## Changes

**src/utils/s57-converter.ts:**
- Adds `TIPPECANOE_LAYER_MANIFEST` constant for the `.tippecanoe-layers` manifest filename
- Introduces `buildLayerManifest()` to generate newline-delimited manifest content in the format `LAYER:/input/file.geojson`
- Introduces `buildTippecanoeCommand()` to construct a fixed 3-element `bash -c` command that reads layer entries from the quoted manifest file at runtime and builds tippecanoe `-L` arguments
- Updates `runTippecanoe` to write the manifest to the GeoJSON scratch directory and invoke tippecanoe via the new command builder instead of spreading layer arguments into argv
- Modifies debug/progress logging to report consolidated layer count based on `mergedLayers.length`
- Removes `buildLayerArgs` from test internals and exports the new helper functions

**test/s57-converter.test.ts:**
- Adds unit tests for `buildLayerManifest()` validating correct newline-delimited output format and layer-name extraction from consolidated filenames
- Adds tests for custom `inputPrefix` handling to support named-volume deployments
- Adds unit tests for `buildTippecanoeCommand()` verifying it returns a fixed-size 3-element command with proper manifest file quoting and space-handling
- Adds assertion validating `TIPPECANOE_LAYER_MANIFEST` is exported as a non-empty string

## Validation

- All 357 tests pass including new test cases for the layer manifest and tippecanoe command builders
- Live testing with podman + toolbox image produces valid MBTiles with manifest paths containing spaces
- Reduces container `Cmd` to a constant 3-element form regardless of layer count, preventing EPIPE errors from oversized commands on older podman versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->