### PR TITLE
fix(catalog): make container-written charts host-writable for metadata patching

### DIFF
--- a/src/utils/container-fs.ts
+++ b/src/utils/container-fs.ts
@@ -38,3 +38,38 @@ export function makeContainerWritable(dir: string): void {
     }
   }
 }
+
+// Single-quote a string for the shell so paths/flags with spaces or
+// metacharacters survive word-splitting intact as one argv element.
+export const shellQuote = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
+
+/**
+ * Wrap a plain-argv container command in a `bash -c` script that runs it and
+ * then `chmod 666`s its output file — while the container is still running as
+ * the owning UID.
+ *
+ * `makeContainerWritable` above fixes the *directory* the container writes
+ * into, but the toolbox image's tools (tippecanoe, gdaladdo, tile-join,
+ * gdal_translate, …) run as the baked-in UID 1001, so the *file* they create
+ * lands owned by 1001 with owner-only write (0o644). On deployments without
+ * userns keep-id remapping (Docker, rootful podman) the host SignalK process
+ * runs as a different UID and can't open that file read-write — the
+ * post-conversion metadata patch (patchS57Mbtiles / setMbtilesType /
+ * setMbtilesDisplayName) then fails with "attempt to write a readonly
+ * database". A host-side chmod can't fix this: the host doesn't own the file.
+ * The chmod has to run in-container as the owning UID, which is what this does.
+ *
+ * `set -e` aborts the script if the wrapped tool fails, so the chmod only runs
+ * on success. Callers that tolerate a non-zero exit from the wrapped tool (and
+ * still patch the file afterwards) must therefore ensure an *earlier*,
+ * mandatory step has already chmod'd the file — see the gdal_translate calls
+ * in rnc-converter.ts.
+ */
+export function withOutputChmod(argv: readonly string[], outputContainerPath: string): string[] {
+  const script = [
+    'set -e',
+    argv.map(shellQuote).join(' '),
+    `chmod 666 ${shellQuote(outputContainerPath)}`
+  ].join('\n');
+  return ['bash', '-c', script];
+}

--- a/src/utils/rnc-converter.ts
+++ b/src/utils/rnc-converter.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import unzipper from 'unzipper';
-import { makeContainerWritableDir } from './container-fs.js';
+import { makeContainerWritableDir, withOutputChmod } from './container-fs.js';
 import { CHARTS_TOOLBOX_IMAGE } from './container-images.js';
 import {
   ensureImage as ensureContainerImage,
@@ -69,21 +69,8 @@ async function extractZip(zipPath: string, targetDir: string): Promise<string[]>
   return allFiles;
 }
 
-// The toolbox image's helper tools (gdal_translate, gdaladdo, …) all run as
-// the image's fixed UID, so whatever they write lands owned by that UID
-// with owner-only write. The host SignalK process is commonly a different
-// UID and can't write the file afterward — e.g. the post-conversion
-// metadata patch (setMbtilesType below) fails with "attempt to write a
-// readonly database". Appending a `chmod` to the same container
-// invocation fixes this at the source, while the container is still
-// running as the owning UID.
-function withOutputChmod(argv: readonly string[], outputContainerPath: string): string[] {
-  const sq = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
-  const script = ['set -e', argv.map(sq).join(' '), `chmod 666 ${sq(outputContainerPath)}`].join(
-    '\n'
-  );
-  return ['bash', '-c', script];
-}
+// `withOutputChmod` lives in container-fs.ts so both converters share one copy
+// — see the import at the top of this file.
 
 function appendLog(chartNumber: string, text: string): void {
   if (!chartNumber || !text) {
@@ -141,18 +128,25 @@ export async function convertKapToMbtiles(
     ? `/output/${resolved['/output'].subPath}`
     : '/output';
 
+  const containerOutput = `${outputPrefix}/${baseName}.mbtiles`;
   const result = await runContainerJob({
     image: CHARTS_TOOLBOX_IMAGE,
     label: `gdal-translate-${chartNumber || baseName}`,
-    command: [
-      'gdal_translate',
-      '-of',
-      'MBTiles',
-      '-co',
-      'TILE_FORMAT=PNG',
-      `${inputPrefix}/${path.basename(kapFile)}`,
-      `${outputPrefix}/${baseName}.mbtiles`
-    ],
+    // chmod on this mandatory step so the file is host-writable for any later
+    // metadata patch, even when the optional addOverviews/gdaladdo step fails
+    // (its withOutputChmod is skipped by `set -e` on a non-zero exit).
+    command: withOutputChmod(
+      [
+        'gdal_translate',
+        '-of',
+        'MBTiles',
+        '-co',
+        'TILE_FORMAT=PNG',
+        `${inputPrefix}/${path.basename(kapFile)}`,
+        containerOutput
+      ],
+      containerOutput
+    ),
     inputs: { '/input': resolved['/input'].source },
     outputs: { '/output': resolved['/output'].source },
     // Single-process GDAL stage; one core is enough.
@@ -322,15 +316,24 @@ export async function processRncZip(
       const translateResult = await runContainerJob({
         image: CHARTS_TOOLBOX_IMAGE,
         label: `gdal-translate-${baseName}`,
-        command: [
-          'gdal_translate',
-          '-of',
-          'MBTiles',
-          '-co',
-          'TILE_FORMAT=PNG',
-          containerInput,
+        // chmod the output here, on the mandatory step that creates the file —
+        // not only on the optional gdaladdo overview step below. gdaladdo
+        // failure is tolerated (a warning, then we still patch metadata via
+        // setMbtilesType), and its withOutputChmod is skipped by `set -e` when
+        // the tool fails — which would leave the file 0o644 and the patch
+        // failing with "attempt to write a readonly database".
+        command: withOutputChmod(
+          [
+            'gdal_translate',
+            '-of',
+            'MBTiles',
+            '-co',
+            'TILE_FORMAT=PNG',
+            containerInput,
+            containerOutput
+          ],
           containerOutput
-        ],
+        ),
         inputs: { '/input': resolved['/input'].source },
         outputs: { '/output': resolved['/output'].source },
         // Single-process GDAL stage; one core is enough.
@@ -548,15 +551,21 @@ export async function processPilotTar(
       const translateResult = await runContainerJob({
         image: CHARTS_TOOLBOX_IMAGE,
         label: `gdal-translate-${baseName}`,
-        command: [
-          'gdal_translate',
-          '-of',
-          'MBTiles',
-          '-co',
-          'TILE_FORMAT=PNG',
-          containerInput,
+        // chmod on this mandatory step (see processRncZip above) so the file is
+        // host-writable even when the optional gdaladdo overview step fails and
+        // its withOutputChmod is skipped by `set -e`.
+        command: withOutputChmod(
+          [
+            'gdal_translate',
+            '-of',
+            'MBTiles',
+            '-co',
+            'TILE_FORMAT=PNG',
+            containerInput,
+            containerOutput
+          ],
           containerOutput
-        ],
+        ),
         inputs: { '/input': convResolved['/input'].source },
         outputs: { '/output': convResolved['/output'].source },
         // Single-process GDAL stage; one core is enough.

--- a/src/utils/rnc-converter.ts
+++ b/src/utils/rnc-converter.ts
@@ -69,6 +69,22 @@ async function extractZip(zipPath: string, targetDir: string): Promise<string[]>
   return allFiles;
 }
 
+// The toolbox image's helper tools (gdal_translate, gdaladdo, …) all run as
+// the image's fixed UID, so whatever they write lands owned by that UID
+// with owner-only write. The host SignalK process is commonly a different
+// UID and can't write the file afterward — e.g. the post-conversion
+// metadata patch (setMbtilesType below) fails with "attempt to write a
+// readonly database". Appending a `chmod` to the same container
+// invocation fixes this at the source, while the container is still
+// running as the owning UID.
+function withOutputChmod(argv: readonly string[], outputContainerPath: string): string[] {
+  const sq = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
+  const script = ['set -e', argv.map(sq).join(' '), `chmod 666 ${sq(outputContainerPath)}`].join(
+    '\n'
+  );
+  return ['bash', '-c', script];
+}
+
 function appendLog(chartNumber: string, text: string): void {
   if (!chartNumber || !text) {
     return;
@@ -175,7 +191,10 @@ async function addOverviews(mbtilesFile: string, chartNumber: string): Promise<v
   const result = await runContainerJob({
     image: CHARTS_TOOLBOX_IMAGE,
     label: `gdaladdo-${chartNumber || name}`,
-    command: ['gdaladdo', '-r', 'average', `${dataPrefix}/${name}`, '2', '4', '8', '16'],
+    command: withOutputChmod(
+      ['gdaladdo', '-r', 'average', `${dataPrefix}/${name}`, '2', '4', '8', '16'],
+      `${dataPrefix}/${name}`
+    ),
     outputs: { '/data': resolved['/data'].source },
     // Single-process; one core is enough.
     resources: { cpus: 1 },
@@ -327,7 +346,10 @@ export async function processRncZip(
       const overviewResult = await runContainerJob({
         image: CHARTS_TOOLBOX_IMAGE,
         label: `gdaladdo-${baseName}`,
-        command: ['gdaladdo', '-r', 'average', containerOutput, '2', '4', '8', '16'],
+        command: withOutputChmod(
+          ['gdaladdo', '-r', 'average', containerOutput, '2', '4', '8', '16'],
+          containerOutput
+        ),
         outputs: { '/output': resolved['/output'].source },
         // Single-process; one core is enough.
         resources: { cpus: 1 },
@@ -550,7 +572,10 @@ export async function processPilotTar(
       const overviewResult = await runContainerJob({
         image: CHARTS_TOOLBOX_IMAGE,
         label: `gdaladdo-${baseName}`,
-        command: ['gdaladdo', '-r', 'average', containerOutput, '2', '4', '8', '16'],
+        command: withOutputChmod(
+          ['gdaladdo', '-r', 'average', containerOutput, '2', '4', '8', '16'],
+          containerOutput
+        ),
         outputs: { '/output': convResolved['/output'].source },
         // Single-process; one core is enough.
         resources: { cpus: 1 },

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -30,7 +30,12 @@ function throwIfJobCancelled(result: { status?: string }): void {
 }
 import { sanitizeChartFilename } from './catalog-title.js';
 import { getCpuBudget } from './concurrency.js';
-import { makeContainerWritable, makeContainerWritableDir } from './container-fs.js';
+import {
+  makeContainerWritable,
+  makeContainerWritableDir,
+  shellQuote,
+  withOutputChmod
+} from './container-fs.js';
 import { CHARTS_TOOLBOX_IMAGE } from './container-images.js';
 import {
   ensureImage as ensureContainerImage,
@@ -675,27 +680,9 @@ function buildLayerManifest(
   );
 }
 
-// Single-quote a string for the shell so paths/flags with spaces or
-// metacharacters survive word-splitting intact as one argv element.
-const shellQuote = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
-
-// The toolbox image's helper tools (tippecanoe, gdaladdo, tile-join, …) all
-// run as the image's fixed UID, so whatever they write lands owned by that
-// UID with owner-only write. The host SignalK process is commonly a
-// different UID and can't write the file afterward — e.g. the
-// post-conversion metadata patch fails with "attempt to write a readonly
-// database". Appending a `chmod` to the same container invocation fixes
-// this at the source, while the container is still running as the owning
-// UID, instead of the host trying (and failing) to reclaim write access
-// after the fact.
-function withOutputChmod(argv: readonly string[], outputContainerPath: string): string[] {
-  const script = [
-    'set -e',
-    argv.map(shellQuote).join(' '),
-    `chmod 666 ${shellQuote(outputContainerPath)}`
-  ].join('\n');
-  return ['bash', '-c', script];
-}
+// `shellQuote` and `withOutputChmod` live in container-fs.ts (next to
+// makeContainerWritable, the rest of the toolbox-UID permission story) so both
+// converters share one copy — see the imports at the top of this file.
 
 // Build the tippecanoe invocation as a small `bash -c` script that reads the
 // `-L` layer pairs from the manifest at runtime, instead of inlining them into

--- a/src/utils/s57-converter.ts
+++ b/src/utils/s57-converter.ts
@@ -675,6 +675,28 @@ function buildLayerManifest(
   );
 }
 
+// Single-quote a string for the shell so paths/flags with spaces or
+// metacharacters survive word-splitting intact as one argv element.
+const shellQuote = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
+
+// The toolbox image's helper tools (tippecanoe, gdaladdo, tile-join, …) all
+// run as the image's fixed UID, so whatever they write lands owned by that
+// UID with owner-only write. The host SignalK process is commonly a
+// different UID and can't write the file afterward — e.g. the
+// post-conversion metadata patch fails with "attempt to write a readonly
+// database". Appending a `chmod` to the same container invocation fixes
+// this at the source, while the container is still running as the owning
+// UID, instead of the host trying (and failing) to reclaim write access
+// after the fact.
+function withOutputChmod(argv: readonly string[], outputContainerPath: string): string[] {
+  const script = [
+    'set -e',
+    argv.map(shellQuote).join(' '),
+    `chmod 666 ${shellQuote(outputContainerPath)}`
+  ].join('\n');
+  return ['bash', '-c', script];
+}
+
 // Build the tippecanoe invocation as a small `bash -c` script that reads the
 // `-L` layer pairs from the manifest at runtime, instead of inlining them into
 // argv. A large bundle has 100+ layers, so inlining produced a 200+ element
@@ -689,15 +711,20 @@ function buildTippecanoeCommand(
   // Single-quote for the shell so paths/flags with spaces survive
   // word-splitting (the manifest path can carry a named-volume subPath, and
   // chart dirs commonly contain spaces).
-  const sq = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
+  const sq = shellQuote;
   const quoted = fixedArgs.map(sq).join(' ');
+  // The `-o <path>` pair gives us the container-side output path to chmod
+  // once tippecanoe is done — see withOutputChmod above for why.
+  const outputIndex = fixedArgs.indexOf('-o');
+  const outputContainerPath = outputIndex >= 0 ? fixedArgs[outputIndex + 1] : undefined;
   const script = [
     'set -e',
     'layers=()',
     `while IFS= read -r line; do`,
     '  [ -n "$line" ] && layers+=(-L "$line")',
     `done < ${sq(manifestContainerPath)}`,
-    `exec tippecanoe ${quoted} "\${layers[@]}"`
+    `tippecanoe ${quoted} "\${layers[@]}"`,
+    ...(outputContainerPath ? [`chmod 666 ${sq(outputContainerPath)}`] : [])
   ].join('\n');
   return ['bash', '-c', script];
 }
@@ -708,6 +735,7 @@ export const _testInternals = {
   bandClampedMaxzoom,
   buildLayerManifest,
   buildTippecanoeCommand,
+  withOutputChmod,
   TIPPECANOE_LAYER_MANIFEST,
   surfaceExportErrorsIfEmpty,
   wantedMbtilesName,
@@ -1022,17 +1050,20 @@ async function runTileJoin(
     result = await runContainerJob({
       image: CHARTS_TOOLBOX_IMAGE,
       label: `tile-join-${chartNumber}`,
-      command: [
-        'tile-join',
-        '-o',
-        `${outputPrefix}/${path.basename(outputMbtiles)}`,
-        // Bake the `name` metadata row so the joined output never defaults
-        // to the `/output/` container path (issue #151).
-        ...(mbtilesName ? ['-n', mbtilesName] : []),
-        '--no-tile-size-limit',
-        '--force',
-        ...inputArgs
-      ],
+      command: withOutputChmod(
+        [
+          'tile-join',
+          '-o',
+          `${outputPrefix}/${path.basename(outputMbtiles)}`,
+          // Bake the `name` metadata row so the joined output never defaults
+          // to the `/output/` container path (issue #151).
+          ...(mbtilesName ? ['-n', mbtilesName] : []),
+          '--no-tile-size-limit',
+          '--force',
+          ...inputArgs
+        ],
+        `${outputPrefix}/${path.basename(outputMbtiles)}`
+      ),
       inputs: { '/input': resolved['/input'].source },
       outputs: { '/output': resolved['/output'].source },
       env: { TIPPECANOE_MAX_THREADS: String(tippecanoeThreads) },
@@ -1812,20 +1843,23 @@ export async function processGshhg(
   const overviewResult = await runContainerJob({
     image: CHARTS_TOOLBOX_IMAGE,
     label: `gdaladdo-${chartNumber}`,
-    command: [
-      'gdaladdo',
-      '-r',
-      'average',
-      `${outputPrefix}/${outputName}`,
-      '2',
-      '4',
-      '8',
-      '16',
-      '32',
-      '64',
-      '128',
-      '256'
-    ],
+    command: withOutputChmod(
+      [
+        'gdaladdo',
+        '-r',
+        'average',
+        `${outputPrefix}/${outputName}`,
+        '2',
+        '4',
+        '8',
+        '16',
+        '32',
+        '64',
+        '128',
+        '256'
+      ],
+      `${outputPrefix}/${outputName}`
+    ),
     outputs: { '/output': resolved['/output'].source },
     // Single-process; one core is enough.
     resources: { cpus: 1 },
@@ -2081,20 +2115,23 @@ export async function processShpBasemap(
     const overviewResult = await runContainerJob({
       image: CHARTS_TOOLBOX_IMAGE,
       label: `gdaladdo-${chartNumber}`,
-      command: [
-        'gdaladdo',
-        '-r',
-        'average',
-        `${outputPrefix}/${outputName}`,
-        '2',
-        '4',
-        '8',
-        '16',
-        '32',
-        '64',
-        '128',
-        '256'
-      ],
+      command: withOutputChmod(
+        [
+          'gdaladdo',
+          '-r',
+          'average',
+          `${outputPrefix}/${outputName}`,
+          '2',
+          '4',
+          '8',
+          '16',
+          '32',
+          '64',
+          '128',
+          '256'
+        ],
+        `${outputPrefix}/${outputName}`
+      ),
       outputs: { '/output': rasterResolved['/output'].source },
       // Single-process; one core is enough.
       resources: { cpus: 1 },

--- a/test/container-fs.test.ts
+++ b/test/container-fs.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { shellQuote, withOutputChmod } from '../dist/utils/container-fs.js';
+
+// `withOutputChmod` wraps a plain-argv container command (gdaladdo, tile-join,
+// gdal_translate) in a `bash -c` script that runs it and then chmod 666's the
+// output — while the container is still the owning UID 1001 — so the host
+// SignalK process (commonly a different UID) can patch the file's metadata
+// afterward instead of hitting "attempt to write a readonly database". This
+// helper used to be copy-pasted into both converters; the tests below exercise
+// the single shared copy directly.
+describe('withOutputChmod (container output becomes host-writable)', () => {
+  it('returns a 3-element bash -c command running the original argv then a chmod', () => {
+    const cmd = withOutputChmod(
+      ['gdaladdo', '-r', 'average', '/output/x.mbtiles'],
+      '/output/x.mbtiles'
+    );
+    assert.strictEqual(cmd.length, 3);
+    assert.strictEqual(cmd[0], 'bash');
+    assert.strictEqual(cmd[1], '-c');
+    const lines = cmd[2].split('\n');
+    const argvLine = lines.findIndex((l: string) => l.includes('gdaladdo'));
+    const chmodLine = lines.findIndex((l: string) => l.includes('chmod 666'));
+    assert.ok(argvLine >= 0 && chmodLine >= 0);
+    assert.ok(chmodLine > argvLine, 'chmod must run after the original command, not before');
+  });
+
+  it('runs `set -e` first so a failing original command skips the chmod', () => {
+    const cmd = withOutputChmod(['gdaladdo', '/output/x.mbtiles'], '/output/x.mbtiles');
+    assert.strictEqual(cmd[2].split('\n')[0], 'set -e');
+  });
+
+  it('shell-quotes both the argv and the chmod target so paths with spaces survive', () => {
+    const cmd = withOutputChmod(
+      ['gdaladdo', '-r', 'average', '/out put/x.mbtiles'],
+      '/out put/x.mbtiles'
+    );
+    assert.match(cmd[2], /'\/out put\/x\.mbtiles'/);
+    assert.match(cmd[2], /chmod 666 '\/out put\/x\.mbtiles'/);
+  });
+
+  // The chmod target is passed independently of the argv, so a caller can chmod
+  // a different path than any single argv element (e.g. the `-o` output) — make
+  // sure both are quoted from the one source of truth.
+  it('quotes an argv element and the chmod target independently', () => {
+    const cmd = withOutputChmod(
+      ['tile-join', '-o', '/output/joined.mbtiles'],
+      '/output/joined.mbtiles'
+    );
+    // Every argv element is single-quoted, including the tool name itself.
+    assert.match(cmd[2], /'tile-join' '-o' '\/output\/joined\.mbtiles'/);
+    assert.match(cmd[2], /chmod 666 '\/output\/joined\.mbtiles'/);
+  });
+});
+
+describe('shellQuote (POSIX single-quote escaping)', () => {
+  it('wraps a plain string in single quotes', () => {
+    assert.strictEqual(shellQuote('/output/x.mbtiles'), `'/output/x.mbtiles'`);
+  });
+
+  // A hostile chart title must not break out of the single-quoted argv: the
+  // POSIX escape closes the quote, emits an escaped quote, then reopens.
+  it('escapes embedded single quotes and shell metacharacters', () => {
+    assert.strictEqual(shellQuote(`evil'; rm -rf / #`), `'evil'\\''; rm -rf / #'`);
+  });
+});

--- a/test/s57-converter.test.ts
+++ b/test/s57-converter.test.ts
@@ -18,7 +18,6 @@ const {
   bandClampedMaxzoom,
   buildLayerManifest,
   buildTippecanoeCommand,
-  withOutputChmod,
   TIPPECANOE_LAYER_MANIFEST,
   surfaceExportErrorsIfEmpty,
   wantedMbtilesName,
@@ -537,41 +536,6 @@ describe('buildTippecanoeCommand (argv stays small regardless of layer count)', 
     assert.ok(
       typeof TIPPECANOE_LAYER_MANIFEST === 'string' && TIPPECANOE_LAYER_MANIFEST.length > 0
     );
-  });
-});
-
-// gdaladdo/tile-join (unlike tippecanoe) run as plain argv today; this is
-// what wraps them in the same bash -c + trailing-chmod shape so their
-// output is host-writable afterward too — see buildTippecanoeCommand above
-// for why that matters.
-describe('withOutputChmod (gdaladdo/tile-join output becomes host-writable)', () => {
-  it('returns a 3-element bash -c command running the original argv then a chmod', () => {
-    const cmd = withOutputChmod(
-      ['gdaladdo', '-r', 'average', '/output/x.mbtiles'],
-      '/output/x.mbtiles'
-    );
-    assert.strictEqual(cmd.length, 3);
-    assert.strictEqual(cmd[0], 'bash');
-    assert.strictEqual(cmd[1], '-c');
-    const lines = cmd[2].split('\n');
-    const argvLine = lines.findIndex((l: string) => l.includes('gdaladdo'));
-    const chmodLine = lines.findIndex((l: string) => l.includes('chmod 666'));
-    assert.ok(argvLine >= 0 && chmodLine >= 0);
-    assert.ok(chmodLine > argvLine, 'chmod must run after the original command, not before');
-  });
-
-  it('shell-quotes both the argv and the chmod target so paths with spaces survive', () => {
-    const cmd = withOutputChmod(
-      ['gdaladdo', '-r', 'average', '/out put/x.mbtiles'],
-      '/out put/x.mbtiles'
-    );
-    assert.match(cmd[2], /'\/out put\/x\.mbtiles'/);
-    assert.match(cmd[2], /chmod 666 '\/out put\/x\.mbtiles'/);
-  });
-
-  it('runs `set -e` first so a failing original command skips the chmod', () => {
-    const cmd = withOutputChmod(['gdaladdo', '/output/x.mbtiles'], '/output/x.mbtiles');
-    assert.strictEqual(cmd[2].split('\n')[0], 'set -e');
   });
 });
 

--- a/test/s57-converter.test.ts
+++ b/test/s57-converter.test.ts
@@ -18,6 +18,7 @@ const {
   bandClampedMaxzoom,
   buildLayerManifest,
   buildTippecanoeCommand,
+  withOutputChmod,
   TIPPECANOE_LAYER_MANIFEST,
   surfaceExportErrorsIfEmpty,
   wantedMbtilesName,
@@ -474,13 +475,25 @@ describe('buildTippecanoeCommand (argv stays small regardless of layer count)', 
     assert.strictEqual(cmd.length, 3);
     assert.strictEqual(cmd[0], 'bash');
     assert.strictEqual(cmd[1], '-c');
-    // Reads the manifest (quoted), assembles -L args, execs tippecanoe.
+    // Reads the manifest (quoted), assembles -L args, runs tippecanoe.
     assert.match(cmd[2], /< '\/input\/\.layers'/);
     assert.match(cmd[2], /layers\+=\(-L "\$line"\)/);
-    assert.match(
-      cmd[2],
-      /exec tippecanoe '-o' '\/output\/out\.mbtiles' '-z' '14' "\$\{layers\[@\]\}"/
-    );
+    assert.match(cmd[2], /tippecanoe '-o' '\/output\/out\.mbtiles' '-z' '14' "\$\{layers\[@\]\}"/);
+  });
+
+  // The toolbox container's fixed UID owns whatever tippecanoe writes; a
+  // trailing chmod (run while still that UID) is what lets the host
+  // SignalK process — commonly a different UID — write to it afterward
+  // (e.g. the post-conversion metadata patch).
+  it('chmods the -o output path after tippecanoe runs, not before (no exec)', () => {
+    const cmd = buildTippecanoeCommand(['-o', '/output/out.mbtiles', '-z', '14'], '/input/.layers');
+    assert.doesNotMatch(cmd[2], /exec tippecanoe/);
+    const lines = cmd[2].split('\n');
+    const tippecanoeLine = lines.findIndex((l: string) => l.includes('tippecanoe '));
+    const chmodLine = lines.findIndex((l: string) => l.includes('chmod 666'));
+    assert.ok(tippecanoeLine >= 0 && chmodLine >= 0);
+    assert.ok(chmodLine > tippecanoeLine, 'chmod must run after tippecanoe, not before');
+    assert.match(lines[chmodLine], /chmod 666 '\/output\/out\.mbtiles'/);
   });
 
   it('keeps argv length constant whether there are 2 or 200 layers', () => {
@@ -524,6 +537,41 @@ describe('buildTippecanoeCommand (argv stays small regardless of layer count)', 
     assert.ok(
       typeof TIPPECANOE_LAYER_MANIFEST === 'string' && TIPPECANOE_LAYER_MANIFEST.length > 0
     );
+  });
+});
+
+// gdaladdo/tile-join (unlike tippecanoe) run as plain argv today; this is
+// what wraps them in the same bash -c + trailing-chmod shape so their
+// output is host-writable afterward too — see buildTippecanoeCommand above
+// for why that matters.
+describe('withOutputChmod (gdaladdo/tile-join output becomes host-writable)', () => {
+  it('returns a 3-element bash -c command running the original argv then a chmod', () => {
+    const cmd = withOutputChmod(
+      ['gdaladdo', '-r', 'average', '/output/x.mbtiles'],
+      '/output/x.mbtiles'
+    );
+    assert.strictEqual(cmd.length, 3);
+    assert.strictEqual(cmd[0], 'bash');
+    assert.strictEqual(cmd[1], '-c');
+    const lines = cmd[2].split('\n');
+    const argvLine = lines.findIndex((l: string) => l.includes('gdaladdo'));
+    const chmodLine = lines.findIndex((l: string) => l.includes('chmod 666'));
+    assert.ok(argvLine >= 0 && chmodLine >= 0);
+    assert.ok(chmodLine > argvLine, 'chmod must run after the original command, not before');
+  });
+
+  it('shell-quotes both the argv and the chmod target so paths with spaces survive', () => {
+    const cmd = withOutputChmod(
+      ['gdaladdo', '-r', 'average', '/out put/x.mbtiles'],
+      '/out put/x.mbtiles'
+    );
+    assert.match(cmd[2], /'\/out put\/x\.mbtiles'/);
+    assert.match(cmd[2], /chmod 666 '\/out put\/x\.mbtiles'/);
+  });
+
+  it('runs `set -e` first so a failing original command skips the chmod', () => {
+    const cmd = withOutputChmod(['gdaladdo', '/output/x.mbtiles'], '/output/x.mbtiles');
+    assert.strictEqual(cmd[2].split('\n')[0], 'set -e');
   });
 });
 


### PR DESCRIPTION
Root cause of the "attempt to write a readonly database" warnings seen during S-57/RNC conversion (confirmed against a live deployment): the charts-toolbox container runs every helper tool (tippecanoe, gdal_translate, gdaladdo, tile-join) as a fixed UID baked into the image. Whatever they write lands on the host owned by that UID with owner-only write (mode 644). The signalk-server process patching that file's MBTiles metadata afterward commonly runs as a *different* host UID and can only read it, not write — confirmed via `ps`/`/proc` on a live instance (container UID 1001 vs. running signalk-server UID 1000). The retries already in patchS57Mbtiles/setMbtilesDisplayName never helped because this is a permanent ownership mismatch, not a transient lock.

Fix at the source: append a `chmod 666` to each container command that produces or last touches a chart's output file, run while the container is still the owning UID, instead of having the host try (and fail) to reclaim write access afterward. Covers tippecanoe (buildTippecanoeCommand), tile-join, and both GSHHG/OSM basemap gdaladdo steps in s57-converter.ts, plus the equivalent gdaladdo steps in rnc-converter.ts (same container/host UID mismatch, not yet reported but identically reproducible).

buildTippecanoeCommand's script no longer `exec`s tippecanoe directly, since a trailing chmod needs to run after it; `set -e` still aborts the script (skipping the chmod) if the underlying tool fails. Adds a withOutputChmod() helper (mirrored in both converter files) for the plain-argv gdaladdo/tile-join commands that weren't already bash -c wrapped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixes “attempt to write a readonly database” warnings during S-57/RNC chart conversion by making chart output files writable by the host immediately after container-side chart-generation steps complete.

- Adds `shellQuote` and a `withOutputChmod()` wrapper in `src/utils/container-fs.ts` that runs a command inside `bash -c` and appends `chmod 666` for a specified output path on successful completion (`set -e` prevents chmod after failures).
- Updates `src/utils/s57-converter.ts` to use `withOutputChmod()` for `tile-join` and the `gdaladdo` overview pipelines, and updates `buildTippecanoeCommand` so it invokes `tippecanoe` without `exec`, allowing the subsequent container-side chmod of the `-o` output to run afterward.
- Updates `src/utils/rnc-converter.ts` to wrap `gdal_translate` (which creates the MBTiles/DB) and the per-chart `gdaladdo -r average` overview step with `withOutputChmod()` so the file is writable before later metadata patching.
- Extends tests to validate `withOutputChmod` structure, quoting, and chmod ordering/failure behavior (`test/container-fs.test.ts`), and updates S-57 command-generation tests to assert `chmod` appears after `tippecanoe` and that `exec tippecanoe` is not used (`test/s57-converter.test.ts`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->