### PR TITLE
chore(release): 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Patch release shipping the EPIPE fix from #138.

## Included since 2.3.0

- **fix(convert): pass tippecanoe layers via a file, not a giant argv (#138)** — large ENC bundles (100+ layers) no longer inline 200+ `-L` args into the container command. The layer list goes through a `.tippecanoe-layers` manifest read inside the container, keeping the command a constant 3 elements. Fixes `write EPIPE` at container create on older podman (issue #132).

Bumps `package.json` to 2.3.1. Tagging `v2.3.1` after merge triggers `publish.yml`.