### PR TITLE
feat(webapp): use charts logo as favicon

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, user-scalable=yes">
+    <link rel="icon" type="image/png" href="assets/charts_logo.png" />
     <link rel="stylesheet" href="css/material-theme.css" />
     <link rel="stylesheet" href="style.css" />
     <link rel="stylesheet" href="css/manage-charts.css" />


### PR DESCRIPTION
## Summary

- The Charts Manager web UI page set no favicon, so the browser tab fell back to the browser's default icon instead of the app's branding.
- Add a `<link rel="icon">` to `public/index.html` pointing at the same `assets/charts_logo.png` already used as the Signal K `appIcon`. The path is relative, matching the page's existing relative asset links so it resolves correctly behind the Signal K plugin mount.

## Tested

- `npm run format`, `npm run build`, and `npm test` (382 tests) all pass
- Confirmed the `<link rel="icon">` is present in `public/index.html` and points at `assets/charts_logo.png`