### PR TITLE
fix: replace blank cell-edge tiles and harden the ancestor walk

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ import { scanAllFolders, scanChartsRecursively } from './utils/file-scanner.js';
 import { repairMbtilesMetadata, setMbtilesDisplayName } from './utils/mbtiles-metadata.js';
 import { open as openMbtilesReader } from './utils/mbtiles-reader.js';
 import { writeChartPathMarker } from './utils/path-marker.js';
-import { getOverzoomedTile } from './utils/tile-overzoom.js';
+import { getBlankTileReplacement, getOverzoomedTile } from './utils/tile-overzoom.js';
 import { arePairWithinBase, isWithinBase, validateChartName } from './utils/path-safety.js';
 import { parsePluginConfig } from './utils/plugin-config-schema.js';
 import {
@@ -3641,7 +3641,9 @@ const serveTileFromFilesystem = (
   });
 };
 
-const serveTileFromMbtiles = (
+// Exported for tests (the Express route registration is not separately
+// constructible without a full server).
+export const serveTileFromMbtiles = (
   res: Response,
   provider: ChartProvider,
   z: number,
@@ -3670,6 +3672,21 @@ const serveTileFromMbtiles = (
       }
       res.sendStatus(404);
     } else {
+      // A stored cell-edge tile whose features all sit outside its visible
+      // extent renders blank and would mask lower-band content; serve a
+      // synthesized replacement instead.
+      if (provider.format === 'pbf' && provider._mbtilesHandle) {
+        const replacement = getBlankTileReplacement(provider._mbtilesHandle, z, x, y, result.data);
+        if (replacement) {
+          res.writeHead(200, {
+            'Content-Type': 'application/x-protobuf',
+            'Content-Encoding': 'gzip',
+            'Cache-Control': responseHttpOptions.headers['Cache-Control']
+          });
+          res.end(replacement);
+          return;
+        }
+      }
       const headers = {
         ...result.headers,
         'Cache-Control': responseHttpOptions.headers['Cache-Control']

--- a/src/utils/tile-overzoom.ts
+++ b/src/utils/tile-overzoom.ts
@@ -10,7 +10,14 @@
  * the requested child tile — lossless for vector data, so clients render it
  * exactly like native overzoom.
  *
- * Nothing is written back to the MBTiles; synthesis is on demand with two
+ * A second band-edge artifact gets the same treatment: tippecanoe emits
+ * STORED tiles at chart-cell edges whose features all lie in the buffer zone
+ * outside the tile's own extent (the neighbor cell's content). Renderers clip
+ * to the extent, so such a tile draws nothing — and because it exists, it
+ * would block the fallback and leave a blank stripe over content a lower band
+ * provides. getBlankTileReplacement() detects those and synthesizes instead.
+ *
+ * Nothing is written back to the MBTiles; synthesis is on demand with
  * in-memory LRUs per reader. The first miss touching an ancestor pays one
  * decode+index (~30–300 ms); further children of the same ancestor are served
  * from cache in ~1 ms.
@@ -42,11 +49,17 @@ const INDEX_SLICE_BUDGET = 64;
 
 // Stored (gzipped) ancestors beyond this size would index into hundreds of MB
 // (tippecanoe runs with --no-tile-size-limit). Real hole-adjacent ancestors
-// measure ≤160 KB; anything bigger keeps today's 404 rather than risking an
-// OOM on small-RAM hosts.
+// measure ≤160 KB; anything bigger is never indexed — the walk passes it like
+// a blank tile, so a coarser ancestor may still cover its descendants —
+// rather than risking an OOM on small-RAM hosts.
 const MAX_ANCESTOR_BYTES = 256 * 1024;
 
 const TILE_CACHE_SIZE = 256;
+
+// Buffer-only edge tiles observed in real combined sets are 0.6–1.2 KB;
+// 32 KB leaves generous headroom while keeping the worst-case blank check
+// (one decode + bbox scan, ~1–2 ms, cached per tile) off large stored tiles.
+const BLANK_CHECK_MAX_BYTES = 32 * 1024;
 
 class LruMap<K, V> {
   private readonly map = new Map<K, V>();
@@ -84,18 +97,29 @@ class LruMap<K, V> {
 }
 
 interface AncestorEntry {
-  // One geojson-vt index per source layer; empty when the ancestor was
-  // skipped as oversized (children then resolve to null/404 naturally).
+  // One geojson-vt index per source layer.
   indexes: Map<string, ReturnType<typeof geojsonvt>>;
   slices: number;
 }
 
 interface OverzoomState {
   indexes: LruMap<string, AncestorEntry>;
+  // Ancestors that contribute nothing to any descendant — buffer-only
+  // cell-edge tiles (all features outside their own extent) and oversized
+  // tiles. Tracked separately from `indexes` so walking past them never
+  // evicts a real index, and their (cheap) decode isn't repaid per walk.
+  blankAncestors: LruMap<string, true>;
   // Cached nulls matter: empty ocean quadrants inside ancestor coverage get
   // hammered while panning and must not re-slice on every request.
   tiles: LruMap<string, Buffer | null>;
+  // Blank-check verdicts for STORED tiles: the synthesized replacement, or
+  // null for "serve the stored tile as-is" (not blank, nothing to
+  // synthesize, or undecodable). Caching nulls keeps the decode+bbox scan
+  // off repeats.
+  replacements: LruMap<string, Buffer | null>;
 }
+
+const BLANK_ANCESTOR_CACHE_SIZE = 64;
 
 // Keyed by reader instance: chart reload/rename/delete builds fresh readers,
 // so stale entries are unreachable and collected without explicit eviction.
@@ -106,7 +130,9 @@ function getState(reader: MBTilesReader): OverzoomState {
   if (!state) {
     state = {
       indexes: new LruMap(INDEX_CACHE_SIZE),
-      tiles: new LruMap(TILE_CACHE_SIZE)
+      blankAncestors: new LruMap(BLANK_ANCESTOR_CACHE_SIZE),
+      tiles: new LruMap(TILE_CACHE_SIZE),
+      replacements: new LruMap(TILE_CACHE_SIZE)
     };
     states.set(reader, state);
   }
@@ -114,25 +140,61 @@ function getState(reader: MBTilesReader): OverzoomState {
 }
 
 /** Test hook: cache occupancy for a reader (entries, not bytes). */
-export function _overzoomCacheStats(reader: MBTilesReader): { indexes: number; tiles: number } {
+export function _overzoomCacheStats(reader: MBTilesReader): {
+  indexes: number;
+  tiles: number;
+  replacements: number;
+} {
   const state = states.get(reader);
-  return { indexes: state?.indexes.size ?? 0, tiles: state?.tiles.size ?? 0 };
+  return {
+    indexes: state?.indexes.size ?? 0,
+    tiles: state?.tiles.size ?? 0,
+    replacements: state?.replacements.size ?? 0
+  };
 }
 
-function buildAncestorEntry(raw: Buffer, az: number, ax: number, ay: number): AncestorEntry {
-  const indexes: AncestorEntry['indexes'] = new Map();
+function decodeTile(raw: Buffer): VectorTile {
+  const bytes = raw[0] === 0x1f && raw[1] === 0x8b ? gunzipSync(raw) : raw;
+  return new VectorTile(new Pbf(bytes));
+}
 
+/** True when at least one feature touches the tile's visible extent. */
+function hasVisibleFeature(tile: VectorTile): boolean {
+  for (const layer of Object.values(tile.layers)) {
+    const extent = layer.extent;
+    for (let i = 0; i < layer.length; i++) {
+      const [x1, y1, x2, y2] = layer.feature(i).bbox();
+      if (!(x2 < 0 || x1 > extent || y2 < 0 || y1 > extent)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Build geojson-vt indexes for an ancestor, or return null for ancestors
+ * that can't contribute visible content to any descendant: buffer-only
+ * cell-edge tiles (their features belong to the neighbor cell and land at
+ * most in descendants' invisible buffer margins) and oversized tiles
+ * (indexing them would cost hundreds of MB; the walk passes them so a
+ * coarser ancestor can still cover their descendants).
+ */
+function buildAncestorEntry(raw: Buffer, az: number, ax: number, ay: number): AncestorEntry | null {
   if (raw.byteLength > MAX_ANCESTOR_BYTES) {
     console.warn(
       `Overzoom: ancestor tile ${az}/${ax}/${ay} is ${raw.byteLength} bytes ` +
-        `(> ${MAX_ANCESTOR_BYTES}); descendants keep returning 404`
+        `(> ${MAX_ANCESTOR_BYTES}); skipping it — coarser ancestors may cover its descendants`
     );
-    return { indexes, slices: 0 };
+    return null;
   }
 
-  const bytes = raw[0] === 0x1f && raw[1] === 0x8b ? gunzipSync(raw) : raw;
-  const tile = new VectorTile(new Pbf(bytes));
+  const tile = decodeTile(raw);
+  if (!hasVisibleFeature(tile)) {
+    return null;
+  }
 
+  const indexes: AncestorEntry['indexes'] = new Map();
   for (const [name, layer] of Object.entries(tile.layers)) {
     if (layer.length === 0) {
       continue;
@@ -159,11 +221,14 @@ function buildAncestorEntry(raw: Buffer, az: number, ax: number, ay: number): An
 }
 
 /**
- * Synthesize a missing pbf tile from the nearest existing ancestor.
- * Returns a gzipped MVT buffer, or null when the chart is not pbf, the
- * nearest ancestor is more than MAX_OVERZOOM_DELTA levels up (or none exists
- * at all — genuinely outside coverage), or the child quadrant is empty — all
- * of which should keep today's 404.
+ * Synthesize a missing pbf tile from the nearest content-bearing ancestor.
+ * Blank ancestors (buffer-only cell-edge tiles, oversized tiles) are walked
+ * past; the first ancestor with visible content is authoritative — if its
+ * slice of the requested quadrant is empty, the area is genuinely empty.
+ * Returns a gzipped MVT buffer, or null when the chart is not pbf, no
+ * ancestor within MAX_OVERZOOM_DELTA covers the quadrant (genuinely outside
+ * coverage), or the quadrant is empty — all of which should keep today's
+ * 404.
  */
 export function getOverzoomedTile(
   reader: MBTilesReader,
@@ -192,8 +257,6 @@ export function getOverzoomedTile(
     const maxzoom = info.maxzoom ?? z - 1;
     const dStart = Math.max(1, z - maxzoom);
 
-    let entry: AncestorEntry | undefined;
-    let entryKey = '';
     for (let d = dStart; d <= MAX_OVERZOOM_DELTA; d++) {
       const az = z - d;
       if (az < minzoom) {
@@ -201,56 +264,129 @@ export function getOverzoomedTile(
       }
       const ax = x >> d;
       const ay = y >> d;
-      entryKey = `${az}/${ax}/${ay}`;
-      entry = state.indexes.get(entryKey);
-      if (entry) {
-        break;
+      const entryKey = `${az}/${ax}/${ay}`;
+
+      // Walk past known-blank ancestors (buffer-only cell-edge or oversized
+      // tiles): a deeper band may cover the area, and stopping at them would
+      // re-blank every zoom above. Content-bearing ancestors are
+      // authoritative below — never walked past — so a request builds at
+      // most ONE index; anything else would thrash the index LRU on every
+      // empty-quadrant miss while panning.
+      if (state.blankAncestors.get(entryKey)) {
+        continue;
       }
-      const raw = reader.getRawTile(az, ax, ay);
-      if (raw) {
-        entry = buildAncestorEntry(raw, az, ax, ay);
+      let entry = state.indexes.get(entryKey);
+      if (!entry) {
+        const raw = reader.getRawTile(az, ax, ay);
+        if (!raw) {
+          continue;
+        }
+        const built = buildAncestorEntry(raw, az, ax, ay);
+        if (!built) {
+          state.blankAncestors.set(entryKey, true);
+          continue;
+        }
+        entry = built;
         state.indexes.set(entryKey, entry);
+      }
+
+      const layers: Record<string, { features: unknown[] }> = {};
+      let hasFeatures = false;
+      for (const [name, index] of entry.indexes) {
+        const sliced = index.getTile(z, x, y);
+        if (sliced && sliced.features.length > 0) {
+          layers[name] = sliced;
+          hasFeatures = true;
+        }
+      }
+
+      // geojson-vt retains every intermediate tile a slice materializes, so
+      // an entry grows with use; retire it after a budget of slices and let
+      // the next miss rebuild it fresh (synthesized children stay cached).
+      entry.slices++;
+      if (entry.slices >= INDEX_SLICE_BUDGET) {
+        state.indexes.delete(entryKey);
+      }
+
+      if (!hasFeatures) {
+        // The nearest content-bearing ancestor has nothing in this quadrant:
+        // the area is genuinely empty (ocean outside any feature). Cache the
+        // null — deeper ancestors cover the same geography and would only
+        // repeat the answer at lower detail.
         break;
       }
+
+      // version: 2 is required — vt-pbf defaults to MVT v1, tippecanoe
+      // emits v2.
+      const encoded = fromGeojsonVt(layers, { version: 2, extent: 4096 });
+      const result = gzipSync(encoded);
+      state.tiles.set(tileKey, result);
+      return result;
     }
 
-    if (!entry) {
-      state.tiles.set(tileKey, null);
-      return null;
-    }
-
-    const layers: Record<string, { features: unknown[] }> = {};
-    let hasFeatures = false;
-    for (const [name, index] of entry.indexes) {
-      const sliced = index.getTile(z, x, y);
-      if (sliced && sliced.features.length > 0) {
-        layers[name] = sliced;
-        hasFeatures = true;
-      }
-    }
-
-    // geojson-vt retains every intermediate tile a slice materializes, so an
-    // entry grows with use; retire it after a budget of slices and let the
-    // next miss rebuild it fresh (already-synthesized children stay cached).
-    entry.slices++;
-    if (entry.slices >= INDEX_SLICE_BUDGET) {
-      state.indexes.delete(entryKey);
-    }
-
-    if (!hasFeatures) {
-      state.tiles.set(tileKey, null);
-      return null;
-    }
-
-    // version: 2 is required — vt-pbf defaults to MVT v1, tippecanoe emits v2.
-    const encoded = fromGeojsonVt(layers, { version: 2, extent: 4096 });
-    const result = gzipSync(encoded);
-    state.tiles.set(tileKey, result);
-    return result;
+    state.tiles.set(tileKey, null);
+    return null;
   } catch (err) {
     // A corrupt ancestor must degrade to 404, never bubble into the route's
     // 500 path. Not cached so a transient failure can recover.
     console.error(`Error synthesizing overzoom tile ${z}/${x}/${y}:`, err);
+    return null;
+  }
+}
+
+/**
+ * Replacement for a STORED pbf tile that would render blank: tippecanoe
+ * writes chart-cell edge tiles whose features all sit in the buffer zone
+ * outside the visible extent (the neighbor cell's content, clipped in).
+ * Returns a synthesized tile from the nearest ancestor — the invisible
+ * buffer features aren't merged in; neighbors carry their own copies — or
+ * null when the stored tile should be served as-is (has visible features,
+ * is too large to cheaply check, undecodable, or there is nothing to
+ * synthesize from).
+ */
+export function getBlankTileReplacement(
+  reader: MBTilesReader,
+  z: number,
+  x: number,
+  y: number,
+  raw: Buffer
+): Buffer | null {
+  let state: OverzoomState | undefined;
+  const tileKey = `${z}/${x}/${y}`;
+  try {
+    if (raw.byteLength > BLANK_CHECK_MAX_BYTES) {
+      return null;
+    }
+    const info = reader.getInfo();
+    if (info.format !== 'pbf') {
+      return null;
+    }
+
+    state = getState(reader);
+    const cached = state.replacements.get(tileKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    let replacement: Buffer | null = null;
+    if (!hasVisibleFeature(decodeTile(raw))) {
+      replacement = getOverzoomedTile(reader, z, x, y);
+      if (replacement === null && state.tiles.get(tileKey) === undefined) {
+        // getOverzoomedTile errored (its legit nulls are recorded in the
+        // tiles cache). Don't pin the verdict — a transient failure should
+        // be able to recover on a later request.
+        return null;
+      }
+    }
+    state.replacements.set(tileKey, replacement);
+    return replacement;
+  } catch (err) {
+    // A corrupt stored tile must fall back to serving its original bytes,
+    // never bubble into the route's 500 path. The stored bytes can't change
+    // within this reader's lifetime, so cache the verdict — otherwise every
+    // serve of that tile would re-decode and re-log.
+    console.error(`Error checking blank tile ${tileKey}:`, err);
+    state?.replacements.set(tileKey, null);
     return null;
   }
 }

--- a/test/fixtures/create-test-vector-mbtiles.cjs
+++ b/test/fixtures/create-test-vector-mbtiles.cjs
@@ -1,7 +1,7 @@
 /**
  * Script to create a minimal vector (pbf) test MBTiles file for the
  * tile-overzoom tests. The pyramid intentionally has holes: metadata
- * advertises minzoom=2..maxzoom=16 but only four tiles exist — the same
+ * advertises minzoom=2..maxzoom=16 but only six tiles exist — the same
  * shape as a combined NOAA chart set where deep zooms are missing in areas
  * covered only by a low band.
  *
@@ -13,6 +13,14 @@
  *                  maxZoom option, whose default 14 would return null)
  *   z2 XYZ (1,1)   corrupt gzip bytes — synthesis from it must degrade to
  *                  null, never throw
+ *   z4 XYZ (0,7)   STORED "buffer-only" tile: four features, each outside
+ *                  the visible extent past a different edge (x > extent,
+ *                  y > extent, x < 0, y < 0), like tippecanoe cell-edge
+ *                  tiles carrying just the neighbor's buffer spill — must be
+ *                  REPLACED by synthesis from z3, which pins every arm of
+ *                  the visibility predicate
+ *   z4 XYZ (3,5)   buffer-only, and its quadrant is empty in every
+ *                  ancestor — stored tile must be served as-is
  *
  * Tile contents are independent per tile (no real pyramid consistency); the
  * overzoom module only ever reads one ancestor at a time, so that's fine.
@@ -130,6 +138,50 @@ insertXyz(3, 0, 3, makeTile({ points: pointFc(43, 'z3-buoy', POINT_LON, POINT_LA
 insertXyz(8, 56, 86, makeTile({ points: pointFc(88, 'z8-buoy', DEEP_LON, DEEP_LAT) }, 8, 56, 86));
 // Corrupt tile: valid gzip magic, garbage body.
 insertXyz(2, 1, 1, Buffer.from([0x1f, 0x8b, 0xde, 0xad, 0xbe, 0xef, 0x00, 0x01, 0x02, 0x03]));
+
+// Hand-built MVTs in raw extent units (no geojson-vt involved).
+function ghostTile(rings) {
+  const mvt = vtpbf.fromGeojsonVt(
+    {
+      ghost: {
+        features: rings.map((ring, i) => ({
+          id: 99 + i,
+          type: 3,
+          geometry: [ring],
+          tags: { kind: 'neighbor-spill' }
+        }))
+      }
+    },
+    { version: 2 }
+  );
+  return gzipSync(Buffer.from(mvt));
+}
+
+const square = (x1, y1, x2, y2) => [
+  [x1, y1],
+  [x2, y1],
+  [x2, y2],
+  [x1, y2],
+  [x1, y1]
+];
+
+// Buffer-only: every feature entirely outside the 0..4096 extent, so the
+// tile renders nothing. (0,7) carries one feature per visibility-predicate
+// arm: right (x1 > extent), bottom (y1 > extent), left (x2 < 0), top
+// (y2 < 0) — losing any arm makes that feature "visible" and the tile
+// non-blank.
+insertXyz(
+  4,
+  0,
+  7,
+  ghostTile([
+    square(4500, 100, 5000, 600),
+    square(100, 4500, 600, 5000),
+    square(-500, 100, -100, 600),
+    square(100, -500, 600, -100)
+  ])
+);
+insertXyz(4, 3, 5, ghostTile([square(-500, 100, -100, 600)]));
 
 db.close();
 

--- a/test/tile-overzoom.test.ts
+++ b/test/tile-overzoom.test.ts
@@ -2,11 +2,13 @@
  * Tests for serve-time overzoom synthesis from vector MBTiles.
  *
  * The fixture (create-test-vector-mbtiles.cjs) advertises minzoom=2,
- * maxzoom=16 but contains only four tiles: z2 (0,1) with 'test-buoy' (id 42)
- * + an `areas` polygon, z3 (0,3) with 'z3-buoy' (id 43) at the same lon/lat,
- * z8 (56,86) with 'z8-buoy' (id 88) far away, and a corrupt-gzip z2 (1,1).
- * That reproduces the pyramid holes of a combined NOAA chart set: deep
- * requests inside coverage must synthesize from the NEAREST ancestor,
+ * maxzoom=16 but contains only six tiles — see the generator's header for
+ * the authoritative inventory: z2 (0,1) 'test-buoy' (id 42) + `areas`
+ * polygon, z3 (0,3) 'z3-buoy' (id 43) at the same lon/lat, z8 (56,86)
+ * 'z8-buoy' (id 88) far away, corrupt-gzip z2 (1,1), buffer-only z4 (0,7)
+ * and z4 (3,5). That reproduces the pyramid
+ * holes and cell-edge artifacts of a combined NOAA chart set: deep requests
+ * inside coverage must synthesize from the NEAREST content-bearing ancestor,
  * requests outside coverage must keep returning null (→ 404).
  */
 
@@ -14,18 +16,21 @@ import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { gunzipSync } from 'node:zlib';
+import { gunzipSync, gzipSync } from 'node:zlib';
 
 import Pbf from 'pbf';
 import { VectorTile } from '@mapbox/vector-tile';
+import { fromGeojsonVt } from 'vt-pbf';
 import type { Feature, Point } from 'geojson';
 
 import { MBTilesReader } from '../dist/utils/mbtiles-reader.js';
 import {
+  getBlankTileReplacement,
   getOverzoomedTile,
   MAX_OVERZOOM_DELTA,
   _overzoomCacheStats
 } from '../dist/utils/tile-overzoom.js';
+import { serveTileFromMbtiles } from '../dist/index.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -187,23 +192,190 @@ describe('getOverzoomedTile()', () => {
         'a different ancestor is read once, the z2 index is not re-read'
       );
 
-      assert.strictEqual(getOverzoomedTile(fresh, 4, 0, 6), null, 'empty quadrant of z3');
-      assert.strictEqual(
-        rawCalls.length,
-        2,
-        'empty quadrant slices from the cached index without raw reads'
+      // (4,2,6) is empty at every ancestor; the walk probes the missing z3
+      // (1,3) once, then slices the already-cached z2 index without reading.
+      assert.strictEqual(getOverzoomedTile(fresh, 4, 2, 6), null, 'empty quadrant');
+      assert.deepStrictEqual(
+        rawCalls,
+        [
+          [2, 0, 1],
+          [3, 0, 3],
+          [3, 1, 3]
+        ],
+        'cached ancestor indexes are sliced without raw re-reads'
       );
 
       const stats = _overzoomCacheStats(fresh);
       assert.strictEqual(stats.indexes, 2, 'both ancestor indexes cached');
       assert.strictEqual(stats.tiles, 3, 'two tiles plus one null cached');
 
-      assert.strictEqual(getOverzoomedTile(fresh, 4, 0, 6), null);
-      assert.strictEqual(rawCalls.length, 2, 'null results are cached too');
+      assert.strictEqual(getOverzoomedTile(fresh, 4, 2, 6), null);
+      assert.strictEqual(rawCalls.length, 3, 'null results are cached too');
       assert.deepStrictEqual(_overzoomCacheStats(fresh), stats);
     } finally {
       fresh.close();
     }
+  });
+
+  it('walks past buffer-only ancestors to deeper coverage', () => {
+    // z5 (1,14) is missing; its nearest ancestor z4 (0,7) is the stored
+    // buffer-only tile (nothing visible). The walk must continue to z3.
+    const tile = getOverzoomedTile(reader, 5, 1, 14);
+    assert.ok(tile, 'must synthesize from z3 despite the blank z4 ancestor');
+    const vt = decode(tile);
+    assert.strictEqual(vt.layers.points.feature(0).properties.name, 'z3-buoy');
+    assert.strictEqual(vt.layers.ghost, undefined);
+  });
+
+  describe('getBlankTileReplacement()', () => {
+    it('replaces a stored buffer-only tile with synthesized content', () => {
+      const raw = reader.getRawTile(4, 0, 7);
+      assert.ok(raw, 'fixture must store the buffer-only tile');
+      assert.ok(decode(raw).layers.ghost, 'stored tile holds only the ghost layer');
+
+      const replacement = getBlankTileReplacement(reader, 4, 0, 7, raw);
+      assert.ok(replacement, 'blank stored tile must be replaced');
+      const vt = decode(replacement);
+      assert.strictEqual(vt.layers.points.feature(0).properties.name, 'z3-buoy');
+      assert.strictEqual(vt.layers.ghost, undefined, 'invisible buffer content is not merged');
+    });
+
+    it('keeps the stored tile when the blank quadrant has nothing to synthesize', () => {
+      const raw = reader.getRawTile(4, 3, 5);
+      assert.ok(raw);
+      assert.strictEqual(getBlankTileReplacement(reader, 4, 3, 5, raw), null);
+    });
+
+    it('leaves stored tiles with visible features untouched', () => {
+      const raw = reader.getRawTile(2, 0, 1);
+      assert.ok(raw);
+      assert.strictEqual(getBlankTileReplacement(reader, 2, 0, 1, raw), null);
+    });
+
+    it('never replaces a stored tile whose feature straddles the tile edge', () => {
+      // Simulate the stored (4,0,7) tile holding a feature whose bbox is
+      // x1 < 0 < x2 — partially visible. That quadrant WOULD synthesize
+      // ('z3-buoy'), so misclassifying straddlers as blank fails loudly.
+      const straddleRaw = gzipSync(
+        Buffer.from(
+          fromGeojsonVt(
+            {
+              ghost: {
+                features: [
+                  {
+                    id: 1,
+                    type: 3,
+                    geometry: [
+                      [
+                        [-100, 200],
+                        [500, 200],
+                        [500, 800],
+                        [-100, 800],
+                        [-100, 200]
+                      ]
+                    ],
+                    tags: { kind: 'straddle' }
+                  }
+                ]
+              }
+            },
+            { version: 2 }
+          )
+        )
+      );
+      const fresh = new MBTilesReader(VECTOR_MBTILES);
+      try {
+        assert.strictEqual(getBlankTileReplacement(fresh, 4, 0, 7, straddleRaw), null);
+      } finally {
+        fresh.close();
+      }
+    });
+
+    it('skips the blank check entirely for oversized stored tiles', () => {
+      // (4,0,7) WOULD synthesize if the check ran (an all-zero buffer parses
+      // as zero layers = blank), so the size cap is pinned by asserting no
+      // synthesis happens.
+      const fresh = new MBTilesReader(VECTOR_MBTILES);
+      try {
+        const rawCalls: Array<[number, number, number]> = [];
+        const realGetRawTile = fresh.getRawTile.bind(fresh);
+        fresh.getRawTile = (z: number, x: number, y: number) => {
+          rawCalls.push([z, x, y]);
+          return realGetRawTile(z, x, y);
+        };
+        assert.strictEqual(getBlankTileReplacement(fresh, 4, 0, 7, Buffer.alloc(40000)), null);
+        assert.strictEqual(rawCalls.length, 0, 'no synthesis attempted beyond the size cap');
+      } finally {
+        fresh.close();
+      }
+    });
+
+    it('degrades to the stored tile on corrupt data and caches that verdict', () => {
+      const fresh = new MBTilesReader(VECTOR_MBTILES);
+      try {
+        const corrupt = fresh.getRawTile(2, 1, 1);
+        assert.ok(corrupt);
+        let result: Buffer | null = null;
+        assert.doesNotThrow(() => {
+          result = getBlankTileReplacement(fresh, 2, 1, 1, corrupt);
+        });
+        assert.strictEqual(result, null);
+        assert.strictEqual(
+          _overzoomCacheStats(fresh).replacements,
+          1,
+          'stored bytes are immutable per reader — the error verdict must be cached'
+        );
+      } finally {
+        fresh.close();
+      }
+    });
+
+    it('caches "serve stored" verdicts for visible tiles', () => {
+      const fresh = new MBTilesReader(VECTOR_MBTILES);
+      try {
+        const raw = fresh.getRawTile(2, 0, 1);
+        assert.ok(raw);
+        assert.strictEqual(getBlankTileReplacement(fresh, 2, 0, 1, raw), null);
+        assert.strictEqual(_overzoomCacheStats(fresh).replacements, 1);
+      } finally {
+        fresh.close();
+      }
+    });
+
+    it('caches replacement verdicts per tile', () => {
+      const fresh = new MBTilesReader(VECTOR_MBTILES);
+      try {
+        const raw = fresh.getRawTile(4, 0, 7);
+        assert.ok(raw);
+        const rawCalls: Array<[number, number, number]> = [];
+        const realGetRawTile = fresh.getRawTile.bind(fresh);
+        fresh.getRawTile = (z: number, x: number, y: number) => {
+          rawCalls.push([z, x, y]);
+          return realGetRawTile(z, x, y);
+        };
+
+        const first = getBlankTileReplacement(fresh, 4, 0, 7, raw);
+        assert.ok(first);
+        assert.deepStrictEqual(rawCalls, [[3, 0, 3]], 'synthesis reads the ancestor once');
+
+        const second = getBlankTileReplacement(fresh, 4, 0, 7, raw);
+        assert.strictEqual(second, first, 'repeat returns the cached Buffer instance');
+        assert.strictEqual(rawCalls.length, 1, 'verdict cache avoids re-checking');
+        assert.ok(_overzoomCacheStats(fresh).replacements >= 1);
+
+        // The verdict is keyed by coordinates, not content: a cached hit
+        // must return without decoding (garbage would throw → null if the
+        // cache lookup were broken).
+        const garbage = Buffer.from([0x1f, 0x8b, 0x00, 0x01, 0x02]);
+        assert.strictEqual(
+          getBlankTileReplacement(fresh, 4, 0, 7, garbage),
+          first,
+          'cache hit must short-circuit before any decode'
+        );
+      } finally {
+        fresh.close();
+      }
+    });
   });
 
   it('returns null for raster charts (overzoom is pbf-only)', () => {
@@ -214,5 +386,71 @@ describe('getOverzoomedTile()', () => {
     } finally {
       raster.close();
     }
+  });
+
+  describe('serveTileFromMbtiles() route handler', () => {
+    type ServeArgs = Parameters<typeof serveTileFromMbtiles>;
+
+    function fakeRes() {
+      const res = {
+        statusCode: 0,
+        headers: {} as Record<string, string>,
+        body: undefined as unknown,
+        writeHead(code: number, headers: Record<string, string>) {
+          res.statusCode = code;
+          res.headers = headers;
+          return res;
+        },
+        end(data?: unknown) {
+          res.body = data;
+        },
+        sendStatus(code: number) {
+          res.statusCode = code;
+        }
+      };
+      return res;
+    }
+
+    const asProvider = (r: MBTilesReader): ServeArgs[1] =>
+      ({ identifier: 'test', format: 'pbf', _mbtilesHandle: r }) as unknown as ServeArgs[1];
+
+    it('serves synthesized tiles for coverage holes with pbf+gzip headers', () => {
+      // z5 (1,14) is missing; synthesis walks past the blank z4 ghost to z3.
+      const res = fakeRes();
+      serveTileFromMbtiles(res as unknown as ServeArgs[0], asProvider(reader), 5, 1, 14);
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.headers['Content-Type'], 'application/x-protobuf');
+      assert.strictEqual(res.headers['Content-Encoding'], 'gzip');
+      assert.ok(res.headers['Cache-Control'], 'cache header must be present');
+      const vt = decode(res.body as Buffer);
+      assert.strictEqual(vt.layers.points.feature(0).properties.name, 'z3-buoy');
+    });
+
+    it('serves the replacement for stored blank tiles', () => {
+      const res = fakeRes();
+      serveTileFromMbtiles(res as unknown as ServeArgs[0], asProvider(reader), 4, 0, 7);
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.headers['Content-Type'], 'application/x-protobuf');
+      assert.strictEqual(res.headers['Content-Encoding'], 'gzip');
+      const vt = decode(res.body as Buffer);
+      assert.strictEqual(vt.layers.points.feature(0).properties.name, 'z3-buoy');
+      assert.strictEqual(vt.layers.ghost, undefined, 'must not serve the stored ghost bytes');
+    });
+
+    it('serves stored tiles with visible content unchanged', () => {
+      const res = fakeRes();
+      serveTileFromMbtiles(res as unknown as ServeArgs[0], asProvider(reader), 2, 0, 1);
+      assert.strictEqual(res.statusCode, 200);
+      const stored = reader.getTile(2, 0, 1);
+      assert.ok(stored);
+      assert.deepStrictEqual(res.body, stored.data, 'stored bytes must pass through untouched');
+      assert.strictEqual(res.headers['Content-Type'], 'application/x-protobuf');
+    });
+
+    it('keeps 404 outside coverage', () => {
+      const res = fakeRes();
+      serveTileFromMbtiles(res as unknown as ServeArgs[0], asProvider(reader), 3, 7, 7);
+      assert.strictEqual(res.statusCode, 404);
+    });
   });
 });

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -7,6 +7,6 @@
     "declarationMap": false,
     "noEmit": false
   },
-  "include": ["test/**/*.ts"],
+  "include": ["test/**/*.ts", "src/types/vt-pbf.d.ts"],
   "exclude": ["node_modules", "dist", "dist-test"]
 }


### PR DESCRIPTION
## Problem

Follow-up to #140. Tippecanoe emits stored cell-edge tiles whose features all sit in the buffer zone outside the tile's visible extent (the neighbor cell's content, clipped in). Such tiles render nothing — and because they exist, they blocked the overzoom fallback, leaving a blank stripe at band boundaries over areas a lower band covers (visible as a black column in combined NOAA sets, e.g. dsadsad z15 column x=5228, features at x ∈ [5024, 5376] of a 4096 extent).

## Approach

- Stored pbf tiles ≤ 32 KB with no feature touching the visible extent are detected at serve time and replaced with a synthesized tile from the nearest content-bearing ancestor (per-tile verdict caching, including null verdicts and error verdicts — stored bytes can't change within a reader's lifetime). Corrupt or oversized stored tiles keep serving their original bytes.
- The ancestor walk distinguishes blank ancestors (buffer-only cell-edge or oversized tiles — walked past, tracked in a dedicated marker cache so they are decoded once and never evict a real index) from content-bearing ancestors, which stay authoritative: an empty slice there means the area is genuinely empty and the walk stops. This keeps the hot path at one index build per request — without it, a buffer-only tile mid-pyramid would re-blank every zoom above it, and walking past empty content slices would rebuild the whole ancestor stack on every empty-quadrant miss while panning.

## Tested

- 377 tests pass, including new coverage: blank-tile replacement (every visibility-predicate arm pinned by per-arm fixture features), kept-stored when nothing synthesizes, edge-straddling tiles never replaced, oversize cap pinned via a raw-read spy, verdict caching (instance identity, coordinate-keyed cache hit before decode, null and error verdicts), walk-past-blank-ancestor, and route-handler tests asserting status/headers/body for the replacement, pass-through, synthesis, and 404 paths.
- Hot-path regression measured on real charts: a 30-tile pan over an all-empty FL_ENCs coverage fringe costs 15 ms (first strip) / 2 ms (second) — an interim version of the walk without the authoritative-stop measured 1277/1131 ms there.
- Live against the real combined sets: the previously blank z15 stored column synthesizes correct band-4 content (LNDARE; coastal tiles gain COALNE/DEPARE), tiles with visible features pass through untouched, and z16 requests above the stripe synthesize.
- Verified in Freeboard-SK in a browser: the black band-boundary column now renders the band-4 underlay seamlessly; the only residual gap is the genuinely uncovered fraction inside a partially-covered stored tile (would require compositing, out of scope).
- prettier + eslint clean.