### PR TITLE
feat: synthesize missing vector tiles from nearest ancestor (overzoom fallback)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ cr-review*
 # samples
 samples/
 
-# Generated test fixture — rebuilt by pretest via test/fixtures/create-test-mbtiles.js
+# Generated test fixtures — rebuilt by pretest via test/fixtures/create-test-*.cjs
 test/fixtures/test-chart.mbtiles
+test/fixtures/test-vector-chart.mbtiles

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:public": "tsc -p tsconfig.public.json",
     "pretest": "npm run build && npm run build:tests && npm run test:fixtures",
     "test": "node --test --test-force-exit dist-test/**/*.test.js",
-    "test:fixtures": "node test/fixtures/create-test-mbtiles.cjs",
+    "test:fixtures": "node test/fixtures/create-test-mbtiles.cjs && node test/fixtures/create-test-vector-mbtiles.cjs",
     "test:e2e": "npm run build && npm run build:e2e && playwright test",
     "lint": "eslint src test e2e public/js playwright.config.ts",
     "lint:fix": "eslint src test e2e public/js playwright.config.ts --fix",
@@ -38,10 +38,14 @@
     "name": "Dirk Wahrheit"
   },
   "dependencies": {
+    "@mapbox/vector-tile": "^2.0.5",
     "@signalk/server-api": "^2.0.0",
     "@sinclair/typebox": "^0.34.49",
     "busboy": "^1.6.0",
+    "geojson-vt": "^3.2.1",
+    "pbf": "^4.0.2",
     "unzipper": "^0.12.3",
+    "vt-pbf": "^3.1.3",
     "xml2js": "^0.6.2"
   },
   "repository": {
@@ -88,6 +92,8 @@
     "@playwright/test": "^1.59.1",
     "@types/busboy": "^1.5.4",
     "@types/express": "^5.0.3",
+    "@types/geojson": "^7946.0.16",
+    "@types/geojson-vt": "^3.2.5",
     "@types/leaflet": "^1.9.12",
     "@types/node": "^22.15.0",
     "@types/unzipper": "^0.10.11",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import { scanAllFolders, scanChartsRecursively } from './utils/file-scanner.js';
 import { repairMbtilesMetadata, setMbtilesDisplayName } from './utils/mbtiles-metadata.js';
 import { open as openMbtilesReader } from './utils/mbtiles-reader.js';
 import { writeChartPathMarker } from './utils/path-marker.js';
+import { getOverzoomedTile } from './utils/tile-overzoom.js';
 import { arePairWithinBase, isWithinBase, validateChartName } from './utils/path-safety.js';
 import { parsePluginConfig } from './utils/plugin-config-schema.js';
 import {
@@ -3651,6 +3652,22 @@ const serveTileFromMbtiles = (
     const result = provider._mbtilesHandle?.getTile(z, x, y) ?? null;
 
     if (!result) {
+      // Combined NOAA chart sets have spatially varying max zoom (per-band
+      // bounds + zoom ranges merged by tile-join), so clients legitimately
+      // request tiles in coverage holes the advertised zoom range implies
+      // should exist. Re-slice the nearest ancestor instead of 404ing black.
+      if (provider.format === 'pbf' && provider._mbtilesHandle) {
+        const synthesized = getOverzoomedTile(provider._mbtilesHandle, z, x, y);
+        if (synthesized) {
+          res.writeHead(200, {
+            'Content-Type': 'application/x-protobuf',
+            'Content-Encoding': 'gzip',
+            'Cache-Control': responseHttpOptions.headers['Cache-Control']
+          });
+          res.end(synthesized);
+          return;
+        }
+      }
       res.sendStatus(404);
     } else {
       const headers = {

--- a/src/types/vt-pbf.d.ts
+++ b/src/types/vt-pbf.d.ts
@@ -1,0 +1,10 @@
+// vt-pbf ships no type declarations (and none exist on DefinitelyTyped).
+// Only the one function the overzoom path uses is declared; layer values are
+// geojson-vt tiles, typed structurally so this shim stays decoupled from
+// geojson-vt's types.
+declare module 'vt-pbf' {
+  export function fromGeojsonVt(
+    layers: Record<string, { features: unknown[] }>,
+    options?: { version?: number; extent?: number }
+  ): Uint8Array;
+}

--- a/src/utils/mbtiles-reader.ts
+++ b/src/utils/mbtiles-reader.ts
@@ -124,7 +124,8 @@ export class MBTilesReader {
     return metadata;
   }
 
-  getTile(z: number, x: number, y: number): TileResult | null {
+  /** Raw tile blob for XYZ coordinates (TMS flip applied), without HTTP headers. */
+  getRawTile(z: number, x: number, y: number): Buffer | null {
     if (!this.db) {
       throw new Error('Database is closed');
     }
@@ -150,7 +151,16 @@ export class MBTilesReader {
     // not. For a 200KB pbf tile that's 200KB of malloc+memcpy avoided
     // per request — material at Freeboard pan/zoom rates.
     const u = row.tile_data;
-    const data = Buffer.from(u.buffer, u.byteOffset, u.byteLength);
+    return Buffer.from(u.buffer, u.byteOffset, u.byteLength);
+  }
+
+  getTile(z: number, x: number, y: number): TileResult | null {
+    const data = this.getRawTile(z, x, y);
+
+    if (!data) {
+      return null;
+    }
+
     const metadata = this.getInfo();
     const format = metadata.format ?? 'png';
 

--- a/src/utils/tile-overzoom.ts
+++ b/src/utils/tile-overzoom.ts
@@ -1,0 +1,256 @@
+/**
+ * Serve-time overzoom fallback for vector (pbf) MBTiles.
+ *
+ * Chart sets combined from multiple ENC bands (tippecanoe + tile-join) have
+ * spatially varying max zoom: in areas covered only by a low band, tiles for
+ * the advertised deeper zooms don't exist, so clients render black instead of
+ * overzooming (OpenLayers/MapLibre only overzoom past the advertised maxzoom,
+ * never for mid-pyramid holes). When a pbf tile is missing, this module walks
+ * up the ancestor pyramid and re-slices the nearest existing ancestor MVT into
+ * the requested child tile — lossless for vector data, so clients render it
+ * exactly like native overzoom.
+ *
+ * Nothing is written back to the MBTiles; synthesis is on demand with two
+ * in-memory LRUs per reader. The first miss touching an ancestor pays one
+ * decode+index (~30–300 ms); further children of the same ancestor are served
+ * from cache in ~1 ms.
+ */
+
+import { gunzipSync, gzipSync } from 'node:zlib';
+import Pbf from 'pbf';
+import { VectorTile } from '@mapbox/vector-tile';
+import geojsonvt from 'geojson-vt';
+import { fromGeojsonVt } from 'vt-pbf';
+import type { Feature } from 'geojson';
+import type { MBTilesReader } from './mbtiles-reader.js';
+
+// Must span the band ceilings the S-57 pipeline can combine: BAND_MAX_ZOOM
+// runs z8 (band 1) to z18 (band 6), so a band-1-only area of a full-district
+// set needs delta 10 at the deepest advertised zoom. Walk cost doesn't scale
+// with delta (one indexed SELECT per probe).
+export const MAX_OVERZOOM_DELTA = 10;
+
+// geojson-vt indexes keep growing after construction: every getTile() caches
+// the intermediate tiles it materializes and never evicts. Measured on the
+// largest hole-adjacent ancestor in a real combined set (157 KB gzipped MVT):
+// ~7 MB at build, ~15 MB after a 60-tile pan. Typical band-edge ancestors are
+// ≤70 KB (~2 MB indexes). The caps below bound the worst case to tens of MB:
+// 4 index slots, and each entry is dropped (rebuilt on next miss) after
+// INDEX_SLICE_BUDGET slices so a long pan can't grow one entry unboundedly.
+const INDEX_CACHE_SIZE = 4;
+const INDEX_SLICE_BUDGET = 64;
+
+// Stored (gzipped) ancestors beyond this size would index into hundreds of MB
+// (tippecanoe runs with --no-tile-size-limit). Real hole-adjacent ancestors
+// measure ≤160 KB; anything bigger keeps today's 404 rather than risking an
+// OOM on small-RAM hosts.
+const MAX_ANCESTOR_BYTES = 256 * 1024;
+
+const TILE_CACHE_SIZE = 256;
+
+class LruMap<K, V> {
+  private readonly map = new Map<K, V>();
+
+  constructor(private readonly capacity: number) {}
+
+  get(key: K): V | undefined {
+    if (!this.map.has(key)) {
+      return undefined;
+    }
+    const value = this.map.get(key) as V;
+    this.map.delete(key);
+    this.map.set(key, value);
+    return value;
+  }
+
+  set(key: K, value: V): void {
+    this.map.delete(key);
+    this.map.set(key, value);
+    if (this.map.size > this.capacity) {
+      const oldest = this.map.keys().next();
+      if (!oldest.done) {
+        this.map.delete(oldest.value);
+      }
+    }
+  }
+
+  delete(key: K): void {
+    this.map.delete(key);
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+}
+
+interface AncestorEntry {
+  // One geojson-vt index per source layer; empty when the ancestor was
+  // skipped as oversized (children then resolve to null/404 naturally).
+  indexes: Map<string, ReturnType<typeof geojsonvt>>;
+  slices: number;
+}
+
+interface OverzoomState {
+  indexes: LruMap<string, AncestorEntry>;
+  // Cached nulls matter: empty ocean quadrants inside ancestor coverage get
+  // hammered while panning and must not re-slice on every request.
+  tiles: LruMap<string, Buffer | null>;
+}
+
+// Keyed by reader instance: chart reload/rename/delete builds fresh readers,
+// so stale entries are unreachable and collected without explicit eviction.
+const states = new WeakMap<MBTilesReader, OverzoomState>();
+
+function getState(reader: MBTilesReader): OverzoomState {
+  let state = states.get(reader);
+  if (!state) {
+    state = {
+      indexes: new LruMap(INDEX_CACHE_SIZE),
+      tiles: new LruMap(TILE_CACHE_SIZE)
+    };
+    states.set(reader, state);
+  }
+  return state;
+}
+
+/** Test hook: cache occupancy for a reader (entries, not bytes). */
+export function _overzoomCacheStats(reader: MBTilesReader): { indexes: number; tiles: number } {
+  const state = states.get(reader);
+  return { indexes: state?.indexes.size ?? 0, tiles: state?.tiles.size ?? 0 };
+}
+
+function buildAncestorEntry(raw: Buffer, az: number, ax: number, ay: number): AncestorEntry {
+  const indexes: AncestorEntry['indexes'] = new Map();
+
+  if (raw.byteLength > MAX_ANCESTOR_BYTES) {
+    console.warn(
+      `Overzoom: ancestor tile ${az}/${ax}/${ay} is ${raw.byteLength} bytes ` +
+        `(> ${MAX_ANCESTOR_BYTES}); descendants keep returning 404`
+    );
+    return { indexes, slices: 0 };
+  }
+
+  const bytes = raw[0] === 0x1f && raw[1] === 0x8b ? gunzipSync(raw) : raw;
+  const tile = new VectorTile(new Pbf(bytes));
+
+  for (const [name, layer] of Object.entries(tile.layers)) {
+    if (layer.length === 0) {
+      continue;
+    }
+    const features: Feature[] = [];
+    for (let i = 0; i < layer.length; i++) {
+      features.push(layer.feature(i).toGeoJSON(ax, ay, az));
+    }
+    indexes.set(
+      name,
+      // maxZoom: 24 is required — geojson-vt's default of 14 makes getTile()
+      // silently return null for deeper children. tolerance 3 (the default)
+      // simplifies the intermediate drill-down tiles; at the requested zoom
+      // it is ~3/4096 of a tile, below what the ancestor's own quantization
+      // already lost, and it nearly halves index memory vs tolerance 0.
+      geojsonvt(
+        { type: 'FeatureCollection', features },
+        { maxZoom: 24, indexMaxZoom: 0, tolerance: 3, buffer: 64, extent: 4096 }
+      )
+    );
+  }
+
+  return { indexes, slices: 0 };
+}
+
+/**
+ * Synthesize a missing pbf tile from the nearest existing ancestor.
+ * Returns a gzipped MVT buffer, or null when the chart is not pbf, the
+ * nearest ancestor is more than MAX_OVERZOOM_DELTA levels up (or none exists
+ * at all — genuinely outside coverage), or the child quadrant is empty — all
+ * of which should keep today's 404.
+ */
+export function getOverzoomedTile(
+  reader: MBTilesReader,
+  z: number,
+  x: number,
+  y: number
+): Buffer | null {
+  try {
+    const info = reader.getInfo();
+    if (info.format !== 'pbf') {
+      return null;
+    }
+    const minzoom = info.minzoom ?? 0;
+    if (z <= minzoom) {
+      return null;
+    }
+
+    const state = getState(reader);
+    const tileKey = `${z}/${x}/${y}`;
+    const cached = state.tiles.get(tileKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    // Levels above the advertised maxzoom hold no tiles; start probing below.
+    const maxzoom = info.maxzoom ?? z - 1;
+    const dStart = Math.max(1, z - maxzoom);
+
+    let entry: AncestorEntry | undefined;
+    let entryKey = '';
+    for (let d = dStart; d <= MAX_OVERZOOM_DELTA; d++) {
+      const az = z - d;
+      if (az < minzoom) {
+        break;
+      }
+      const ax = x >> d;
+      const ay = y >> d;
+      entryKey = `${az}/${ax}/${ay}`;
+      entry = state.indexes.get(entryKey);
+      if (entry) {
+        break;
+      }
+      const raw = reader.getRawTile(az, ax, ay);
+      if (raw) {
+        entry = buildAncestorEntry(raw, az, ax, ay);
+        state.indexes.set(entryKey, entry);
+        break;
+      }
+    }
+
+    if (!entry) {
+      state.tiles.set(tileKey, null);
+      return null;
+    }
+
+    const layers: Record<string, { features: unknown[] }> = {};
+    let hasFeatures = false;
+    for (const [name, index] of entry.indexes) {
+      const sliced = index.getTile(z, x, y);
+      if (sliced && sliced.features.length > 0) {
+        layers[name] = sliced;
+        hasFeatures = true;
+      }
+    }
+
+    // geojson-vt retains every intermediate tile a slice materializes, so an
+    // entry grows with use; retire it after a budget of slices and let the
+    // next miss rebuild it fresh (already-synthesized children stay cached).
+    entry.slices++;
+    if (entry.slices >= INDEX_SLICE_BUDGET) {
+      state.indexes.delete(entryKey);
+    }
+
+    if (!hasFeatures) {
+      state.tiles.set(tileKey, null);
+      return null;
+    }
+
+    // version: 2 is required — vt-pbf defaults to MVT v1, tippecanoe emits v2.
+    const encoded = fromGeojsonVt(layers, { version: 2, extent: 4096 });
+    const result = gzipSync(encoded);
+    state.tiles.set(tileKey, result);
+    return result;
+  } catch (err) {
+    // A corrupt ancestor must degrade to 404, never bubble into the route's
+    // 500 path. Not cached so a transient failure can recover.
+    console.error(`Error synthesizing overzoom tile ${z}/${x}/${y}:`, err);
+    return null;
+  }
+}

--- a/test/fixtures/create-test-vector-mbtiles.cjs
+++ b/test/fixtures/create-test-vector-mbtiles.cjs
@@ -1,0 +1,136 @@
+/**
+ * Script to create a minimal vector (pbf) test MBTiles file for the
+ * tile-overzoom tests. The pyramid intentionally has holes: metadata
+ * advertises minzoom=2..maxzoom=16 but only four tiles exist — the same
+ * shape as a combined NOAA chart set where deep zooms are missing in areas
+ * covered only by a low band.
+ *
+ *   z2 XYZ (0,1)   point 'test-buoy' (id 42) + polygon (layer `areas`)
+ *   z3 XYZ (0,3)   point 'z3-buoy'   (id 43), same lon/lat — lets tests pin
+ *                  that synthesis picks the NEAREST ancestor, not just any
+ *   z8 XYZ (56,86) point 'z8-buoy'   (id 88) far from the others — lets tests
+ *                  synthesize a z15 child (deep targets pin geojson-vt's
+ *                  maxZoom option, whose default 14 would return null)
+ *   z2 XYZ (1,1)   corrupt gzip bytes — synthesis from it must degrade to
+ *                  null, never throw
+ *
+ * Tile contents are independent per tile (no real pyramid consistency); the
+ * overzoom module only ever reads one ancestor at a time, so that's fine.
+ * Run with: node test/fixtures/create-test-vector-mbtiles.cjs
+ */
+
+const { DatabaseSync } = require('node:sqlite');
+const path = require('path');
+const fs = require('fs');
+const { gzipSync } = require('node:zlib');
+const geojsonvt = require('geojson-vt');
+const vtpbf = require('vt-pbf');
+
+const outputPath = path.join(__dirname, 'test-vector-chart.mbtiles');
+
+if (fs.existsSync(outputPath)) {
+  fs.unlinkSync(outputPath);
+}
+
+const db = new DatabaseSync(outputPath);
+
+db.exec(`
+  CREATE TABLE metadata (name TEXT, value TEXT);
+  CREATE TABLE tiles (zoom_level INTEGER, tile_column INTEGER, tile_row INTEGER, tile_data BLOB);
+  CREATE UNIQUE INDEX tile_index ON tiles (zoom_level, tile_column, tile_row);
+`);
+
+const insertMetadata = db.prepare('INSERT INTO metadata (name, value) VALUES (?, ?)');
+insertMetadata.run('name', 'Test Vector Chart');
+insertMetadata.run('description', 'A vector test chart with pyramid holes');
+insertMetadata.run('format', 'pbf');
+// z2 tile (0,1) footprint; bounds are required or charts-loader rejects the file
+insertMetadata.run('bounds', '-180,0,-90,66.51');
+insertMetadata.run('minzoom', '2');
+// Advertised far deeper than any stored tile, like a real combined set.
+insertMetadata.run('maxzoom', '16');
+insertMetadata.run('type', 'overlay');
+insertMetadata.run('json', JSON.stringify({ vector_layers: [{ id: 'points' }, { id: 'areas' }] }));
+
+// The point sits at ~25% of the z2 tile's width (~49% of its z3 child's), so
+// child-quadrant assertions at z3 are unambiguous (well clear of the 64/4096
+// buffer spill into sibling tiles). The polygon must be ±0.5° — anything much
+// smaller collapses to nothing at z2, where one extent unit is ~0.022° and
+// geojson-vt simplifies below its 3-unit tolerance.
+const POINT_LON = -157.9;
+const POINT_LAT = 21.4;
+const AREA_HALF_WIDTH = 0.5;
+// In z8 tile XYZ (56,86); its z15 descendant containing the point is (7281,11113).
+const DEEP_LON = -100;
+const DEEP_LAT = 50;
+
+function pointFc(id, name, lon, lat) {
+  return {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        id,
+        properties: { name, kind: 'buoy' },
+        geometry: { type: 'Point', coordinates: [lon, lat] }
+      }
+    ]
+  };
+}
+
+const areaFc = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      id: 7,
+      properties: { kind: 'anchorage' },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [POINT_LON - AREA_HALF_WIDTH, POINT_LAT - AREA_HALF_WIDTH],
+            [POINT_LON + AREA_HALF_WIDTH, POINT_LAT - AREA_HALF_WIDTH],
+            [POINT_LON + AREA_HALF_WIDTH, POINT_LAT + AREA_HALF_WIDTH],
+            [POINT_LON - AREA_HALF_WIDTH, POINT_LAT + AREA_HALF_WIDTH],
+            [POINT_LON - AREA_HALF_WIDTH, POINT_LAT - AREA_HALF_WIDTH]
+          ]
+        ]
+      }
+    }
+  ]
+};
+
+const vtOptions = { maxZoom: 10, indexMaxZoom: 0, buffer: 64, extent: 4096 };
+
+function makeTile(layersSpec, z, x, y) {
+  const layers = {};
+  for (const [layerName, fc] of Object.entries(layersSpec)) {
+    const tile = geojsonvt(fc, vtOptions).getTile(z, x, y);
+    if (!tile) {
+      throw new Error(`Fixture generation failed: no features in ${layerName} at ${z}/${x}/${y}`);
+    }
+    layers[layerName] = tile;
+  }
+  return gzipSync(Buffer.from(vtpbf.fromGeojsonVt(layers, { version: 2 })));
+}
+
+const insertTile = db.prepare(
+  'INSERT INTO tiles (zoom_level, tile_column, tile_row, tile_data) VALUES (?, ?, ?, ?)'
+);
+const insertXyz = (z, x, y, data) => insertTile.run(z, x, (1 << z) - 1 - y, data);
+
+insertXyz(
+  2,
+  0,
+  1,
+  makeTile({ points: pointFc(42, 'test-buoy', POINT_LON, POINT_LAT), areas: areaFc }, 2, 0, 1)
+);
+insertXyz(3, 0, 3, makeTile({ points: pointFc(43, 'z3-buoy', POINT_LON, POINT_LAT) }, 3, 0, 3));
+insertXyz(8, 56, 86, makeTile({ points: pointFc(88, 'z8-buoy', DEEP_LON, DEEP_LAT) }, 8, 56, 86));
+// Corrupt tile: valid gzip magic, garbage body.
+insertXyz(2, 1, 1, Buffer.from([0x1f, 0x8b, 0xde, 0xad, 0xbe, 0xef, 0x00, 0x01, 0x02, 0x03]));
+
+db.close();
+
+console.log(`Created test vector MBTiles file: ${outputPath}`);

--- a/test/mbtiles-reader.test.ts
+++ b/test/mbtiles-reader.test.ts
@@ -157,6 +157,19 @@ describe('MBTilesReader', () => {
     });
   });
 
+  describe('getRawTile()', () => {
+    it('returns the same bytes getTile() serves', () => {
+      const raw = reader.getRawTile(0, 0, 0);
+      const served = reader.getTile(0, 0, 0);
+      assert.ok(raw && served);
+      assert.deepStrictEqual(raw, served.data);
+    });
+
+    it('returns null for non-existing tile', () => {
+      assert.strictEqual(reader.getRawTile(10, 999, 999), null);
+    });
+  });
+
   describe('close()', () => {
     it('should close database without error', () => {
       const tempReader = new MBTilesReader(TEST_MBTILES);

--- a/test/tile-overzoom.test.ts
+++ b/test/tile-overzoom.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for serve-time overzoom synthesis from vector MBTiles.
+ *
+ * The fixture (create-test-vector-mbtiles.cjs) advertises minzoom=2,
+ * maxzoom=16 but contains only four tiles: z2 (0,1) with 'test-buoy' (id 42)
+ * + an `areas` polygon, z3 (0,3) with 'z3-buoy' (id 43) at the same lon/lat,
+ * z8 (56,86) with 'z8-buoy' (id 88) far away, and a corrupt-gzip z2 (1,1).
+ * That reproduces the pyramid holes of a combined NOAA chart set: deep
+ * requests inside coverage must synthesize from the NEAREST ancestor,
+ * requests outside coverage must keep returning null (→ 404).
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { gunzipSync } from 'node:zlib';
+
+import Pbf from 'pbf';
+import { VectorTile } from '@mapbox/vector-tile';
+import type { Feature, Point } from 'geojson';
+
+import { MBTilesReader } from '../dist/utils/mbtiles-reader.js';
+import {
+  getOverzoomedTile,
+  MAX_OVERZOOM_DELTA,
+  _overzoomCacheStats
+} from '../dist/utils/tile-overzoom.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const VECTOR_MBTILES = path.join(__dirname, '..', 'test', 'fixtures', 'test-vector-chart.mbtiles');
+const RASTER_MBTILES = path.join(__dirname, '..', 'test', 'fixtures', 'test-chart.mbtiles');
+
+const POINT_LON = -157.9;
+const POINT_LAT = 21.4;
+const DEEP_LON = -100;
+const DEEP_LAT = 50;
+// One MVT extent unit at z3 ≈ 0.011°; allow generous slack for geojson-vt
+// rounding on top of quantization.
+const TOLERANCE_DEG = 0.05;
+
+function decode(tile: Buffer): VectorTile {
+  assert.strictEqual(tile[0], 0x1f, 'synthesized tile must be gzipped');
+  assert.strictEqual(tile[1], 0x8b, 'synthesized tile must be gzipped');
+  return new VectorTile(new Pbf(gunzipSync(tile)));
+}
+
+function pointCoords(vt: VectorTile, x: number, y: number, z: number): [number, number] {
+  const geo = vt.layers.points.feature(0).toGeoJSON(x, y, z) as Feature<Point>;
+  return [geo.geometry.coordinates[0], geo.geometry.coordinates[1]];
+}
+
+describe('getOverzoomedTile()', () => {
+  let reader!: MBTilesReader;
+
+  before(() => {
+    reader = new MBTilesReader(VECTOR_MBTILES);
+  });
+
+  after(() => {
+    reader?.close();
+  });
+
+  it('synthesizes a child tile one level below the ancestor', () => {
+    const tile = getOverzoomedTile(reader, 3, 0, 3);
+    assert.ok(tile, 'child quadrant containing the point should synthesize');
+
+    const vt = decode(tile);
+    assert.ok(vt.layers.points, 'points layer should survive re-slicing');
+    assert.ok(vt.layers.areas, 'areas layer should survive re-slicing');
+    assert.strictEqual(vt.layers.points.version, 2, 'must emit MVT v2 like tippecanoe');
+
+    const feature = vt.layers.points.feature(0);
+    assert.strictEqual(feature.id, 42, 'feature id should survive');
+    assert.strictEqual(feature.properties.name, 'test-buoy');
+    assert.strictEqual(feature.properties.kind, 'buoy');
+
+    const [lon, lat] = pointCoords(vt, 0, 3, 3);
+    assert.ok(
+      Math.abs(lon - POINT_LON) < TOLERANCE_DEG,
+      `lon should round-trip (got ${lon}, want ~${POINT_LON})`
+    );
+    assert.ok(
+      Math.abs(lat - POINT_LAT) < TOLERANCE_DEG,
+      `lat should round-trip (got ${lat}, want ~${POINT_LAT})`
+    );
+  });
+
+  it('slices from the NEAREST ancestor, not just any', () => {
+    // z4 (0,7) has two candidate ancestors: z3 (0,3) and z2 (0,1). The z3
+    // tile must win — it carries 'z3-buoy' and has no `areas` layer.
+    const tile = getOverzoomedTile(reader, 4, 0, 7);
+    assert.ok(tile, 'z4 child should synthesize');
+
+    const vt = decode(tile);
+    const feature = vt.layers.points.feature(0);
+    assert.strictEqual(feature.properties.name, 'z3-buoy', 'must slice from z3, not z2');
+    assert.strictEqual(feature.id, 43);
+    assert.strictEqual(vt.layers.areas, undefined, 'z2 content must not leak in');
+
+    const [lon, lat] = pointCoords(vt, 0, 7, 4);
+    assert.ok(Math.abs(lon - POINT_LON) < TOLERANCE_DEG);
+    assert.ok(Math.abs(lat - POINT_LAT) < TOLERANCE_DEG);
+  });
+
+  it('synthesizes deep targets (z15) — pins the geojson-vt maxZoom option', () => {
+    // geojson-vt's DEFAULT maxZoom is 14: without the explicit maxZoom: 24 in
+    // buildAncestorEntry, any synthesis target deeper than z14 silently
+    // returns null. Real combined sets advertise maxzoom 16+, so this is the
+    // production shape: z15 request, nearest ancestor at z8 (delta 7).
+    const tile = getOverzoomedTile(reader, 15, 7281, 11113);
+    assert.ok(tile, 'z15 child of the z8 ancestor should synthesize');
+
+    const vt = decode(tile);
+    const feature = vt.layers.points.feature(0);
+    assert.strictEqual(feature.properties.name, 'z8-buoy');
+    assert.strictEqual(feature.id, 88);
+
+    const [lon, lat] = pointCoords(vt, 7281, 11113, 15);
+    assert.ok(Math.abs(lon - DEEP_LON) < TOLERANCE_DEG);
+    assert.ok(Math.abs(lat - DEEP_LAT) < TOLERANCE_DEG);
+  });
+
+  it('returns null for empty sibling quadrants of an existing ancestor', () => {
+    assert.strictEqual(getOverzoomedTile(reader, 3, 1, 3), null);
+    assert.strictEqual(getOverzoomedTile(reader, 3, 0, 2), null);
+    assert.strictEqual(getOverzoomedTile(reader, 3, 1, 2), null);
+  });
+
+  it('returns null outside ancestor coverage', () => {
+    assert.strictEqual(getOverzoomedTile(reader, 3, 7, 7), null);
+  });
+
+  it('returns null at or below minzoom', () => {
+    assert.strictEqual(getOverzoomedTile(reader, 2, 0, 1), null);
+    assert.strictEqual(getOverzoomedTile(reader, 1, 0, 0), null);
+  });
+
+  it('synthesizes up to MAX_OVERZOOM_DELTA levels and no further', () => {
+    // The S-57 pipeline can combine band 1 (ceiling z8) with band 6 (z18),
+    // so the cap must span at least 10 levels.
+    assert.strictEqual(MAX_OVERZOOM_DELTA, 10);
+    // z13 (502,3597) → nearest ancestor z3 (0,3), delta exactly 10.
+    const within = getOverzoomedTile(reader, 13, 502, 3597);
+    assert.ok(within, 'delta 10 should synthesize');
+    const vt = decode(within);
+    assert.strictEqual(vt.layers.points.feature(0).properties.name, 'z3-buoy');
+    // z14 (1005,7194) would need delta 11 to reach z3.
+    assert.strictEqual(getOverzoomedTile(reader, 14, 1005, 7194), null);
+  });
+
+  it('degrades to null (not a throw) on a corrupt ancestor', () => {
+    // z2 (1,1) holds gzip magic followed by garbage.
+    let result: Buffer | null = null;
+    assert.doesNotThrow(() => {
+      result = getOverzoomedTile(reader, 3, 2, 2);
+    });
+    assert.strictEqual(result, null);
+  });
+
+  it('caches synthesized tiles, nulls, and ancestor indexes per reader', () => {
+    const fresh = new MBTilesReader(VECTOR_MBTILES);
+    try {
+      const rawCalls: Array<[number, number, number]> = [];
+      const realGetRawTile = fresh.getRawTile.bind(fresh);
+      fresh.getRawTile = (z: number, x: number, y: number) => {
+        rawCalls.push([z, x, y]);
+        return realGetRawTile(z, x, y);
+      };
+
+      const first = getOverzoomedTile(fresh, 3, 0, 3);
+      assert.ok(first);
+      assert.deepStrictEqual(rawCalls, [[2, 0, 1]], 'first synthesis reads the ancestor once');
+
+      const repeat = getOverzoomedTile(fresh, 3, 0, 3);
+      assert.strictEqual(repeat, first, 'repeat request returns the cached Buffer instance');
+      assert.strictEqual(rawCalls.length, 1, 'repeat request does no raw reads');
+
+      assert.ok(getOverzoomedTile(fresh, 4, 0, 7));
+      assert.deepStrictEqual(
+        rawCalls,
+        [
+          [2, 0, 1],
+          [3, 0, 3]
+        ],
+        'a different ancestor is read once, the z2 index is not re-read'
+      );
+
+      assert.strictEqual(getOverzoomedTile(fresh, 4, 0, 6), null, 'empty quadrant of z3');
+      assert.strictEqual(
+        rawCalls.length,
+        2,
+        'empty quadrant slices from the cached index without raw reads'
+      );
+
+      const stats = _overzoomCacheStats(fresh);
+      assert.strictEqual(stats.indexes, 2, 'both ancestor indexes cached');
+      assert.strictEqual(stats.tiles, 3, 'two tiles plus one null cached');
+
+      assert.strictEqual(getOverzoomedTile(fresh, 4, 0, 6), null);
+      assert.strictEqual(rawCalls.length, 2, 'null results are cached too');
+      assert.deepStrictEqual(_overzoomCacheStats(fresh), stats);
+    } finally {
+      fresh.close();
+    }
+  });
+
+  it('returns null for raster charts (overzoom is pbf-only)', () => {
+    const raster = new MBTilesReader(RASTER_MBTILES);
+    try {
+      assert.strictEqual(raster.getInfo().format, 'png');
+      assert.strictEqual(getOverzoomedTile(raster, 3, 0, 0), null);
+    } finally {
+      raster.close();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Chart sets combined from multiple ENC bands (tippecanoe + tile-join) have spatially varying max zoom: each band has its own zoom ceiling and bounds, but the merged MBTiles advertises the union. In areas covered only by a low band, tiles for the advertised deeper zooms don't exist — the tile endpoint 404s and clients render a black background. This can't be fixed client-side: OpenLayers/MapLibre only overzoom past the advertised maxzoom, never for mid-pyramid holes.

## Approach

When a pbf tile is missing, the tile endpoint now walks up the ancestor pyramid (up to 10 levels, spanning the band-1 z8 to band-6 z18 ceilings) and re-slices the nearest existing ancestor MVT into the requested child tile (pbf/@mapbox/vector-tile → geojson-vt → vt-pbf, served gzipped). Re-slicing is lossless for vector data, so clients render it exactly like native overzoom. Serving the parent tile as-is would be geographically wrong — it covers 4^Δ the area — hence the re-slice.

- Genuinely-outside-coverage requests keep returning 404; raster charts are untouched.
- Nothing changes at conversion time: no new tiles are written, file size and conversion duration are identical, and already-converted combined sets are fixed without re-conversion.
- Synthesis is on demand with bounded per-reader in-memory caches: 4 ancestor indexes, each retired after 64 slices (geojson-vt indexes grow with use), 256 encoded child tiles including cached nulls, and a 256 KB ancestor size guard for pathological tiles. Cache state is keyed per reader instance, so chart reload/rename/delete invalidates it automatically.
- Corrupt ancestors degrade to 404, never 500.

## Tested

- Full suite: 369 tests pass, including 10 new tile-overzoom tests (child synthesis correctness with geometry round-trip, nearest-ancestor selection, deep z15 targets, delta cap, empty quadrants, outside coverage, corrupt-ancestor degradation, cache behavior, raster guard) and 2 new MBTilesReader.getRawTile tests.
- Mutation-checked the critical pins: reverting geojson-vt's maxZoom option or inverting the ancestor-walk order each fails the suite.
- Verified live against a real combined NOAA set with mid-pyramid holes: a z15 request in a band-3-only area that 404s today returns a correct MVT (LNDARE, MAGVAR, M_COVR, …) in ~30 ms on first synthesis, ~0.7 ms for siblings from the cached index, ~0.01 ms for repeats; z16/z18 requests work; a 200-request hammer over one ancestor (crossing the slice-budget rebuild) completes without errors.
- Index memory measured on the largest hole-adjacent ancestor (157 KB gzipped MVT): ~7 MB at build, ~15 MB after a 60-tile pan — bounded by the cache caps above.
- prettier + eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Implements serve-time synthesization of missing vector MBTiles tiles through overzoom fallback. When a requested PBF tile is missing, the endpoint walks up the tile ancestor pyramid to find the nearest existing ancestor MVT and re-slices it into the requested child tile, eliminating black holes in combined charts with non-uniform zoom coverage.

## Core Implementation

- **Tile synthesis engine** (`src/utils/tile-overzoom.ts`): Probes up to 10 ancestor zoom levels for missing tiles, decodes the nearest valid ancestor using geojson-vt, slices the result to match the requested `z/x/y` coordinates, and encodes the output as a gzipped MVT v2 buffer. Includes per-reader LRU caches for ancestor indexes and synthesized tiles (with bounded size guards: 4 ancestor indexes, 256 encoded tiles, 256 KB ancestor size), and graceful degradation to `null` for corrupt ancestors, out-of-coverage requests, or empty quadrants.

- **Integration into tile endpoint** (`src/index.ts`): Calls overzoom synthesis when a PBF tile lookup returns no result, returning synthesized bytes with protocol headers and cache-control, or falling back to 404.

- **Reader enhancement** (`src/utils/mbtiles-reader.ts`): Exposes new `getRawTile(z, x, y)` method that performs TMS-Y flip lookup and returns tile payload as zero-copy `Buffer`, enabling efficient ancestor tile reads.

## Supporting Changes

- **Dependencies** (`package.json`): Adds `geojson-vt`, `pbf`, and `vt-pbf` for vector-tile and GeoJSON processing; adds type definitions for `geojson` and `geojson-vt`.

- **TypeScript declarations** (`src/types/vt-pbf.d.ts`): Module shim declaring `fromGeojsonVt` function to convert GeoJSON-vt layers to Uint8Array.

- **Test fixtures** (`test/fixtures/create-test-vector-mbtiles.cjs`): Generator script producing a minimal vector MBTiles database with tiles at z2/z3/z8 levels and one intentionally corrupted gzip tile for degradation testing.

- **Test coverage**: New `getRawTile()` tests in `mbtiles-reader.test.ts` and comprehensive 10-test overzoom suite in `tile-overzoom.test.ts` validating feature preservation, ancestor selection, zoom limits, cache behavior, error handling, and raster exclusion.

## Behavior & Constraints

- Genuine out-of-coverage requests still return 404; raster charts remain unchanged.
- No changes to tile conversion pipeline; existing combined MBTiles fixed on-demand without reconversion.
- Re-slicing is lossless for vector data and matches native overzoom rendering.
- Corrupt ancestors degrade to 404 (not 500).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->