### PR TITLE
fix(charts): infer S-57 type from vector layers when metadata patch failed

### DIFF
--- a/src/charts-loader.ts
+++ b/src/charts-loader.ts
@@ -13,9 +13,36 @@ import type {
 
 const KNOWN_CHART_TYPES = new Set(['tilelayer', 's-57', 'mapstylejson', 'tilejson', 'wms', 'wmts']);
 
-function resolveChartType(metadataType: string | undefined): string {
+// S-57 object-class layer names that only ever appear in ENC-derived vector
+// tiles. Freeboard only applies its land/depth S-57 style when the served
+// chart type is `S-57`; a chart whose `type=S-57` metadata row failed to get
+// written (e.g. the post-conversion patch couldn't open the file read-write
+// under Docker/rootful-podman — issue #157) still carries these layers, so we
+// can recognize it as S-57 from the tile schema and style it correctly instead
+// of serving it as a generic, unstyled vector tilelayer (freeboard-sk #436).
+const S57_LAYER_MARKERS = ['LNDARE', 'DEPARE', 'DEPCNT', 'COALNE', 'SOUNDG'];
+
+function looksLikeS57(format: string | undefined, layerIds: string[]): boolean {
+  if ((format ?? '').toLowerCase() !== 'pbf') {
+    return false;
+  }
+  return layerIds.some((id) => S57_LAYER_MARKERS.includes(id));
+}
+
+function resolveChartType(
+  metadataType: string | undefined,
+  format?: string,
+  layerIds: string[] = []
+): string {
   if (metadataType && KNOWN_CHART_TYPES.has(metadataType.toLowerCase())) {
     return metadataType;
+  }
+  // The metadata `type` is missing or unrecognized (tippecanoe's default
+  // `overlay`, or an un-patched file). Recover the S-57 type from the tile
+  // schema so the chart still gets its proper style; otherwise fall back to a
+  // plain tilelayer.
+  if (looksLikeS57(format, layerIds)) {
+    return 'S-57';
   }
   return 'tilelayer';
 }
@@ -102,7 +129,7 @@ async function openMbtilesFile(file: string, filename: string): Promise<ChartPro
       minzoom: metadata.minzoom,
       maxzoom: metadata.maxzoom,
       format: metadata.format ?? 'png',
-      type: resolveChartType(metadata.type),
+      type: resolveChartType(metadata.type, metadata.format, vectorLayers),
       scale: parseInt(metadata.scale ?? '', 10) || 250000,
       ...(tileSize !== undefined ? { tileSize } : {}),
 

--- a/test/charts-loader-s57-type.test.ts
+++ b/test/charts-loader-s57-type.test.ts
@@ -1,0 +1,120 @@
+/**
+ * charts-loader: recover the S-57 chart type from the tile schema when the
+ * metadata `type` row is missing or unrecognized.
+ *
+ * Background (freeboard-sk #436 / this repo's #157): the post-conversion patch
+ * that stamps `type=S-57` opens the .mbtiles read-write. Under Docker or
+ * rootful podman the container writes the file owned by a different UID than
+ * signalk-server, so that patch fails ("attempt to write a readonly database")
+ * and the file keeps tippecanoe's default `type=overlay`. charts-loader then
+ * served it as a generic `tilelayer`, and Freeboard only applies its land/depth
+ * S-57 style when the served type is `S-57` — so land silently stopped
+ * rendering. The loader now recognizes an ENC vector tileset from its S-57
+ * object-class layers and serves it as `S-57` regardless.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { gzipSync } from 'node:zlib';
+
+import { findCharts } from '../dist/charts-loader.js';
+
+// A minimal valid MVT tile so the file isn't empty. Content is irrelevant to
+// the metadata-driven type resolution under test; charts-loader keys off the
+// metadata `format`/`vector_layers`, not the tile bytes.
+const EMPTY_MVT = gzipSync(Buffer.from([]));
+
+function writeMbtiles(
+  file: string,
+  opts: { type?: string; format: string; layers: string[] }
+): void {
+  const db = new DatabaseSync(file);
+  db.exec(`
+    CREATE TABLE metadata (name TEXT, value TEXT);
+    CREATE TABLE tiles (zoom_level INTEGER, tile_column INTEGER, tile_row INTEGER, tile_data BLOB);
+    CREATE UNIQUE INDEX tile_index ON tiles (zoom_level, tile_column, tile_row);
+  `);
+  const md = db.prepare('INSERT INTO metadata (name, value) VALUES (?, ?)');
+  md.run('name', 'fixture');
+  md.run('format', opts.format);
+  md.run('bounds', '-5,50,0,54');
+  md.run('minzoom', '9');
+  md.run('maxzoom', '16');
+  if (opts.type !== undefined) {
+    md.run('type', opts.type);
+  }
+  md.run('json', JSON.stringify({ vector_layers: opts.layers.map((id) => ({ id, fields: {} })) }));
+  db.prepare('INSERT INTO tiles VALUES (9, 0, 0, ?)').run(EMPTY_MVT);
+  db.close();
+}
+
+describe('charts-loader S-57 type recovery (freeboard-sk #436)', () => {
+  let dir: string;
+  before(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cps-loader-'));
+  });
+  after(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('serves an un-patched ENC vector chart (type=overlay) as S-57', async () => {
+    writeMbtiles(path.join(dir, 'unpatched.mbtiles'), {
+      type: 'overlay',
+      format: 'pbf',
+      layers: ['DEPARE', 'LNDARE', 'SOUNDG', 'COALNE']
+    });
+    const charts = await findCharts(dir);
+    assert.strictEqual(charts['unpatched'].type, 'S-57');
+  });
+
+  it('serves a vector chart with no type row at all as S-57 when S-57 layers are present', async () => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.mkdirSync(dir, { recursive: true });
+    writeMbtiles(path.join(dir, 'notype.mbtiles'), {
+      format: 'pbf',
+      layers: ['LNDARE', 'DEPCNT']
+    });
+    const charts = await findCharts(dir);
+    assert.strictEqual(charts['notype'].type, 'S-57');
+  });
+
+  it('keeps an explicit type=S-57 chart as S-57 (no regression)', async () => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.mkdirSync(dir, { recursive: true });
+    writeMbtiles(path.join(dir, 'patched.mbtiles'), {
+      type: 'S-57',
+      format: 'pbf',
+      layers: ['LNDARE', 'DEPARE']
+    });
+    const charts = await findCharts(dir);
+    assert.strictEqual(charts['patched'].type, 'S-57');
+  });
+
+  it('does NOT promote a generic vector tileset (no S-57 layers) to S-57', async () => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.mkdirSync(dir, { recursive: true });
+    writeMbtiles(path.join(dir, 'generic.mbtiles'), {
+      type: 'overlay',
+      format: 'pbf',
+      layers: ['water', 'roads', 'buildings']
+    });
+    const charts = await findCharts(dir);
+    assert.strictEqual(charts['generic'].type, 'tilelayer');
+  });
+
+  it('does NOT treat a raster chart as S-57 even if its type is unrecognized', async () => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.mkdirSync(dir, { recursive: true });
+    writeMbtiles(path.join(dir, 'raster.mbtiles'), {
+      type: 'overlay',
+      format: 'png',
+      layers: []
+    });
+    const charts = await findCharts(dir);
+    assert.strictEqual(charts['raster'].type, 'tilelayer');
+  });
+});

--- a/test/charts-loader-s57-type.test.ts
+++ b/test/charts-loader-s57-type.test.ts
@@ -53,68 +53,73 @@ function writeMbtiles(
 }
 
 describe('charts-loader S-57 type recovery (freeboard-sk #436)', () => {
-  let dir: string;
+  let root: string;
   before(() => {
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cps-loader-'));
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'cps-loader-'));
   });
   after(() => {
-    fs.rmSync(dir, { recursive: true, force: true });
+    // maxRetries/retryDelay rides out the brief window where Windows still
+    // holds a lock on a just-closed .mbtiles (EBUSY on unlink otherwise).
+    fs.rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
   });
 
+  // Write a one-chart .mbtiles into its own subdir, load it through the real
+  // findCharts, then close the reader handle findCharts leaves open (charts
+  // hold a live node:sqlite handle, which locks the file on Windows). Returns
+  // the served chart type.
+  async function loadType(
+    name: string,
+    opts: { type?: string; format: string; layers: string[] }
+  ): Promise<string> {
+    const dir = fs.mkdtempSync(path.join(root, `${name}-`));
+    writeMbtiles(path.join(dir, `${name}.mbtiles`), opts);
+    const charts = await findCharts(dir);
+    const chart = charts[name] as { type: string; _mbtilesHandle?: { close?: () => void } };
+    chart._mbtilesHandle?.close?.();
+    return chart.type;
+  }
+
   it('serves an un-patched ENC vector chart (type=overlay) as S-57', async () => {
-    writeMbtiles(path.join(dir, 'unpatched.mbtiles'), {
+    const type = await loadType('unpatched', {
       type: 'overlay',
       format: 'pbf',
       layers: ['DEPARE', 'LNDARE', 'SOUNDG', 'COALNE']
     });
-    const charts = await findCharts(dir);
-    assert.strictEqual(charts['unpatched'].type, 'S-57');
+    assert.strictEqual(type, 'S-57');
   });
 
   it('serves a vector chart with no type row at all as S-57 when S-57 layers are present', async () => {
-    fs.rmSync(dir, { recursive: true, force: true });
-    fs.mkdirSync(dir, { recursive: true });
-    writeMbtiles(path.join(dir, 'notype.mbtiles'), {
+    const type = await loadType('notype', {
       format: 'pbf',
       layers: ['LNDARE', 'DEPCNT']
     });
-    const charts = await findCharts(dir);
-    assert.strictEqual(charts['notype'].type, 'S-57');
+    assert.strictEqual(type, 'S-57');
   });
 
   it('keeps an explicit type=S-57 chart as S-57 (no regression)', async () => {
-    fs.rmSync(dir, { recursive: true, force: true });
-    fs.mkdirSync(dir, { recursive: true });
-    writeMbtiles(path.join(dir, 'patched.mbtiles'), {
+    const type = await loadType('patched', {
       type: 'S-57',
       format: 'pbf',
       layers: ['LNDARE', 'DEPARE']
     });
-    const charts = await findCharts(dir);
-    assert.strictEqual(charts['patched'].type, 'S-57');
+    assert.strictEqual(type, 'S-57');
   });
 
   it('does NOT promote a generic vector tileset (no S-57 layers) to S-57', async () => {
-    fs.rmSync(dir, { recursive: true, force: true });
-    fs.mkdirSync(dir, { recursive: true });
-    writeMbtiles(path.join(dir, 'generic.mbtiles'), {
+    const type = await loadType('generic', {
       type: 'overlay',
       format: 'pbf',
       layers: ['water', 'roads', 'buildings']
     });
-    const charts = await findCharts(dir);
-    assert.strictEqual(charts['generic'].type, 'tilelayer');
+    assert.strictEqual(type, 'tilelayer');
   });
 
   it('does NOT treat a raster chart as S-57 even if its type is unrecognized', async () => {
-    fs.rmSync(dir, { recursive: true, force: true });
-    fs.mkdirSync(dir, { recursive: true });
-    writeMbtiles(path.join(dir, 'raster.mbtiles'), {
+    const type = await loadType('raster', {
       type: 'overlay',
       format: 'png',
       layers: []
     });
-    const charts = await findCharts(dir);
-    assert.strictEqual(charts['raster'].type, 'tilelayer');
+    assert.strictEqual(type, 'tilelayer');
   });
 });


### PR DESCRIPTION
## Why

A vector chart whose `type=S-57` metadata row never got written is served as a generic `tilelayer`, and Freeboard only applies its land/depth S-57 style when the served type is `S-57` — so land silently stops rendering (SignalK/freeboard-sk#436).

That `type` row is normally stamped by the post-conversion patch (`patchS57Mbtiles` / `setMbtilesDisplayName`), which opens the `.mbtiles` read-write. When the container wrote the file as a different UID than signalk-server (Docker / rootful podman, no userns keep-id remap), that patch failed with *"attempt to write a readonly database"* (#157) and the file kept tippecanoe's default `type=overlay`. #158 fixes the write path so the patch succeeds; this change makes the loader resilient even if that stamp is ever missing.

## What

`resolveChartType` now recovers the S-57 type from the tile schema: a `pbf` chart carrying S-57 object-class layers (LNDARE / DEPARE / DEPCNT / COALNE / SOUNDG) is served as `S-57` even when the metadata `type` row is missing or unrecognized. Generic vector tilesets (no S-57 layers) and raster charts are unaffected — they still resolve to `tilelayer` as before.

This is defense-in-depth alongside #158 (the write-path fix): #158 removes the cause, this bounds the blast radius so a failed patch degrades gracefully instead of silently un-styling the chart.

## Tested

- New `test/charts-loader-s57-type.test.ts` drives the real `findCharts` against generated `.mbtiles` fixtures: un-patched (`type=overlay`) ENC vector chart → served as `S-57`; no `type` row at all → `S-57`; explicit `type=S-57` unchanged; generic vector tileset (no S-57 layers) not promoted; raster chart not promoted.
- `npm run format && npm run build && npm run test` (423 pass) and `npm run lint` all green.

Relates to SignalK/freeboard-sk#436.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Infers `S-57` chart type for MBTiles `pbf` vector tiles when the metadata `type` row is missing or unrecognized, by checking the tile schema for known S-57 object-class layer IDs and only then promoting the chart; it otherwise preserves explicit `S-57` when present and falls back to `tilelayer` for generic vector tilesets and raster charts.

Updates the chart-loading tests to use per-test `mkdtemp` subdirectories via a `loadType()` helper, avoiding cross-test teardown issues on Windows and preventing `EBUSY` unlink races by closing the SQLite handle after loading and using retry-based cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->