### PR TITLE
fix(charts): make stampMbtilesName atomic

### DIFF
--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -165,16 +165,30 @@ function wantedMbtilesName(chartNumber: string, displayName: string | undefined)
  * tile-join single-input degenerate path, where no container job runs to bake
  * the name in via `-n`. DELETE-then-INSERT (not INSERT OR REPLACE) because
  * tippecanoe's `metadata` table has no UNIQUE constraint on `name`, so REPLACE
- * would append a second row rather than overwrite. Never throws — the
- * post-conversion patch is the authoritative pass.
+ * would append a second row rather than overwrite. The DELETE + INSERT run in
+ * a transaction so a throwing INSERT can't leave the file with the old `name`
+ * deleted and no replacement (mirrors setMbtilesDisplayName). Never throws —
+ * the post-conversion patch is the authoritative pass.
  */
 function stampMbtilesName(outputPath: string, name: string): void {
   try {
     const db = new DatabaseSync(outputPath);
+    let inTransaction = false;
     try {
+      db.exec('BEGIN TRANSACTION');
+      inTransaction = true;
       db.exec("DELETE FROM metadata WHERE name = 'name'");
       db.prepare("INSERT INTO metadata (name, value) VALUES ('name', ?)").run(name);
+      db.exec('COMMIT');
+      inTransaction = false;
     } finally {
+      if (inTransaction) {
+        try {
+          db.exec('ROLLBACK');
+        } catch {
+          /* already closed / rolled back */
+        }
+      }
       db.close();
     }
   } catch {


### PR DESCRIPTION
## What

Wrap the `DELETE` + `INSERT` in `stampMbtilesName` in a transaction so a throwing `INSERT` can't leave the moved MBTiles with the old `name` row deleted and no replacement. Mirrors the atomicity that `setMbtilesDisplayName` and `patchS57Mbtiles` already use.

## Why

`stampMbtilesName` runs on the per-band single-input degenerate tile-join path (a plain file move, no container job), where it's the only thing that overwrites the `/output/...` default name. Without a transaction, a failure between the `DELETE` and the `INSERT` would leave the file with **no** `name` row at all. It stays best-effort / never-throws — the post-conversion patch remains the authoritative pass — but the window where it could half-apply is now closed.

Follow-up to #152 (issue #151). CodeRabbit flagged this in the #152 review; the fix landed after merge, so it's split out here.

## Tested

- `npm run format:check` — clean
- `npm run build` — clean
- `npm test` — 411 passing, 0 failing (existing `stampMbtilesName` tests cover overwrite, single-row, and never-throw-on-missing-file)

Verified end to end against the real `charts-toolbox:1.1.0` image on a live Signal K server: a catalog ENC conversion produces an MBTiles whose `name` row is the cleaned catalog title (not `/output/...`), with exactly one `name` row.
