### PR TITLE
chore(deps): bump vector-tile decode stack majors

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -132,9 +132,10 @@ module.exports = [
     }
   },
 
-  // Test fixtures stay as CommonJS scripts — they're one-off setup
-  // scripts, not under test. The `.cjs` extension keeps them parseable
-  // as CJS now that the package is `"type": "module"`.
+  // Test fixtures are one-off setup scripts, not under test. Plain-CJS
+  // fixtures keep the `.cjs` extension so they stay parseable as CJS now
+  // that the package is `"type": "module"`; fixtures that import ESM-only
+  // dependencies (geojson-vt 4) are `.mjs` — see the block below.
   {
     files: ['test/fixtures/**/*.cjs'],
     plugins: {
@@ -151,6 +152,36 @@ module.exports = [
         module: 'readonly',
         require: 'readonly',
         exports: 'readonly',
+        Promise: 'readonly'
+      }
+    },
+    rules: {
+      'prettier/prettier': 'error',
+      'no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ],
+      'no-console': 'off'
+    }
+  },
+
+  // ESM fixtures (same policy as the CJS block above, module flavor).
+  {
+    files: ['test/fixtures/**/*.mjs'],
+    plugins: {
+      prettier
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+        Buffer: 'readonly',
         Promise: 'readonly'
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:public": "tsc -p tsconfig.public.json",
     "pretest": "npm run build && npm run build:tests && npm run test:fixtures",
     "test": "node --test --test-force-exit dist-test/**/*.test.js",
-    "test:fixtures": "node test/fixtures/create-test-mbtiles.cjs && node test/fixtures/create-test-vector-mbtiles.cjs",
+    "test:fixtures": "node test/fixtures/create-test-mbtiles.cjs && node test/fixtures/create-test-vector-mbtiles.mjs",
     "test:e2e": "npm run build && npm run build:e2e && playwright test",
     "lint": "eslint src test e2e public/js playwright.config.ts",
     "lint:fix": "eslint src test e2e public/js playwright.config.ts --fix",
@@ -38,12 +38,12 @@
     "name": "Dirk Wahrheit"
   },
   "dependencies": {
-    "@mapbox/vector-tile": "^2.0.5",
+    "@mapbox/vector-tile": "^3.0.0",
     "@signalk/server-api": "^2.0.0",
     "@sinclair/typebox": "^0.34.49",
     "busboy": "^1.6.0",
-    "geojson-vt": "^3.2.1",
-    "pbf": "^4.0.2",
+    "geojson-vt": "^4.0.3",
+    "pbf": "^5.1.0",
     "unzipper": "^0.12.3",
     "vt-pbf": "^3.1.3",
     "xml2js": "^0.6.2"

--- a/src/utils/tile-overzoom.ts
+++ b/src/utils/tile-overzoom.ts
@@ -24,7 +24,7 @@
  */
 
 import { gunzipSync, gzipSync } from 'node:zlib';
-import Pbf from 'pbf';
+import { PbfReader } from 'pbf';
 import { VectorTile } from '@mapbox/vector-tile';
 import geojsonvt from 'geojson-vt';
 import { fromGeojsonVt } from 'vt-pbf';
@@ -155,7 +155,7 @@ export function _overzoomCacheStats(reader: MBTilesReader): {
 
 function decodeTile(raw: Buffer): VectorTile {
   const bytes = raw[0] === 0x1f && raw[1] === 0x8b ? gunzipSync(raw) : raw;
-  return new VectorTile(new Pbf(bytes));
+  return new VectorTile(new PbfReader(bytes));
 }
 
 /** True when at least one feature touches the tile's visible extent. */

--- a/test/fixtures/create-test-vector-mbtiles.mjs
+++ b/test/fixtures/create-test-vector-mbtiles.mjs
@@ -24,17 +24,18 @@
  *
  * Tile contents are independent per tile (no real pyramid consistency); the
  * overzoom module only ever reads one ancestor at a time, so that's fine.
- * Run with: node test/fixtures/create-test-vector-mbtiles.cjs
+ * Run with: node test/fixtures/create-test-vector-mbtiles.mjs
  */
 
-const { DatabaseSync } = require('node:sqlite');
-const path = require('path');
-const fs = require('fs');
-const { gzipSync } = require('node:zlib');
-const geojsonvt = require('geojson-vt');
-const vtpbf = require('vt-pbf');
+// ESM because geojson-vt 4 is ESM-only (no CJS entry to require()).
+import { DatabaseSync } from 'node:sqlite';
+import path from 'node:path';
+import fs from 'node:fs';
+import { gzipSync } from 'node:zlib';
+import geojsonvt from 'geojson-vt';
+import vtpbf from 'vt-pbf';
 
-const outputPath = path.join(__dirname, 'test-vector-chart.mbtiles');
+const outputPath = path.join(import.meta.dirname, 'test-vector-chart.mbtiles');
 
 if (fs.existsSync(outputPath)) {
   fs.unlinkSync(outputPath);

--- a/test/tile-overzoom.test.ts
+++ b/test/tile-overzoom.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for serve-time overzoom synthesis from vector MBTiles.
  *
- * The fixture (create-test-vector-mbtiles.cjs) advertises minzoom=2,
+ * The fixture (create-test-vector-mbtiles.mjs) advertises minzoom=2,
  * maxzoom=16 but contains only six tiles — see the generator's header for
  * the authoritative inventory: z2 (0,1) 'test-buoy' (id 42) + `areas`
  * polygon, z3 (0,3) 'z3-buoy' (id 43) at the same lon/lat, z8 (56,86)
@@ -18,7 +18,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { gunzipSync, gzipSync } from 'node:zlib';
 
-import Pbf from 'pbf';
+import { PbfReader } from 'pbf';
 import { VectorTile } from '@mapbox/vector-tile';
 import { fromGeojsonVt } from 'vt-pbf';
 import type { Feature, Point } from 'geojson';
@@ -48,7 +48,7 @@ const TOLERANCE_DEG = 0.05;
 function decode(tile: Buffer): VectorTile {
   assert.strictEqual(tile[0], 0x1f, 'synthesized tile must be gzipped');
   assert.strictEqual(tile[1], 0x8b, 'synthesized tile must be gzipped');
-  return new VectorTile(new Pbf(gunzipSync(tile)));
+  return new VectorTile(new PbfReader(gunzipSync(tile)));
 }
 
 function pointCoords(vt: VectorTile, x: number, y: number, z: number): [number, number] {


### PR DESCRIPTION
## Why

Dependabot opened three separate major bumps for the vector-tile decode stack — #143 (`@mapbox/vector-tile` 2→3), #144 (`pbf` 4→5), #145 (`geojson-vt` 3→4) — and all three fail CI individually: `vector-tile@3` hard-depends on `pbf@^5`, and each new major needs small code adaptations (`error TS1192: Module 'pbf' has no default export` at `tile-overzoom.ts:27`). The three libraries are used together in one production module (the overzoom-synthesis path in `tile-overzoom.ts`), so they have to move as one change.

## What

- Bumps `pbf` → ^5.1.0, `@mapbox/vector-tile` → ^3.0.0, `geojson-vt` → ^4.0.3 together.
- `pbf` 5 split the `Pbf` class into `PbfReader`/`PbfWriter`; the overzoom path only decodes, so `new Pbf(bytes)` becomes `new PbfReader(bytes)` (src + test). The `VectorTile` import is unchanged.
- `geojson-vt` 4 is ESM-only, so the vector fixture generator moves from `.cjs` to `.mjs` with native imports (`import.meta.dirname` instead of `__dirname`). This avoids relying on `require(esm)` (Node ≥22.12) and keeps the package's Node ≥22.5 floor intact. A matching `test/fixtures/**/*.mjs` eslint block mirrors the existing `.cjs` one.
- `vt-pbf` stays at 3.1.3 — no newer release exists; it consumes geojson-vt tile objects structurally and carries its own nested `pbf`, so it is unaffected.
- `@types/geojson-vt` stays — geojson-vt 4 ships no type declarations and the v3 stubs still match the API surface used here.

Supersedes #143, #144, #145 (Dependabot closes them automatically once main satisfies the new ranges).

## Tested

- Strict `tsc` build passes (the step where all three Dependabot PRs fail).
- Full suite: 423/423 pass, including the complete tile-overzoom suite (real MVT encode/decode round-trips, buffer-only edge tiles, blank-tile replacement, corrupt-tile degradation).
- Fixture generator regenerates `test-vector-chart.mbtiles` through geojson-vt@4 → vt-pbf@3.
- Real-chart smoke: a production ENC MBTiles synthesized genuine z17/z18 overzoom tiles through the new decode stack and decoded them back cleanly.
- `npm run lint` and `npm run format:check` clean.
