### PR TITLE
fix(charts): prevent /output/ container path leaking into ENC chart names (#151)

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "eslint-plugin-prettier": "^5.5.4",
     "express": "^5.2.1",
     "leaflet": "^1.9.4",
-    "prettier": "^3.7.4",
+    "prettier": "3.9.1",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.33.1"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1616,16 +1616,14 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
           try {
             const countRow = db.prepare('SELECT COUNT(*) as count FROM map').get() as
-              | { count: number }
-              | undefined;
+              { count: number } | undefined;
             if (countRow) {
               metadata.tileCount = countRow.count;
             }
           } catch {
             try {
               const countRow = db.prepare('SELECT COUNT(*) as count FROM tiles').get() as
-                | { count: number }
-                | undefined;
+                { count: number } | undefined;
               if (countRow) {
                 metadata.tileCount = countRow.count;
               }

--- a/src/types.ts
+++ b/src/types.ts
@@ -246,12 +246,7 @@ export interface CatalogUpdate {
 // ---- Conversion Progress ----
 
 export type ConversionStatus =
-  | 'starting'
-  | 'pulling'
-  | 'extracting'
-  | 'converting'
-  | 'completed'
-  | 'failed';
+  'starting' | 'pulling' | 'extracting' | 'converting' | 'completed' | 'failed';
 
 export interface ConversionProgress {
   status: string;

--- a/src/utils/catalog-manager.ts
+++ b/src/utils/catalog-manager.ts
@@ -274,8 +274,7 @@ async function parseCatalogXml(xmlData: string, catalogFile: string): Promise<Ca
 
   const parsed = result as Record<string, unknown>;
   const root = (parsed.RncProductCatalogChartCatalogs ?? parsed.EncProductCatalogcellCatalogs) as
-    | Record<string, unknown>
-    | undefined;
+    Record<string, unknown> | undefined;
 
   if (!root) {
     throw new Error('Unexpected XML root element');

--- a/src/utils/file-scanner.ts
+++ b/src/utils/file-scanner.ts
@@ -15,8 +15,7 @@ function getChartName(filePath: string): string | null {
 
     try {
       const row = db.prepare("SELECT value FROM metadata WHERE name = 'name'").get() as
-        | { value: string }
-        | undefined;
+        { value: string } | undefined;
       return row ? row.value : null;
     } finally {
       db.close();

--- a/src/utils/mbtiles-metadata.ts
+++ b/src/utils/mbtiles-metadata.ts
@@ -8,8 +8,7 @@ import { DatabaseSync } from 'node:sqlite';
  * engines guard, an import-time failure is loud enough.
  */
 function loadSqlite():
-  | { ok: true; DatabaseSync: typeof DatabaseSync }
-  | { ok: false; reason: string } {
+  { ok: true; DatabaseSync: typeof DatabaseSync } | { ok: false; reason: string } {
   if (typeof DatabaseSync !== 'function') {
     return { ok: false, reason: 'node:sqlite DatabaseSync is not a function' };
   }

--- a/src/utils/mbtiles-reader.ts
+++ b/src/utils/mbtiles-reader.ts
@@ -238,8 +238,7 @@ export class MBTilesReader {
     }
     try {
       const row = this.db.prepare('SELECT tile_data FROM tiles LIMIT 1').get() as unknown as
-        | TileRow
-        | undefined;
+        TileRow | undefined;
       if (!row?.tile_data) {
         return null;
       }

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -1467,11 +1467,14 @@ export async function processS57Directory(
     // patchS57Mbtiles just wrote with the cleaned catalog title, and set
     // `description` to the full original title for provenance. Manual
     // uploads leave displayName undefined and keep the patcher's
-    // `S-57 <chartNumber>` default.
-    if (options.displayName) {
+    // `S-57 <chartNumber>` default. Trim before both the guard and the
+    // value so a whitespace-only label falls through to the fallback
+    // instead of overwriting it with blanks (mirrors wantedMbtilesName).
+    const displayName = options.displayName?.trim();
+    if (displayName) {
       const dnResult = await setMbtilesDisplayName(
         outputPath,
-        options.displayName,
+        displayName,
         options.displayDescription,
         {
           onMessage: (msg) => {

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -143,6 +143,46 @@ function setProgress(chartNumber: string, status: string, message: string): void
 }
 
 /**
+ * The `name` metadata row tippecanoe/tile-join should bake into the output
+ * MBTiles. Without an explicit `-n/--name`, both tools default that row to
+ * the `-o` container path (e.g. `/output/Waddenzee.mbtiles`), which then
+ * leaks into the chart name shown in clients and the catalog screen when the
+ * post-conversion metadata patch fails (it is best-effort and never throws).
+ * Passing this up front means the file is born with a sensible name and the
+ * `/output/...` value can never survive — the patch only ever refines it to
+ * the cleaned catalog title.
+ *
+ * Mirrors the fallback the patcher uses (`S-57 <chartNumber>`) so an
+ * un-patched file matches a patched one's `name` when no displayName exists.
+ */
+function wantedMbtilesName(chartNumber: string, displayName: string | undefined): string {
+  const trimmed = displayName?.trim();
+  return trimmed ? trimmed : `S-57 ${chartNumber || 'ENC'}`;
+}
+
+/**
+ * Best-effort, synchronous overwrite of the `name` metadata row. Used by the
+ * tile-join single-input degenerate path, where no container job runs to bake
+ * the name in via `-n`. DELETE-then-INSERT (not INSERT OR REPLACE) because
+ * tippecanoe's `metadata` table has no UNIQUE constraint on `name`, so REPLACE
+ * would append a second row rather than overwrite. Never throws — the
+ * post-conversion patch is the authoritative pass.
+ */
+function stampMbtilesName(outputPath: string, name: string): void {
+  try {
+    const db = new DatabaseSync(outputPath);
+    try {
+      db.exec("DELETE FROM metadata WHERE name = 'name'");
+      db.prepare("INSERT INTO metadata (name, value) VALUES ('name', ?)").run(name);
+    } finally {
+      db.close();
+    }
+  } catch {
+    /* best-effort; patchS57Mbtiles/setMbtilesDisplayName run afterward */
+  }
+}
+
+/**
  * Decide the on-disk `.mbtiles` filename for a freshly converted chart.
  *
  * Catalogs (NL_IENC, etc.) hand us sequential chart numbers like "1",
@@ -655,7 +695,9 @@ export const _testInternals = {
   buildLayerManifest,
   buildTippecanoeCommand,
   TIPPECANOE_LAYER_MANIFEST,
-  surfaceExportErrorsIfEmpty
+  surfaceExportErrorsIfEmpty,
+  wantedMbtilesName,
+  stampMbtilesName
 };
 
 async function runTippecanoe(
@@ -663,7 +705,11 @@ async function runTippecanoe(
   outputMbtiles: string,
   chartNumber: string,
   options: S57ConversionOptions = {},
-  onTilePercent?: (pct: number) => void
+  onTilePercent?: (pct: number) => void,
+  // The `name` metadata row to bake in. Set only for the final output of a
+  // conversion (single-pass, or the joined per-band result); per-band
+  // intermediates leave it undefined since tile-join sets the final name.
+  mbtilesName?: string
 ): Promise<void> {
   const minzoom = options.minzoom ?? 9;
   const maxzoom = options.maxzoom ?? 16;
@@ -760,6 +806,9 @@ async function runTippecanoe(
       [
         '-o',
         `${outputPrefix}/${path.basename(outputMbtiles)}`,
+        // Bake the `name` metadata row so it never defaults to the `/output/`
+        // container path (issue #151). Omitted for per-band intermediates.
+        ...(mbtilesName ? ['-n', mbtilesName] : []),
         '-z',
         String(maxzoom),
         '-Z',
@@ -825,7 +874,10 @@ async function runTileJoin(
   outputMbtiles: string,
   chartNumber: string,
   onPercent?: (pct: number) => void,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  // The `name` metadata row to bake into the joined output, so it never
+  // defaults to the `/output/` container path (issue #151).
+  mbtilesName?: string
 ): Promise<void> {
   if (inputMbtiles.length === 0) {
     throw new Error('runTileJoin called with no inputs');
@@ -850,6 +902,13 @@ async function runTileJoin(
       }
       fs.copyFileSync(inputMbtiles[0], outputMbtiles);
       fs.unlinkSync(inputMbtiles[0]);
+    }
+    // No tile-join ran, so the moved intermediate still carries its
+    // per-band tippecanoe `name` (the `/output/` default). Stamp the
+    // wanted name directly so this branch matches the joined path.
+    // Best-effort: the post-conversion patch refines it further.
+    if (mbtilesName) {
+      stampMbtilesName(outputMbtiles, mbtilesName);
     }
     // Mirror the multi-input path's completion so the "Combining" bar
     // reaches 100% even when the join collapsed to a single file move.
@@ -953,6 +1012,9 @@ async function runTileJoin(
         'tile-join',
         '-o',
         `${outputPrefix}/${path.basename(outputMbtiles)}`,
+        // Bake the `name` metadata row so the joined output never defaults
+        // to the `/output/` container path (issue #151).
+        ...(mbtilesName ? ['-n', mbtilesName] : []),
         '--no-tile-size-limit',
         '--force',
         ...inputArgs
@@ -1216,7 +1278,14 @@ async function runPerBandPipeline(
       bucketPercent
     });
   emitJoin(0);
-  await runTileJoin(intermediates, outputMbtiles, chartNumber, emitJoin, options.signal);
+  await runTileJoin(
+    intermediates,
+    outputMbtiles,
+    chartNumber,
+    emitJoin,
+    options.signal,
+    wantedMbtilesName(chartNumber, options.displayName)
+  );
 }
 
 /**
@@ -1355,14 +1424,20 @@ export async function processS57Directory(
         appendLog(chartNumber, msg);
       }
       const effectiveOptions: S57ConversionOptions = { ...options, maxzoom: clamp.effective };
-      await runTippecanoe(geojsonDir, outputPath, chartNumber, effectiveOptions, (pct) =>
-        options.onProgress?.({
-          stage: 'tiles',
-          bucketIndex: 1,
-          bucketCount: 1,
-          bucketLabel: 'Charts',
-          bucketPercent: pct
-        })
+      await runTippecanoe(
+        geojsonDir,
+        outputPath,
+        chartNumber,
+        effectiveOptions,
+        (pct) =>
+          options.onProgress?.({
+            stage: 'tiles',
+            bucketIndex: 1,
+            bucketCount: 1,
+            bucketLabel: 'Charts',
+            bucketPercent: pct
+          }),
+        wantedMbtilesName(chartNumber, options.displayName)
       );
     }
 

--- a/test/s57-converter.test.ts
+++ b/test/s57-converter.test.ts
@@ -593,8 +593,7 @@ describe('stampMbtilesName (degenerate single-input tile-join path)', () => {
   function readName(file: string): string | null {
     const db = new DatabaseSync(file);
     const row = db.prepare("SELECT value FROM metadata WHERE name = 'name'").get() as
-      | { value: string }
-      | undefined;
+      { value: string } | undefined;
     db.close();
     return row ? row.value : null;
   }

--- a/test/s57-converter.test.ts
+++ b/test/s57-converter.test.ts
@@ -4,6 +4,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 
 import {
   _testInternals,
@@ -18,7 +19,9 @@ const {
   buildLayerManifest,
   buildTippecanoeCommand,
   TIPPECANOE_LAYER_MANIFEST,
-  surfaceExportErrorsIfEmpty
+  surfaceExportErrorsIfEmpty,
+  wantedMbtilesName,
+  stampMbtilesName
 } = _testInternals;
 
 interface GeoJSONFeature {
@@ -500,6 +503,92 @@ describe('buildTippecanoeCommand (argv stays small regardless of layer count)', 
     assert.ok(
       typeof TIPPECANOE_LAYER_MANIFEST === 'string' && TIPPECANOE_LAYER_MANIFEST.length > 0
     );
+  });
+});
+
+describe('wantedMbtilesName (never lets the /output/ container path become the chart name)', () => {
+  it('uses the cleaned displayName when the catalog supplied one', () => {
+    assert.strictEqual(
+      wantedMbtilesName('1', 'Waddenzee met Diepte 2026 - Week 18'),
+      'Waddenzee met Diepte 2026 - Week 18'
+    );
+  });
+
+  it('trims surrounding whitespace from the displayName', () => {
+    assert.strictEqual(wantedMbtilesName('1', '  Port of Rotterdam  '), 'Port of Rotterdam');
+  });
+
+  it('falls back to `S-57 <chartNumber>` when displayName is missing', () => {
+    assert.strictEqual(wantedMbtilesName('7', undefined), 'S-57 7');
+  });
+
+  it('falls back to `S-57 <chartNumber>` when displayName is blank', () => {
+    assert.strictEqual(wantedMbtilesName('7', '   '), 'S-57 7');
+  });
+
+  it('falls back to `S-57 ENC` when both chartNumber and displayName are empty', () => {
+    assert.strictEqual(wantedMbtilesName('', undefined), 'S-57 ENC');
+  });
+
+  it('never returns a /output/-prefixed value', () => {
+    for (const name of [wantedMbtilesName('1', undefined), wantedMbtilesName('', '')]) {
+      assert.ok(!name.startsWith('/output/'), `unexpected /output/ prefix in "${name}"`);
+    }
+  });
+});
+
+describe('stampMbtilesName (degenerate single-input tile-join path)', () => {
+  let tmp: string;
+
+  before(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-charts-stamp-name-'));
+  });
+
+  after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  // Build a minimal tippecanoe-shaped metadata table whose `name` row is the
+  // leaked container path, then assert stampMbtilesName overwrites it cleanly.
+  function makeMbtiles(name: string): string {
+    const file = path.join(tmp, `${name.replace(/\W+/g, '_')}.mbtiles`);
+    const db = new DatabaseSync(file);
+    db.exec('CREATE TABLE metadata (name TEXT, value TEXT)');
+    db.prepare('INSERT INTO metadata (name, value) VALUES (?, ?)').run('name', name);
+    db.close();
+    return file;
+  }
+
+  function readName(file: string): string | null {
+    const db = new DatabaseSync(file);
+    const row = db.prepare("SELECT value FROM metadata WHERE name = 'name'").get() as
+      | { value: string }
+      | undefined;
+    db.close();
+    return row ? row.value : null;
+  }
+
+  it('overwrites the leaked /output/ name with the wanted name', () => {
+    const file = makeMbtiles('/output/Waddenzee.mbtiles');
+    stampMbtilesName(file, 'Waddenzee met Diepte 2026 - Week 18');
+    assert.strictEqual(readName(file), 'Waddenzee met Diepte 2026 - Week 18');
+  });
+
+  it('leaves exactly one name row (no duplicate from append-style writes)', () => {
+    const file = makeMbtiles('/output/x.mbtiles');
+    stampMbtilesName(file, 'S-57 3');
+    const db = new DatabaseSync(file);
+    const row = db.prepare("SELECT COUNT(*) AS n FROM metadata WHERE name = 'name'").get() as {
+      n: number;
+    };
+    db.close();
+    assert.strictEqual(row.n, 1);
+  });
+
+  it('never throws on a missing file (best-effort contract)', () => {
+    assert.doesNotThrow(() => {
+      stampMbtilesName(path.join(tmp, 'does-not-exist.mbtiles'), 'whatever');
+    });
   });
 });
 

--- a/test/s57-converter.test.ts
+++ b/test/s57-converter.test.ts
@@ -494,6 +494,27 @@ describe('buildTippecanoeCommand (argv stays small regardless of layer count)', 
     assert.match(cmd[2], /'\/out put\/x\.mbtiles'/);
   });
 
+  // The actual #151 leak prevention: an explicit `-n NAME` stops tippecanoe
+  // from defaulting the `name` metadata row to the `-o` container path.
+  it('passes a baked `-n NAME` through (with spaces) so the name is never the /output/ path', () => {
+    const cmd = buildTippecanoeCommand(
+      ['-o', '/output/0.mbtiles', '-n', 'Waddenzee met Diepte 2026 - Week 18'],
+      '/input/.layers'
+    );
+    assert.match(cmd[2], /'-n' 'Waddenzee met Diepte 2026 - Week 18'/);
+  });
+
+  // A hostile chart title must not break out of the single-quoted argv.
+  it('single-quote-escapes a name containing a quote and shell metacharacters', () => {
+    const cmd = buildTippecanoeCommand(
+      ['-o', '/output/0.mbtiles', '-n', `evil'; rm -rf / #`],
+      '/input/.layers'
+    );
+    // The POSIX escape closes the quote, emits an escaped quote, reopens:
+    // evil'\''; rm -rf / # — so the metacharacters stay inside one literal arg.
+    assert.match(cmd[2], /'-n' 'evil'\\''; rm -rf \/ #'/);
+  });
+
   it('quotes the manifest path so a named-volume subPath with spaces works', () => {
     const cmd = buildTippecanoeCommand(['-o', '/output/out.mbtiles'], '/input/My Charts/.layers');
     assert.match(cmd[2], /done < '\/input\/My Charts\/\.layers'/);
@@ -530,8 +551,18 @@ describe('wantedMbtilesName (never lets the /output/ container path become the c
     assert.strictEqual(wantedMbtilesName('', undefined), 'S-57 ENC');
   });
 
-  it('never returns a /output/-prefixed value', () => {
-    for (const name of [wantedMbtilesName('1', undefined), wantedMbtilesName('', '')]) {
+  // wantedMbtilesName produces the name we hand to tippecanoe/tile-join's
+  // `-n`; it does NOT sanitize an already-leaked path (the catalog never
+  // supplies one). The actual leak prevention is that the conversion always
+  // passes THIS value as `-n` so the tool never falls back to the `-o`
+  // container path — asserted in the buildTippecanoeCommand suite below.
+  it('every fallback output is a friendly label, never an /output/ path', () => {
+    for (const name of [
+      wantedMbtilesName('1', undefined),
+      wantedMbtilesName('1', '   '),
+      wantedMbtilesName('', '')
+    ]) {
+      assert.ok(name.startsWith('S-57 '), `expected an S-57 fallback label, got "${name}"`);
       assert.ok(!name.startsWith('/output/'), `unexpected /output/ prefix in "${name}"`);
     }
   });


### PR DESCRIPTION
## Problem

ENC charts converted from the Chart Catalog screen could show up with the container output path baked into their name — e.g. `/output/Waddenzee.mbtiles` instead of the catalog title (issue #151).

## Root cause

The conversion runs `tippecanoe` / `tile-join` in the toolbox container with `-o /output/<file>.mbtiles`. With no explicit `-n/--name`, both tools default the MBTiles `name` metadata row to that `-o` path. The plugin then *post-patches* the name (`patchS57Mbtiles` → `setMbtilesDisplayName`), but those patchers are best-effort and only `console.warn` on failure — so when the patch couldn't run on a user's setup, the `/output/...` name survived into clients and the catalog screen. `charts-loader` surfaces `metadata.name` directly, so it was visible everywhere.

## Fix

Bake the name in at the source so `/output/...` can never become the chart name, instead of relying on the post-hoc cleanup:

- `wantedMbtilesName()` derives the cleaned catalog `displayName`, else `S-57 <chartNumber>` (the same fallback the patcher uses).
- Pass `-n <name>` to `tippecanoe` (single-pass output) and `tile-join` (per-band joined output).
- `stampMbtilesName()` covers the per-band single-input degenerate path, where a plain file move runs instead of a `tile-join` container job.
- Per-band *intermediates* deliberately get no name — `tile-join` sets the final one.

The post-conversion patch stays as the authoritative pass that refines the name to the catalog title; the change just guarantees the worst case is a sensible `S-57 N` label rather than a leaked container path. Defense in depth.

## Scope

This addresses the ENC pipeline (the subject of #151). The BSB/KAP and Pilot raster paths in `rnc-converter.ts` have a similar GDAL-driver name default and are out of scope here — I'll track that separately.

## Tested

- `npm run format:check` — clean (prettier + eslint)
- `npm run build` — clean
- `npm test` — 411 passing, 0 failing
- New unit tests: `wantedMbtilesName` fallbacks; `buildTippecanoeCommand` emits `-n <name>` (incl. a name with spaces and a hostile single-quote/metacharacter title that stays inside one quoted argv); `stampMbtilesName` overwrites a seeded `/output/...` name, leaves exactly one `name` row, and never throws on a missing file.

Closes #151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixes ENC MBTiles naming so chart exports no longer inherit the container `/output/...` path. The conversion pipeline derives a cleaned MBTiles `metadata.name` from the catalog display name (trimming whitespace) or falls back to `S-57 <chartNumber>` / `S-57 ENC`, and passes it into `tippecanoe` and `tile-join` via `-n` so the correct name is baked in during conversion. It adds `stampMbtilesName()` to best-effort overwrite the `metadata.name` for the single-input path that skips `tile-join`, and retains the existing post-conversion display-name metadata patch as a final refinement step.

Updates tests to cover derived-name trimming and fallbacks, prevention of `/output/`-prefixed names, `-n` argv emission (including spaces and shell metacharacters escaping), and SQLite stamping behavior (no duplicate `name` rows, no throw when the MBTiles file is missing). Also pins `prettier` to keep formatting consistent between local and CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->