### PR TITLE
feat(charts): default to the installer-mounted host charts folder

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -324,9 +324,13 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       exists = fs.existsSync(chartPath);
       createdOrWritable = exists && isDirWritable(chartPath);
     } else {
-      // In-data-volume default or a user-typed path: create-on-demand as before.
-      createdOrWritable = ensureDirectoryExists(chartPath);
-      exists = createdOrWritable || fs.existsSync(chartPath);
+      // In-data-volume default or a user-typed path: create-on-demand, then
+      // verify it is an actually-writable directory. ensureDirectoryExists
+      // returns true for any path that already exists, so without the
+      // isDirWritable probe an existing read-only dir (or a regular file at
+      // that path) would slip through as usable and only fail on first write.
+      createdOrWritable = ensureDirectoryExists(chartPath) && isDirWritable(chartPath);
+      exists = fs.existsSync(chartPath);
     }
 
     const access = classifyChartDirAccess(isHostMount, exists, createdOrWritable);

--- a/src/index.ts
+++ b/src/index.ts
@@ -332,11 +332,16 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     const access = classifyChartDirAccess(isHostMount, exists, createdOrWritable);
     if (!access.ok) {
       if (access.reason === 'mount-missing') {
+        // NB: clearing the Chart path setting does NOT help here — with
+        // SIGNALK_CHARTS_HOST_PATH still set, the default resolves right back to
+        // this same (missing) mount. The real fixes are restoring the mount or
+        // removing the installer env / pointing at a reachable in-container dir.
         app.setPluginError(
           `Shared charts folder is not mounted into the container at ${chartPath}. ` +
             `Charts live in a host folder the installer shares with the container; that ` +
-            `mount appears to be missing. Re-run the installer to restore it, or clear the ` +
-            `Chart path setting to fall back to Signal K's own charts folder.`
+            `mount appears to be missing. Re-run the installer to restore it, remove the ` +
+            `installer-provided SIGNALK_CHARTS_HOST_PATH setting, or set Chart path to a ` +
+            `directory that is reachable inside the container.`
         );
       } else if (access.reason === 'exists-unwritable') {
         app.setPluginError(
@@ -3654,13 +3659,19 @@ const ensureDirectoryExists = (dirPath: string): boolean => {
   }
 };
 
-// Probe whether an EXISTING directory is writable, without creating it. Used
-// for the injected host charts mount: we must NOT mkdir a missing mount (that
-// silently shadows it with an ephemeral in-container dir), so we check
-// existence + writability separately instead of create-on-demand.
+// Probe whether an EXISTING directory is usable as a chart root, without
+// creating it. Used for the injected host charts mount: we must NOT mkdir a
+// missing mount (that silently shadows it with an ephemeral in-container dir),
+// so we check existence + usability separately instead of create-on-demand.
+// Requires an actual directory (W_OK alone would accept a writable regular
+// file) with both write AND execute/search permission (X_OK — needed to
+// traverse into it to read/write chart files).
 const isDirWritable = (dirPath: string): boolean => {
   try {
-    fs.accessSync(dirPath, fs.constants.W_OK);
+    if (!fs.statSync(dirPath).isDirectory()) {
+      return false;
+    }
+    fs.accessSync(dirPath, fs.constants.W_OK | fs.constants.X_OK);
     return true;
   } catch {
     return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,14 @@ import { repairMbtilesMetadata, setMbtilesDisplayName } from './utils/mbtiles-me
 import { open as openMbtilesReader } from './utils/mbtiles-reader.js';
 import { writeChartPathMarker } from './utils/path-marker.js';
 import { getBlankTileReplacement, getOverzoomedTile } from './utils/tile-overzoom.js';
-import { arePairWithinBase, isWithinBase, validateChartName } from './utils/path-safety.js';
+import {
+  arePairWithinBase,
+  classifyChartDirAccess,
+  hasHostChartsMountEnv,
+  isWithinBase,
+  resolveDefaultChartsPath,
+  validateChartName
+} from './utils/path-safety.js';
 import { parsePluginConfig } from './utils/plugin-config-schema.js';
 import {
   cleanupQuarantineDir,
@@ -140,12 +147,24 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
   let defaultChartsPath = '';
   let serverMajorVersion = 1;
 
+  // The effective default chart directory. When Signal K runs in a container
+  // (signalk-universal-installer), the installer can mount a host folder the
+  // user shares with other chart apps (OpenCPN/qtVlm/...) and inject its
+  // in-container path via SIGNALK_CHARTS_HOST_PATH. When that env is present we
+  // default to it instead of the in-data-volume `charts-simple` dir, so a
+  // container user gets the shared host folder out of the box with no config —
+  // and so the chartPath field is never the free-text foot-gun that pointed at
+  // an unmounted host path. A user can still override via the chartPath setting.
   function getDefaultChartsPath(): string {
     if (!defaultChartsPath) {
       pluginDataDir = app.getDataDirPath();
-      const configBasePath = path.dirname(path.dirname(pluginDataDir));
-      defaultChartsPath = path.join(configBasePath, 'charts-simple');
       serverMajorVersion = app.config?.version ? parseInt(app.config.version.split('.')[0], 10) : 1;
+      const configBasePath = path.dirname(path.dirname(pluginDataDir));
+      const inDataVolumeDefault = path.join(configBasePath, 'charts-simple');
+      defaultChartsPath = resolveDefaultChartsPath(
+        process.env.SIGNALK_CHARTS_HOST_PATH,
+        inDataVolumeDefault
+      );
     }
     return defaultChartsPath;
   }
@@ -160,7 +179,12 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         chartPath: {
           type: 'string',
           title: 'Chart path',
-          description: `Main directory for chart files. Defaults to "${getDefaultChartsPath()}". Subfolders will be scanned recursively.`,
+          description:
+            (hasHostChartsMountEnv(process.env.SIGNALK_CHARTS_HOST_PATH)
+              ? `Main directory for chart files. Defaults to the shared host charts folder mounted by the installer. ` +
+                `Leave this blank to use it; only change it if you know the path is reachable inside the container. `
+              : `Main directory for chart files. Defaults to "${getDefaultChartsPath()}". `) +
+            `Subfolders will be scanned recursively.`,
           default: getDefaultChartsPath()
         },
         cpuBudget: {
@@ -281,10 +305,48 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     setCpuBudget(props.cpuBudget);
 
     getDefaultChartsPath(); // ensure lazy init
-    ensureDirectoryExists(defaultChartsPath);
     const chartPath = props.chartPath || defaultChartsPath;
-    if (!ensureDirectoryExists(chartPath)) {
-      app.setPluginError(`Chart directory is not writable: ${chartPath}`);
+
+    // Is the effective path the host folder the installer bind-mounted (via
+    // SIGNALK_CHARTS_HOST_PATH) and which the user left as the default? If so we
+    // must NOT create it on demand: that folder is supposed to already exist
+    // (the installer made it and mounted it), so a missing dir means a missing
+    // mount — and `mkdir`-ing it would silently shadow the absent mount with an
+    // ephemeral in-container dir whose charts vanish on container recreate.
+    const isHostMount =
+      hasHostChartsMountEnv(process.env.SIGNALK_CHARTS_HOST_PATH) &&
+      chartPath === defaultChartsPath;
+
+    let exists: boolean;
+    let createdOrWritable: boolean;
+    if (isHostMount) {
+      // Probe, never create.
+      exists = fs.existsSync(chartPath);
+      createdOrWritable = exists && isDirWritable(chartPath);
+    } else {
+      // In-data-volume default or a user-typed path: create-on-demand as before.
+      createdOrWritable = ensureDirectoryExists(chartPath);
+      exists = createdOrWritable || fs.existsSync(chartPath);
+    }
+
+    const access = classifyChartDirAccess(isHostMount, exists, createdOrWritable);
+    if (!access.ok) {
+      if (access.reason === 'mount-missing') {
+        app.setPluginError(
+          `Shared charts folder is not mounted into the container at ${chartPath}. ` +
+            `Charts live in a host folder the installer shares with the container; that ` +
+            `mount appears to be missing. Re-run the installer to restore it, or clear the ` +
+            `Chart path setting to fall back to Signal K's own charts folder.`
+        );
+      } else if (access.reason === 'exists-unwritable') {
+        app.setPluginError(
+          `Chart directory exists but is not writable by Signal K: ${chartPath}. ` +
+            `In a container this is usually a folder-ownership mismatch — make sure the ` +
+            `host folder is owned by the user that runs Signal K.`
+        );
+      } else {
+        app.setPluginError(`Chart directory is not writable: ${chartPath}`);
+      }
       app.setPluginStatus('Started (no chart directory)');
       return;
     }
@@ -3586,6 +3648,19 @@ const ensureDirectoryExists = (dirPath: string): boolean => {
     if (!fs.existsSync(dirPath)) {
       fs.mkdirSync(dirPath, { recursive: true });
     }
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+// Probe whether an EXISTING directory is writable, without creating it. Used
+// for the injected host charts mount: we must NOT mkdir a missing mount (that
+// silently shadows it with an ephemeral in-container dir), so we check
+// existence + writability separately instead of create-on-demand.
+const isDirWritable = (dirPath: string): boolean => {
+  try {
+    fs.accessSync(dirPath, fs.constants.W_OK);
     return true;
   } catch {
     return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ import {
   arePairWithinBase,
   classifyChartDirAccess,
   hasHostChartsMountEnv,
+  isHostMountPath,
   isWithinBase,
   resolveDefaultChartsPath,
   validateChartName
@@ -308,14 +309,14 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     const chartPath = props.chartPath || defaultChartsPath;
 
     // Is the effective path the host folder the installer bind-mounted (via
-    // SIGNALK_CHARTS_HOST_PATH) and which the user left as the default? If so we
-    // must NOT create it on demand: that folder is supposed to already exist
-    // (the installer made it and mounted it), so a missing dir means a missing
-    // mount — and `mkdir`-ing it would silently shadow the absent mount with an
-    // ephemeral in-container dir whose charts vanish on container recreate.
-    const isHostMount =
-      hasHostChartsMountEnv(process.env.SIGNALK_CHARTS_HOST_PATH) &&
-      chartPath === defaultChartsPath;
+    // SIGNALK_CHARTS_HOST_PATH)? If so we must NOT create it on demand: that
+    // folder is supposed to already exist (the installer made it and mounted
+    // it), so a missing dir means a missing mount — and `mkdir`-ing it would
+    // silently shadow the absent mount with an ephemeral in-container dir whose
+    // charts vanish on container recreate. isHostMountPath normalizes both
+    // sides so a trailing slash / `.`/`..` can't divert the mount into the
+    // mkdir branch.
+    const isHostMount = isHostMountPath(chartPath, process.env.SIGNALK_CHARTS_HOST_PATH);
 
     let exists: boolean;
     let createdOrWritable: boolean;

--- a/src/utils/path-safety.ts
+++ b/src/utils/path-safety.ts
@@ -61,3 +61,83 @@ export function validateChartName(name: string): { valid: boolean; reason?: stri
   }
   return { valid: true };
 }
+
+/**
+ * True when the installer has injected a host charts-folder mount path via the
+ * `SIGNALK_CHARTS_HOST_PATH` env var (non-empty after trimming). Single source
+ * of truth for "are we defaulting to a mounted host folder" — used by the
+ * default-path resolver, the schema description, and the startup access check
+ * so they can never disagree.
+ */
+export function hasHostChartsMountEnv(hostMountEnv: string | undefined): boolean {
+  return hostMountEnv !== undefined && hostMountEnv.trim() !== '';
+}
+
+/**
+ * Resolve the plugin's effective default chart directory.
+ *
+ * When Signal K runs in a container (signalk-universal-installer), the
+ * installer can mount a host folder the user shares with other chart apps
+ * (OpenCPN/qtVlm/…) and inject its in-container path via the
+ * `SIGNALK_CHARTS_HOST_PATH` env var. When that env is a non-empty path we
+ * default to it, so a container user gets the shared host folder with no
+ * config — and the chartPath field is never the free-text foot-gun that
+ * pointed at an unmounted host path. Otherwise we fall back to the
+ * in-data-volume `charts-simple` directory.
+ *
+ * Pure: takes the env value and the computed fallback explicitly so it is
+ * testable without a real container or a Signal K `app`.
+ */
+export function resolveDefaultChartsPath(
+  hostMountEnv: string | undefined,
+  inDataVolumeDefault: string
+): string {
+  if (hasHostChartsMountEnv(hostMountEnv)) {
+    return (hostMountEnv as string).trim();
+  }
+  return inDataVolumeDefault;
+}
+
+/** Verdict of {@link classifyChartDirAccess}. */
+export type ChartDirAccess =
+  | { ok: true }
+  /** The path is the injected host mount but does not exist inside the
+   *  container → the bind mount is missing/failed. Do NOT create it (that would
+   *  silently shadow the absent mount with an ephemeral in-container dir whose
+   *  charts vanish on container recreate). */
+  | { ok: false; reason: 'mount-missing' }
+  /** The path exists but is not writable (rootless keep-id owns it as a
+   *  different uid, a read-only bind, or no space) → an ownership/permission
+   *  problem, NOT a missing mount. */
+  | { ok: false; reason: 'exists-unwritable' }
+  /** A non-mount path (in-data-volume default, or a user-typed path) that the
+   *  plugin should create on demand but couldn't. */
+  | { ok: false; reason: 'not-writable' };
+
+/**
+ * Decide how to treat a chart directory's accessibility, given pre-probed fs
+ * facts. Pure (no fs calls) so the branching is unit-testable.
+ *
+ * The `isHostMount` path is treated as "should already exist" — the installer
+ * created the host folder and bind-mounted it — so a missing dir means a
+ * missing mount and must surface an error, NOT be `mkdir`-ed (the bug that
+ * masks a forgotten mount). A non-mount path keeps create-on-demand semantics.
+ *
+ * @param isHostMount   resolved path === the injected host mount
+ * @param exists        fs.existsSync(path)
+ * @param createdOrWritable for a host mount: is it writable? for a non-mount:
+ *                          did create-on-demand (mkdir -p) succeed?
+ */
+export function classifyChartDirAccess(
+  isHostMount: boolean,
+  exists: boolean,
+  createdOrWritable: boolean
+): ChartDirAccess {
+  if (isHostMount) {
+    if (!exists) {
+      return { ok: false, reason: 'mount-missing' };
+    }
+    return createdOrWritable ? { ok: true } : { ok: false, reason: 'exists-unwritable' };
+  }
+  return createdOrWritable ? { ok: true } : { ok: false, reason: 'not-writable' };
+}

--- a/src/utils/path-safety.ts
+++ b/src/utils/path-safety.ts
@@ -98,6 +98,32 @@ export function resolveDefaultChartsPath(
   return inDataVolumeDefault;
 }
 
+/**
+ * True when `effectivePath` IS the installer-injected host charts mount (the
+ * value of `SIGNALK_CHARTS_HOST_PATH`). Used to decide "must already exist,
+ * probe-don't-create" vs create-on-demand.
+ *
+ * Both sides are normalized so a trailing slash, `//`, or `.`/`..` in a
+ * user-typed path can't divert the mount into the create-on-demand branch
+ * (which would `mkdir` and silently shadow a missing bind mount). Returns false
+ * when the env is unset/blank (there is no mount to match).
+ */
+export function isHostMountPath(effectivePath: string, hostMountEnv: string | undefined): boolean {
+  if (!hasHostChartsMountEnv(hostMountEnv)) {
+    return false;
+  }
+  return (
+    normalizeForCompare(effectivePath) === normalizeForCompare((hostMountEnv as string).trim())
+  );
+}
+
+// Normalize a path for equality comparison: collapse `.`/`..`/`//` AND strip a
+// trailing separator (path.normalize keeps a trailing slash, so `/a/b/` and
+// `/a/b` would otherwise compare unequal — the #150 trailing-slash edge).
+function normalizeForCompare(p: string): string {
+  return stripTrailingSep(path.normalize(p));
+}
+
 /** Verdict of {@link classifyChartDirAccess}. */
 export type ChartDirAccess =
   | { ok: true }

--- a/test/path-safety.test.ts
+++ b/test/path-safety.test.ts
@@ -116,7 +116,11 @@ describe('validateChartName', () => {
 });
 
 describe('resolveDefaultChartsPath', () => {
-  const fallback = '/home/node/.signalk/charts-simple';
+  // Synthetic paths only — the values are arbitrary for these pure tests, and
+  // a literal `/home/<user>/` would trip the SignalK plugin-CI "hardcoded home
+  // directory path" scan.
+  const fallback = '/srv/sk-data/charts-simple';
+  const hostMount = '/srv/charts-host';
 
   it('uses the in-data-volume default when the host-mount env is unset', () => {
     assert.strictEqual(resolveDefaultChartsPath(undefined, fallback), fallback);
@@ -131,17 +135,11 @@ describe('resolveDefaultChartsPath', () => {
   });
 
   it('prefers the host-mount env when it is a non-empty path', () => {
-    assert.strictEqual(
-      resolveDefaultChartsPath('/home/node/charts-host', fallback),
-      '/home/node/charts-host'
-    );
+    assert.strictEqual(resolveDefaultChartsPath(hostMount, fallback), hostMount);
   });
 
   it('trims surrounding whitespace from the host-mount env', () => {
-    assert.strictEqual(
-      resolveDefaultChartsPath('  /home/node/charts-host  ', fallback),
-      '/home/node/charts-host'
-    );
+    assert.strictEqual(resolveDefaultChartsPath(`  ${hostMount}  `, fallback), hostMount);
   });
 });
 
@@ -153,7 +151,7 @@ describe('hasHostChartsMountEnv', () => {
   });
 
   it('is true for a non-empty path', () => {
-    assert.strictEqual(hasHostChartsMountEnv('/home/node/charts-host'), true);
+    assert.strictEqual(hasHostChartsMountEnv('/srv/charts-host'), true);
     assert.strictEqual(hasHostChartsMountEnv('  /x  '), true);
   });
 });

--- a/test/path-safety.test.ts
+++ b/test/path-safety.test.ts
@@ -2,7 +2,14 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import path from 'node:path';
 
-import { isWithinBase, arePairWithinBase, validateChartName } from '../dist/utils/path-safety.js';
+import {
+  isWithinBase,
+  arePairWithinBase,
+  validateChartName,
+  resolveDefaultChartsPath,
+  hasHostChartsMountEnv,
+  classifyChartDirAccess
+} from '../dist/utils/path-safety.js';
 
 const BASE = '/srv/charts';
 
@@ -105,5 +112,81 @@ describe('validateChartName', () => {
 
   it('rejects an embedded ".." sequence', () => {
     assert.strictEqual(validateChartName('a..b').valid, false);
+  });
+});
+
+describe('resolveDefaultChartsPath', () => {
+  const fallback = '/home/node/.signalk/charts-simple';
+
+  it('uses the in-data-volume default when the host-mount env is unset', () => {
+    assert.strictEqual(resolveDefaultChartsPath(undefined, fallback), fallback);
+  });
+
+  it('uses the in-data-volume default when the host-mount env is empty', () => {
+    assert.strictEqual(resolveDefaultChartsPath('', fallback), fallback);
+  });
+
+  it('uses the in-data-volume default when the host-mount env is only whitespace', () => {
+    assert.strictEqual(resolveDefaultChartsPath('   ', fallback), fallback);
+  });
+
+  it('prefers the host-mount env when it is a non-empty path', () => {
+    assert.strictEqual(
+      resolveDefaultChartsPath('/home/node/charts-host', fallback),
+      '/home/node/charts-host'
+    );
+  });
+
+  it('trims surrounding whitespace from the host-mount env', () => {
+    assert.strictEqual(
+      resolveDefaultChartsPath('  /home/node/charts-host  ', fallback),
+      '/home/node/charts-host'
+    );
+  });
+});
+
+describe('hasHostChartsMountEnv', () => {
+  it('is false for undefined / empty / whitespace', () => {
+    assert.strictEqual(hasHostChartsMountEnv(undefined), false);
+    assert.strictEqual(hasHostChartsMountEnv(''), false);
+    assert.strictEqual(hasHostChartsMountEnv('   '), false);
+  });
+
+  it('is true for a non-empty path', () => {
+    assert.strictEqual(hasHostChartsMountEnv('/home/node/charts-host'), true);
+    assert.strictEqual(hasHostChartsMountEnv('  /x  '), true);
+  });
+});
+
+describe('classifyChartDirAccess', () => {
+  // Host-mount path: must NOT be created on demand; missing dir = missing mount.
+  it('host mount, missing dir -> mount-missing (never silently created)', () => {
+    assert.deepStrictEqual(classifyChartDirAccess(true, false, false), {
+      ok: false,
+      reason: 'mount-missing'
+    });
+  });
+
+  it('host mount, exists but not writable -> exists-unwritable (ownership, not missing)', () => {
+    assert.deepStrictEqual(classifyChartDirAccess(true, true, false), {
+      ok: false,
+      reason: 'exists-unwritable'
+    });
+  });
+
+  it('host mount, exists and writable -> ok', () => {
+    assert.deepStrictEqual(classifyChartDirAccess(true, true, true), { ok: true });
+  });
+
+  // Non-mount path: create-on-demand semantics (existence is not load-bearing).
+  it('non-mount, created/writable -> ok', () => {
+    assert.deepStrictEqual(classifyChartDirAccess(false, false, true), { ok: true });
+  });
+
+  it('non-mount, could not create/write -> not-writable', () => {
+    assert.deepStrictEqual(classifyChartDirAccess(false, false, false), {
+      ok: false,
+      reason: 'not-writable'
+    });
   });
 });

--- a/test/path-safety.test.ts
+++ b/test/path-safety.test.ts
@@ -8,6 +8,7 @@ import {
   validateChartName,
   resolveDefaultChartsPath,
   hasHostChartsMountEnv,
+  isHostMountPath,
   classifyChartDirAccess
 } from '../dist/utils/path-safety.js';
 
@@ -153,6 +154,38 @@ describe('hasHostChartsMountEnv', () => {
   it('is true for a non-empty path', () => {
     assert.strictEqual(hasHostChartsMountEnv('/srv/charts-host'), true);
     assert.strictEqual(hasHostChartsMountEnv('  /x  '), true);
+  });
+});
+
+describe('isHostMountPath', () => {
+  const mount = '/srv/charts-host';
+
+  it('is false when the env is unset/blank (no mount to match)', () => {
+    assert.strictEqual(isHostMountPath(mount, undefined), false);
+    assert.strictEqual(isHostMountPath(mount, ''), false);
+    assert.strictEqual(isHostMountPath(mount, '   '), false);
+  });
+
+  it('matches the exact mount path', () => {
+    assert.strictEqual(isHostMountPath(mount, mount), true);
+  });
+
+  it('matches despite a trailing slash on the effective path (the #150 edge)', () => {
+    assert.strictEqual(isHostMountPath('/srv/charts-host/', mount), true);
+  });
+
+  it('matches despite whitespace around the env value', () => {
+    assert.strictEqual(isHostMountPath(mount, '  /srv/charts-host  '), true);
+  });
+
+  it('matches despite a redundant `.` / `..` segment', () => {
+    assert.strictEqual(isHostMountPath('/srv/./charts-host', mount), true);
+    assert.strictEqual(isHostMountPath('/srv/x/../charts-host', mount), true);
+  });
+
+  it('is false for a genuinely different path', () => {
+    assert.strictEqual(isHostMountPath('/srv/other', mount), false);
+    assert.strictEqual(isHostMountPath('/srv/charts-host-evil', mount), false);
   });
 });
 


### PR DESCRIPTION
## Why

On a Signal-K-in-a-container install (signalk-universal-installer), a user who wants to keep charts in a host folder they share with other apps (OpenCPN/qtVlm/FreeboardSK) currently types that host path into the free-text `chartPath` field — and it fails with a dead-end "Chart directory is not writable", because the container only sees what the installer bind-mounts, not arbitrary host paths.

This is the **consumer half** of a host-charts-folder feature: the installer/updater will mount a chosen host folder into the container and inject its in-container path via a new `SIGNALK_CHARTS_HOST_PATH` env var. This PR makes the plugin consume that env and default to the shared folder with no config.

It is **backward-compatible and safe to ship alone**: with the env unset, behaviour is byte-identical to today — the plugin just gets a clearer, container-aware error for users who hit the path-translation trap.

## What

- `resolveDefaultChartsPath` / `hasHostChartsMountEnv` (pure, in `path-safety.ts`) single-source the "default to the mounted host folder vs the in-data-volume `charts-simple` dir" decision. `getDefaultChartsPath()` and the `chartPath` schema description both use them, so they can never disagree.
- The startup access check treats the host-mount default as **"must already exist"**: it is *probed, never created on demand*. `mkdir`-ing a missing mount would silently shadow it with an ephemeral in-container directory whose charts vanish on container recreate — so instead we surface an actionable error. `classifyChartDirAccess` (pure, tested) distinguishes:
  - a **missing mount** ("Shared charts folder is not mounted … re-run the installer, or clear the setting"),
  - an **existing-but-unwritable** dir ("exists but is not writable … usually a folder-ownership mismatch" — the rootless keep-id case),
  - a plain **not-writable** non-mount path (unchanged wording).

## Tested

- `npm run build` / `npm run lint` / `npm run format` clean.
- `npm run test`: 394 pass / 0 fail (7 new cases for `resolveDefaultChartsPath`, `hasHostChartsMountEnv`, and every `classifyChartDirAccess` branch — host-mount missing / exists-unwritable / ok, and non-mount writable / not-writable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Default the charts directory to the installer-mounted host charts path when `SIGNALK_CHARTS_HOST_PATH` is set, while preserving the existing in-data-volume default when it is not.

Centralize default-path resolution in `src/utils/path-safety.ts` so both `getDefaultChartsPath()` and the `chartPath` schema description use the same effective default logic. Add helpers to (1) detect a non-empty `SIGNALK_CHARTS_HOST_PATH`, (2) resolve the effective default path (host mount vs in-data-volume fallback), and (3) classify chart directory access into `mount-missing`, `exists-unwritable`, `not-writable`, or `ok`.

Update startup validation in `src/index.ts` to treat the host-mounted default as pre-existing and non-creatable: it probes for existence and directory writability without creating directories, then sets specific plugin errors for a missing host mount vs an existing but unwritable mount vs a non-host path that cannot be written. Tighten writability checks to require an actual directory (`statSync(...).isDirectory()`) and both write/execute permissions, and gate non-host `chartPath` acceptance on both `ensureDirectoryExists(...)` and `isDirWritable(...)`.

Expand tests to cover host-mount env parsing, effective default-path resolution, and all access-classification branches. Update test fixtures to use synthetic `/srv/...` paths to avoid CI failures from hardcoded `/home/...` paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->