### PR TITLE
chore(release): 2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Patch release: serve-time overzoom fallback for combined vector charts (#140). Tagging v2.3.2 after merge triggers the npm publish workflow.