### PR TITLE
chore(release): 2.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Release 2.3.3.
- Ships the favicon change from #146 (the Charts Manager web UI now uses the charts logo as its favicon).