### PR TITLE
feat(catalog): raise conversion log retention from 100 to 1000 lines

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ import { initChartState, isChartEnabled, setChartEnabled } from './utils/chart-s
 import { getCpuBudget, setCpuBudget } from './utils/concurrency.js';
 import { PLUGIN_OWNER_ID } from './utils/container-jobs.js';
 import { getContainerManager, waitForContainerManager } from './utils/container-manager.js';
-import { MAX_CONVERSION_LOG_LINES } from './utils/conversion-log.js';
+import { MAX_CONVERSION_LOG_LINES, resolveLogTail } from './utils/conversion-log.js';
 import { downloadManager } from './utils/download-manager.js';
 import { scanAllFolders, scanChartsRecursively } from './utils/file-scanner.js';
 import { repairMbtilesMetadata, setMbtilesDisplayName } from './utils/mbtiles-metadata.js';
@@ -101,6 +101,7 @@ import {
   isCatalogCancelRequested,
   isValidCatalogId,
   listCustomCatalogs,
+  MAX_CATALOG_MANAGER_LOG_LINES,
   registerCatalogAbort,
   requestCatalogCancel,
   saveCustomCatalog,
@@ -1973,7 +1974,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         res.json({ log: [], status: null });
         return;
       }
-      const tail = parseInt(req.query.tail as string) || MAX_CONVERSION_LOG_LINES;
+      const tail = resolveLogTail(req.query.tail, MAX_CONVERSION_LOG_LINES);
       const log = progress.log || [];
       res.json({
         log: log.slice(-tail),
@@ -2645,7 +2646,14 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         res.status(400).json({ log: [], status: null });
         return;
       }
-      const tail = parseInt(req.query.tail as string) || MAX_CONVERSION_LOG_LINES;
+      // Default returns the whole log: the concatenated manager + s57 log can
+      // be at most the sum of the two per-source caps, so this fallback never
+      // truncates by default (at the cost of a larger payload on each poll —
+      // callers that want less should pass an explicit ?tail=).
+      const tail = resolveLogTail(
+        req.query.tail,
+        MAX_CATALOG_MANAGER_LOG_LINES + MAX_CONVERSION_LOG_LINES
+      );
       const managerProgress = getCatalogProgress(id);
       const s57 = getS57Progress(id);
       // Manager progress carries the download phase; the S-57 converter carries

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import { initChartState, isChartEnabled, setChartEnabled } from './utils/chart-s
 import { getCpuBudget, setCpuBudget } from './utils/concurrency.js';
 import { PLUGIN_OWNER_ID } from './utils/container-jobs.js';
 import { getContainerManager, waitForContainerManager } from './utils/container-manager.js';
+import { MAX_CONVERSION_LOG_LINES } from './utils/conversion-log.js';
 import { downloadManager } from './utils/download-manager.js';
 import { scanAllFolders, scanChartsRecursively } from './utils/file-scanner.js';
 import { repairMbtilesMetadata, setMbtilesDisplayName } from './utils/mbtiles-metadata.js';
@@ -1972,7 +1973,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         res.json({ log: [], status: null });
         return;
       }
-      const tail = parseInt(req.query.tail as string) || 100;
+      const tail = parseInt(req.query.tail as string) || MAX_CONVERSION_LOG_LINES;
       const log = progress.log || [];
       res.json({
         log: log.slice(-tail),
@@ -2644,7 +2645,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         res.status(400).json({ log: [], status: null });
         return;
       }
-      const tail = parseInt(req.query.tail as string) || 200;
+      const tail = parseInt(req.query.tail as string) || MAX_CONVERSION_LOG_LINES;
       const managerProgress = getCatalogProgress(id);
       const s57 = getS57Progress(id);
       // Manager progress carries the download phase; the S-57 converter carries

--- a/src/utils/conversion-log.ts
+++ b/src/utils/conversion-log.ts
@@ -6,3 +6,16 @@
  * being stored.
  */
 export const MAX_CONVERSION_LOG_LINES = 1000;
+
+/**
+ * Resolve the `tail` query param for a log-polling route into the number of
+ * trailing lines to return. Falls back to `fallback` (which callers set to the
+ * maximum number of lines that route can have stored) for anything that isn't a
+ * positive integer — missing, non-numeric, `0`, or negative. Negative values
+ * are rejected rather than passed through, since `slice(-tail)` would otherwise
+ * flip meaning and drop the newest lines instead of tailing.
+ */
+export function resolveLogTail(raw: unknown, fallback: number): number {
+  const parsed = parseInt(String(raw), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/src/utils/conversion-log.ts
+++ b/src/utils/conversion-log.ts
@@ -1,0 +1,8 @@
+/**
+ * Cap on how many lines of per-chart conversion log output are retained in
+ * memory (s57-converter.ts, rnc-converter.ts) and the default number of
+ * lines returned by the log-polling routes in index.ts. Single source of
+ * truth so the routes never truncate a response below what's actually
+ * being stored.
+ */
+export const MAX_CONVERSION_LOG_LINES = 1000;

--- a/src/utils/custom-catalog-manager.ts
+++ b/src/utils/custom-catalog-manager.ts
@@ -24,7 +24,8 @@ import { computeInclusion, coverageByBox, type FootprintIndex } from './noaa-enc
 
 export const CUSTOM_CATALOG_SCHEMA_VERSION = 1;
 const CATALOG_DIR_NAME = 'custom-catalogs';
-const MAX_LOG_LINES = 200;
+export const MAX_CATALOG_MANAGER_LOG_LINES = 200;
+const MAX_LOG_LINES = MAX_CATALOG_MANAGER_LOG_LINES;
 
 export type CustomCatalogStatus = 'empty' | 'out_of_date' | 'downloaded' | 'converted';
 

--- a/src/utils/rnc-converter.ts
+++ b/src/utils/rnc-converter.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import unzipper from 'unzipper';
 import { makeContainerWritableDir } from './container-fs.js';
 import { CHARTS_TOOLBOX_IMAGE } from './container-images.js';
+import { MAX_CONVERSION_LOG_LINES } from './conversion-log.js';
 import {
   ensureImage as ensureContainerImage,
   resolveJobPaths,
@@ -20,7 +21,7 @@ import type {
 } from '../types.js';
 
 const conversionProgress: ConversionProgressMap = {};
-const MAX_LOG_LINES = 100;
+const MAX_LOG_LINES = MAX_CONVERSION_LOG_LINES;
 
 let debug: DebugFunction = () => {};
 

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -32,6 +32,7 @@ import { sanitizeChartFilename } from './catalog-title.js';
 import { getCpuBudget } from './concurrency.js';
 import { makeContainerWritable, makeContainerWritableDir } from './container-fs.js';
 import { CHARTS_TOOLBOX_IMAGE } from './container-images.js';
+import { MAX_CONVERSION_LOG_LINES } from './conversion-log.js';
 import {
   ensureImage as ensureContainerImage,
   resolveJobPaths,
@@ -49,7 +50,7 @@ import {
 } from './s57-band.js';
 
 const conversionProgress: ConversionProgressMap = {};
-const MAX_LOG_LINES = 100;
+const MAX_LOG_LINES = MAX_CONVERSION_LOG_LINES;
 
 let debug: DebugFunction = () => {};
 


### PR DESCRIPTION
Tippecanoe's tile-progress output alone can burn through ~90 lines going from 93% to 100%, pushing meaningful messages (errors, retries, patch warnings) out of the previous 100-line window before anyone gets to read them.

Add a shared MAX_CONVERSION_LOG_LINES constant (utils/conversion-log.ts, following the same single-source-of-truth pattern as CHARTS_TOOLBOX_IMAGE in container-images.ts) so the per-chart log cap in both converters and the default `tail` on
/catalog-s57-log/:chartNumber and /custom-catalogs/:id/log all move together — bumping the cap can no longer leave a route silently truncating the larger stored log back down to the old default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized log output limits across conversion-related endpoints and processing.
  * Increased the default number of log lines returned for log views, so you can see more recent history by default.
  * Kept the optional `tail` parameter behavior unchanged while aligning its default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->