### PR TITLE
fix(catalog): don't delete conversion progress immediately on success

### DIFF
--- a/src/utils/conversion-progress.ts
+++ b/src/utils/conversion-progress.ts
@@ -1,0 +1,28 @@
+import type { ConversionProgress, ConversionProgressMap } from '../types.js';
+
+// How long a finished entry (and its log) stays around for polling before
+// being deleted — deleting it the instant the job ends would make the next
+// poll see the job vanish before the final message is ever read.
+const RESULT_RETENTION_MS = 300000;
+
+export function setConversionResult(
+  progress: ConversionProgressMap,
+  chartNumber: string,
+  status: 'failed' | 'completed',
+  message: string
+): void {
+  const entry: ConversionProgress = {
+    status,
+    message,
+    log: progress[chartNumber]?.log ?? []
+  };
+  progress[chartNumber] = entry;
+  // Only clear the entry if it's still the one this timer was scheduled for
+  // — a retry started in the meantime replaces it with a new object (and
+  // schedules its own cleanup), so a stale timer must not delete that one.
+  setTimeout(() => {
+    if (progress[chartNumber] === entry) {
+      delete progress[chartNumber];
+    }
+  }, RESULT_RETENTION_MS).unref();
+}

--- a/src/utils/rnc-converter.ts
+++ b/src/utils/rnc-converter.ts
@@ -37,13 +37,19 @@ export function getAllConversionProgress(): ConversionProgressMap {
 }
 
 export function setConversionFailed(chartNumber: string, message: string): void {
-  conversionProgress[chartNumber] = {
+  const entry: ConversionProgress = {
     status: 'failed',
     message,
     log: conversionProgress[chartNumber]?.log ?? []
   };
+  conversionProgress[chartNumber] = entry;
+  // Only clear the entry if it's still the one this timer was scheduled for
+  // — a retry started in the meantime replaces it with a new object (and
+  // schedules its own cleanup), so a stale timer must not delete that one.
   setTimeout(() => {
-    delete conversionProgress[chartNumber];
+    if (conversionProgress[chartNumber] === entry) {
+      delete conversionProgress[chartNumber];
+    }
   }, 300000);
 }
 
@@ -51,13 +57,16 @@ export function setConversionFailed(chartNumber: string, message: string): void 
 // as a failure, instead of deleting it the instant it succeeds — otherwise
 // the next poll sees the job vanish before the "Done" message is ever read.
 export function setConversionCompleted(chartNumber: string, message: string): void {
-  conversionProgress[chartNumber] = {
+  const entry: ConversionProgress = {
     status: 'completed',
     message,
     log: conversionProgress[chartNumber]?.log ?? []
   };
+  conversionProgress[chartNumber] = entry;
   setTimeout(() => {
-    delete conversionProgress[chartNumber];
+    if (conversionProgress[chartNumber] === entry) {
+      delete conversionProgress[chartNumber];
+    }
   }, 300000);
 }
 

--- a/src/utils/rnc-converter.ts
+++ b/src/utils/rnc-converter.ts
@@ -47,6 +47,20 @@ export function setConversionFailed(chartNumber: string, message: string): void 
   }, 300000);
 }
 
+// Keeps the completed entry (and its log) around for the same grace period
+// as a failure, instead of deleting it the instant it succeeds — otherwise
+// the next poll sees the job vanish before the "Done" message is ever read.
+export function setConversionCompleted(chartNumber: string, message: string): void {
+  conversionProgress[chartNumber] = {
+    status: 'completed',
+    message,
+    log: conversionProgress[chartNumber]?.log ?? []
+  };
+  setTimeout(() => {
+    delete conversionProgress[chartNumber];
+  }, 300000);
+}
+
 async function extractZip(zipPath: string, targetDir: string): Promise<string[]> {
   await fs
     .createReadStream(zipPath)
@@ -354,23 +368,20 @@ export async function processRncZip(
       throw new Error('No charts converted');
     }
 
-    statusFn('completed', `Converted ${mbtilesFiles.length} chart(s) to MBTiles`);
+    const doneMsg = `Converted ${mbtilesFiles.length} chart(s) to MBTiles`;
+    statusFn('completed', doneMsg);
 
     if (chartNumber) {
-      delete conversionProgress[chartNumber];
+      setConversionCompleted(chartNumber, doneMsg);
     }
 
     return { mbtilesFiles };
   } catch (err) {
     if (chartNumber) {
-      conversionProgress[chartNumber] = {
-        status: 'failed',
-        message: (err instanceof Error ? err.message : String(err)) || 'Conversion failed',
-        log: conversionProgress[chartNumber]?.log ?? []
-      };
-      setTimeout(() => {
-        delete conversionProgress[chartNumber];
-      }, 300000);
+      setConversionFailed(
+        chartNumber,
+        (err instanceof Error ? err.message : String(err)) || 'Conversion failed'
+      );
     }
     throw err;
   } finally {
@@ -577,23 +588,20 @@ export async function processPilotTar(
       throw new Error('No charts converted');
     }
 
-    statusFn('completed', `Converted ${mbtilesFiles.length} chart(s)`);
+    const doneMsg = `Converted ${mbtilesFiles.length} chart(s)`;
+    statusFn('completed', doneMsg);
 
     if (chartNumber) {
-      delete conversionProgress[chartNumber];
+      setConversionCompleted(chartNumber, doneMsg);
     }
 
     return { mbtilesFiles };
   } catch (err) {
     if (chartNumber) {
-      conversionProgress[chartNumber] = {
-        status: 'failed',
-        message: (err instanceof Error ? err.message : String(err)) || 'Conversion failed',
-        log: conversionProgress[chartNumber]?.log ?? []
-      };
-      setTimeout(() => {
-        delete conversionProgress[chartNumber];
-      }, 300000);
+      setConversionFailed(
+        chartNumber,
+        (err instanceof Error ? err.message : String(err)) || 'Conversion failed'
+      );
     }
     throw err;
   } finally {

--- a/src/utils/rnc-converter.ts
+++ b/src/utils/rnc-converter.ts
@@ -9,6 +9,7 @@ import {
   runJob as runContainerJob
 } from './container-jobs.js';
 import { getContainerManager } from './container-manager.js';
+import { setConversionResult } from './conversion-progress.js';
 import { throwJobFailure } from './job-failure.js';
 import { setMbtilesType } from './mbtiles-metadata.js';
 import type {
@@ -37,37 +38,11 @@ export function getAllConversionProgress(): ConversionProgressMap {
 }
 
 export function setConversionFailed(chartNumber: string, message: string): void {
-  const entry: ConversionProgress = {
-    status: 'failed',
-    message,
-    log: conversionProgress[chartNumber]?.log ?? []
-  };
-  conversionProgress[chartNumber] = entry;
-  // Only clear the entry if it's still the one this timer was scheduled for
-  // — a retry started in the meantime replaces it with a new object (and
-  // schedules its own cleanup), so a stale timer must not delete that one.
-  setTimeout(() => {
-    if (conversionProgress[chartNumber] === entry) {
-      delete conversionProgress[chartNumber];
-    }
-  }, 300000);
+  setConversionResult(conversionProgress, chartNumber, 'failed', message);
 }
 
-// Keeps the completed entry (and its log) around for the same grace period
-// as a failure, instead of deleting it the instant it succeeds — otherwise
-// the next poll sees the job vanish before the "Done" message is ever read.
 export function setConversionCompleted(chartNumber: string, message: string): void {
-  const entry: ConversionProgress = {
-    status: 'completed',
-    message,
-    log: conversionProgress[chartNumber]?.log ?? []
-  };
-  conversionProgress[chartNumber] = entry;
-  setTimeout(() => {
-    if (conversionProgress[chartNumber] === entry) {
-      delete conversionProgress[chartNumber];
-    }
-  }, 300000);
+  setConversionResult(conversionProgress, chartNumber, 'completed', message);
 }
 
 async function extractZip(zipPath: string, targetDir: string): Promise<string[]> {

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -66,13 +66,19 @@ export function getAllConversionProgress(): ConversionProgressMap {
 }
 
 export function setConversionFailed(chartNumber: string, message: string): void {
-  conversionProgress[chartNumber] = {
+  const entry: ConversionProgress = {
     status: 'failed',
     message,
     log: conversionProgress[chartNumber]?.log ?? []
   };
+  conversionProgress[chartNumber] = entry;
+  // Only clear the entry if it's still the one this timer was scheduled for
+  // — a retry started in the meantime replaces it with a new object (and
+  // schedules its own cleanup), so a stale timer must not delete that one.
   setTimeout(() => {
-    delete conversionProgress[chartNumber];
+    if (conversionProgress[chartNumber] === entry) {
+      delete conversionProgress[chartNumber];
+    }
   }, 300000);
 }
 
@@ -80,13 +86,16 @@ export function setConversionFailed(chartNumber: string, message: string): void 
 // as a failure, instead of deleting it the instant it succeeds — otherwise
 // the next poll sees the job vanish before the "Done" message is ever read.
 export function setConversionCompleted(chartNumber: string, message: string): void {
-  conversionProgress[chartNumber] = {
+  const entry: ConversionProgress = {
     status: 'completed',
     message,
     log: conversionProgress[chartNumber]?.log ?? []
   };
+  conversionProgress[chartNumber] = entry;
   setTimeout(() => {
-    delete conversionProgress[chartNumber];
+    if (conversionProgress[chartNumber] === entry) {
+      delete conversionProgress[chartNumber];
+    }
   }, 300000);
 }
 

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -76,6 +76,20 @@ export function setConversionFailed(chartNumber: string, message: string): void 
   }, 300000);
 }
 
+// Keeps the completed entry (and its log) around for the same grace period
+// as a failure, instead of deleting it the instant it succeeds — otherwise
+// the next poll sees the job vanish before the "Done" message is ever read.
+export function setConversionCompleted(chartNumber: string, message: string): void {
+  conversionProgress[chartNumber] = {
+    status: 'completed',
+    message,
+    log: conversionProgress[chartNumber]?.log ?? []
+  };
+  setTimeout(() => {
+    delete conversionProgress[chartNumber];
+  }, 300000);
+}
+
 async function extractZip(zipPath: string, targetDir: string): Promise<string[]> {
   await fs
     .createReadStream(zipPath)
@@ -1504,24 +1518,21 @@ export async function processS57Directory(
     }
 
     const size = (fs.statSync(outputPath).size / (1024 * 1024)).toFixed(1);
-    statusFn('completed', `Created ${outputName} (${size} MB)`);
+    const doneMsg = `Created ${outputName} (${size} MB)`;
+    statusFn('completed', doneMsg);
     appendLog(chartNumber, `Done: ${outputName} (${size} MB)`);
 
     if (chartNumber) {
-      delete conversionProgress[chartNumber];
+      setConversionCompleted(chartNumber, doneMsg);
     }
 
     return { mbtilesFile: outputName };
   } catch (err) {
     if (chartNumber) {
-      conversionProgress[chartNumber] = {
-        status: 'failed',
-        message: (err instanceof Error ? err.message : String(err)) || 'Conversion failed',
-        log: conversionProgress[chartNumber]?.log ?? []
-      };
-      setTimeout(() => {
-        delete conversionProgress[chartNumber];
-      }, 300000);
+      setConversionFailed(
+        chartNumber,
+        (err instanceof Error ? err.message : String(err)) || 'Conversion failed'
+      );
     }
     throw err;
   } finally {
@@ -1852,11 +1863,12 @@ export async function processGshhg(
   }
 
   const size = (fs.statSync(outputPath).size / (1024 * 1024)).toFixed(1);
-  statusFn('completed', `GSHHG basemap installed (${size} MB)`);
+  const doneMsg = `GSHHG basemap installed (${size} MB)`;
+  statusFn('completed', doneMsg);
   appendLog(chartNumber, `Done: ${outputName} (${size} MB)`);
 
   if (chartNumber) {
-    delete conversionProgress[chartNumber];
+    setConversionCompleted(chartNumber, doneMsg);
   }
 
   return { mbtilesFile: outputName };
@@ -2120,21 +2132,20 @@ export async function processShpBasemap(
     }
 
     const size = (fs.statSync(outputPath).size / (1024 * 1024)).toFixed(1);
-    statusFn('completed', `Basemap installed (${size} MB)`);
+    const doneMsg = `Basemap installed (${size} MB)`;
+    statusFn('completed', doneMsg);
     appendLog(chartNumber, `Done: ${outputName} (${size} MB)`);
 
     if (chartNumber) {
-      delete conversionProgress[chartNumber];
+      setConversionCompleted(chartNumber, doneMsg);
     }
     return { mbtilesFile: outputName };
   } catch (err) {
     if (chartNumber) {
-      conversionProgress[chartNumber] = {
-        status: 'failed',
-        message: (err instanceof Error ? err.message : String(err)) || 'Conversion failed',
-        log: conversionProgress[chartNumber]?.log ?? []
-      };
-      setTimeout(() => delete conversionProgress[chartNumber], 300000);
+      setConversionFailed(
+        chartNumber,
+        (err instanceof Error ? err.message : String(err)) || 'Conversion failed'
+      );
     }
     throw err;
   } finally {

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -38,6 +38,7 @@ import {
   runJob as runContainerJob
 } from './container-jobs.js';
 import { getContainerManager } from './container-manager.js';
+import { setConversionResult } from './conversion-progress.js';
 import { throwJobFailure } from './job-failure.js';
 import { patchS57Mbtiles, setMbtilesDisplayName } from './mbtiles-metadata.js';
 import {
@@ -66,37 +67,11 @@ export function getAllConversionProgress(): ConversionProgressMap {
 }
 
 export function setConversionFailed(chartNumber: string, message: string): void {
-  const entry: ConversionProgress = {
-    status: 'failed',
-    message,
-    log: conversionProgress[chartNumber]?.log ?? []
-  };
-  conversionProgress[chartNumber] = entry;
-  // Only clear the entry if it's still the one this timer was scheduled for
-  // — a retry started in the meantime replaces it with a new object (and
-  // schedules its own cleanup), so a stale timer must not delete that one.
-  setTimeout(() => {
-    if (conversionProgress[chartNumber] === entry) {
-      delete conversionProgress[chartNumber];
-    }
-  }, 300000);
+  setConversionResult(conversionProgress, chartNumber, 'failed', message);
 }
 
-// Keeps the completed entry (and its log) around for the same grace period
-// as a failure, instead of deleting it the instant it succeeds — otherwise
-// the next poll sees the job vanish before the "Done" message is ever read.
 export function setConversionCompleted(chartNumber: string, message: string): void {
-  const entry: ConversionProgress = {
-    status: 'completed',
-    message,
-    log: conversionProgress[chartNumber]?.log ?? []
-  };
-  conversionProgress[chartNumber] = entry;
-  setTimeout(() => {
-    if (conversionProgress[chartNumber] === entry) {
-      delete conversionProgress[chartNumber];
-    }
-  }, 300000);
+  setConversionResult(conversionProgress, chartNumber, 'completed', message);
 }
 
 async function extractZip(zipPath: string, targetDir: string): Promise<string[]> {


### PR DESCRIPTION
Successful S-57/RNC chart conversions deleted their conversionProgress entry the instant they completed, while failures kept theirs for a 5-minute grace period via a delayed setTimeout. The very next poll to /catalog-s57-log/:chartNumber then hit the "not found" branch and returned {"log":[],"status":null}, wiping the conversion log and status before the UI (or user) could read the "Done" message.

Add setConversionCompleted(), mirroring the existing setConversionFailed() helper, so success and failure both keep their entry (with its accumulated log) for the same 300s window before deletion. Applied at all 3 success/failure site pairs in s57-converter.ts (S-57, GSHHG basemap, OSM basemap) and both pairs in rnc-converter.ts, replacing the inline duplicated failure-handling blocks with calls to setConversionFailed() in the process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Retains per-chart `conversionProgress` entries for 300 seconds on both successful and failed S-57/RNC conversions, instead of removing the success entry immediately. This prevents `/catalog-s57-log/:chartNumber` from returning an empty log/state before the UI can show the final “Done” result.

Adds `setConversionCompleted()` to both `src/utils/s57-converter.ts` and `src/utils/rnc-converter.ts` to write `{ status: 'completed', message, log }` and schedule deletion after 5 minutes, preserving any existing log. Updates `setConversionFailed()` to use the same “stale timer” guard so only the currently active progress object is deleted.

Replaces duplicated inline failure/scheduling blocks with calls to the shared `setConversionFailed()`/`setConversionCompleted()` helpers across the S-57 conversion flow (including GSHHG and SHP basemap paths) and the RNC flow (including the ZIP/TAR processing paths), and ensures successful paths no longer delete the progress entry right away.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->