### PR TITLE
ci(charts-toolbox): only rebuild image on recipe changes

### DIFF
--- a/.github/workflows/build-charts-toolbox.yml
+++ b/.github/workflows/build-charts-toolbox.yml
@@ -4,9 +4,13 @@ on:
   workflow_dispatch:
   push:
     branches: [main, master]
+    # Only rebuild when the image recipe itself changes. Deliberately not
+    # triggered by edits to this workflow file: a change here (e.g. a
+    # Dependabot action bump) doesn't alter the image, and rebuilding an
+    # unchanged VERSION would just fail the "tag already exists" guard. Use
+    # workflow_dispatch to run a build after editing the workflow.
     paths:
       - 'docker/charts-toolbox/**'
-      - '.github/workflows/build-charts-toolbox.yml'
 
 env:
   IMAGE: ghcr.io/${{ github.repository }}/charts-toolbox


### PR DESCRIPTION
Merging #149 (Dependabot bump of `actions/checkout` v6→v7) triggered the "Build charts-toolbox image" workflow on push to `main`, which then failed:

```
##[error]Image tag …/charts-toolbox:1.1.0 already exists in the registry.
##[error]Bump docker/charts-toolbox/VERSION before pushing changes to docker/charts-toolbox/**.
```

([failed run](https://github.com/dirkwa/signalk-charts-provider-simple/actions/runs/28662094686))

## Root cause

The workflow's trigger included its own file in `paths:`:

```yaml
paths:
  - 'docker/charts-toolbox/**'
  - '.github/workflows/build-charts-toolbox.yml'
```

Dependabot's bump edited `- uses: actions/checkout@v7` inside that workflow file, so the second path matched and a build kicked off — even though the image itself was unchanged. The "Verify VERSION tag is unique" guard (added deliberately to refuse re-publishing an existing tag) then correctly failed, because `docker/charts-toolbox/VERSION` is still `1.1.0`, which is already in the registry.

So the failure was spurious: no image content changed, only the checkout action version in the workflow YAML. But the path filter can't distinguish "the image recipe changed" from "the workflow's own plumbing changed".

## Fix

Drop the self-referential path from the trigger so the image only rebuilds when `docker/charts-toolbox/**` actually changes. `workflow_dispatch` remains, so a build can still be run manually to validate edits to the workflow itself.

## Tested

- Validated the workflow YAML parses and that the `push` trigger's `paths` now contains only `docker/charts-toolbox/**`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Restricts the `ci(charts-toolbox)` workflow so pushes only rebuild the charts-toolbox image when `docker/charts-toolbox/**` changes. Removes the workflow file itself from the push path filter, while keeping `workflow_dispatch` available for manual runs. Adds comments clarifying that workflow-only edits do not trigger an image rebuild.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->