### PR TITLE
chore(release): 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump for the 2.4.0 release. Since v2.3.4:

- fix(catalog): make container-written charts host-writable for metadata patching (#158) — resolves the "attempt to write a readonly database" failures on Docker / rootful podman (#157)
- feat(container-fs): shared `withOutputChmod` helper with tests (#158)
- fix(charts): infer S-57 type from vector layers when the metadata patch failed (#159) — defense-in-depth for SignalK/freeboard-sk#436
- feat(catalog): raise conversion log retention from 100 to 1000 lines (#156)
- fix(catalog): conversion-progress lifecycle fixes — keep progress on success, don't let a stale cleanup timer delete a retry's progress (#155)
- fix(catalog): stop /custom-catalogs log default from truncating (#155)
- chore(deps): bump vector-tile decode stack majors — pbf 5, @mapbox/vector-tile 3, geojson-vt 4 (#161)
- chore(deps): bump actions/checkout from 6 to 7 (#149)

## Tested

- Full suite on the release branch: 423/423 pass, build + lint clean.
- 2.4.0 content was e2e-verified on a live signalk-server serving a real ENC chart, including overzoom synthesis through the new vector-tile stack (#161).
