### PR TITLE
chore(release): 2.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release 2.3.4.

## Changes since 2.3.3

- **fix(charts): prevent `/output/` container path leaking into ENC chart names (#151, #152)** — ENC charts converted from the Chart Catalog screen could show up with the container output path baked into their name (e.g. `/output/Waddenzee.mbtiles`). tippecanoe/tile-join default the MBTiles `name` metadata row to the `-o` path; now an explicit `-n <name>` bakes the cleaned catalog title (or `S-57 <chartNumber>` fallback) at the source, with the post-conversion patch still the authoritative pass.
- **fix(charts): make `stampMbtilesName` atomic (#153)** — wrap the degenerate single-input tile-join name stamp in a transaction so a throwing INSERT can't leave the file with no `name` row.

Both shipped via PRs already merged to `main` (#152, #153). This is the version bump only.
