### PR TITLE
fix(download): prevent quarantine races and unhandled rejections in zip downloads

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -128,6 +128,15 @@ import type {
 } from './types.js';
 const pluginVersion: string = (packageJson as { version: string }).version;
 
+// The startup-global 'job-completed' handler is re-registered on every
+// start() because its closure captures the current chartPath. Track the
+// previous instance (module scope, like downloadManager itself) so
+// re-registration removes exactly that handler — a blanket
+// removeAllListeners('job-completed') would also strip the per-job
+// promotion/cleanup listeners of downloads still running from a prior
+// plugin lifecycle, stranding their files in the quarantine.
+let globalJobCompletedListener: ((job: DownloadJob) => void) | null = null;
+
 // Single source of truth lives in container-jobs.ts as PLUGIN_OWNER_ID
 // (used as the `ownerPluginId` label on every runJob call). The plugin
 // id Signal K uses must match exactly so `cleanupOrphanedJobs` reaps
@@ -545,8 +554,10 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
     startCatalogUpdateChecker();
 
-    downloadManager.removeAllListeners('job-completed');
-    downloadManager.on('job-completed', (job: DownloadJob) => {
+    if (globalJobCompletedListener) {
+      downloadManager.removeListener('job-completed', globalJobCompletedListener);
+    }
+    globalJobCompletedListener = (job: DownloadJob): void => {
       app.debug(
         `Download job completed: ${job.id}, extracted files: ${job.extractedFiles.join(', ')}`
       );
@@ -568,7 +579,8 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           }
         }
       });
-    });
+    };
+    downloadManager.on('job-completed', globalJobCompletedListener);
 
     // Filesystem housekeeping (removing invalid .mbtiles and orphaned
     // journal/WAL files) runs independently of the display path so it can
@@ -1727,6 +1739,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
               });
             });
 
+            // Observe the rejection now: Promise.all only attaches in the
+            // 'finish' handler, which never fires on an aborted request —
+            // a staging failure there would otherwise surface as a
+            // process-level unhandled rejection.
+            writePromise.catch(() => undefined);
             writePromises.push(writePromise);
           }
         );
@@ -1795,6 +1812,24 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
               cleanupQuarantineDir(quarantineDir);
             }
           })();
+        });
+
+        // An aborted request or a Busboy parse error never reaches
+        // 'finish', which owns the normal cleanup — without these the
+        // staged files stay on disk and the dir stays registered as
+        // active (so the startup sweep skips it) until a full server
+        // restart. cleanupQuarantineDir is idempotent, so a late abort
+        // racing the finish path is harmless.
+        bb.on('error', (err: unknown) => {
+          app.error('Upload stream error: ' + (err instanceof Error ? err.message : String(err)));
+          cleanupQuarantineDir(quarantineDir);
+          if (!res.headersSent) {
+            res.status(400).send('Malformed upload');
+          }
+        });
+        req.on('aborted', () => {
+          app.debug('Upload request aborted by client');
+          cleanupQuarantineDir(quarantineDir);
         });
 
         req.pipe(bb);
@@ -2375,8 +2410,6 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           const jobId = downloadManager.createJob(url, quarantineDir, chartNumber);
           createdJobId = jobId;
 
-          trackInstall(chartNumber, catalogFile, zipfileDatetime ?? '', url);
-
           const cleanupListener = (job: DownloadJob): void => {
             if (job.id !== jobId) {
               return;
@@ -2447,6 +2480,12 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           };
           downloadManager.on('job-failed', cleanupListener);
           downloadManager.on('job-completed', cleanupListener);
+
+          // Only after the listeners own the job/quarantine lifecycle:
+          // if this throws, the catch below must NOT touch the dir (the
+          // listeners will promote or clean it), and nothing before the
+          // registration above can throw once createJob has returned.
+          trackInstall(chartNumber, catalogFile, zipfileDatetime ?? '', url);
 
           app.debug(`Catalog download started: ${chartNumber} from ${catalogFile}, job: ${jobId}`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ import { parsePluginConfig } from './utils/plugin-config-schema.js';
 import {
   cleanupQuarantineDir,
   makeQuarantineDir,
+  makeUniqueQuarantineDir,
   promoteQuarantine,
   sweepStaleQuarantineDirs
 } from './utils/quarantine.js';
@@ -802,6 +803,13 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           return;
         }
 
+        // Setup-failure cleanup state: if anything throws after the
+        // quarantine dir exists but before the job owns it, the catch
+        // below removes the orphan. Once createJob has returned, the
+        // job's completion/failure listeners own the dir — the catch
+        // must NOT touch it then.
+        let stagedDir: string | null = null;
+        let createdJobId: string | null = null;
         try {
           console.log(`Creating download job for: ${downloadUrl}`);
           console.log(`Target folder: ${targetFolder}`);
@@ -818,11 +826,16 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             fs.mkdirSync(targetDir, { recursive: true });
           }
 
-          // Stage the download in the quarantine dir; promote on
+          // Stage the download in a per-job quarantine dir; promote on
           // job-completed so a crash mid-fetch never leaves a partial
-          // .mbtiles in the live chart library.
-          const quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartName);
+          // .mbtiles in the live chart library. Per-job (unique) because
+          // download jobs run concurrently: two downloads with the same
+          // chart name must not share a dir, or the first to finish wipes
+          // the workspace out from under the other mid-extraction.
+          const quarantineDir = makeUniqueQuarantineDir(app.getDataDirPath(), chartName);
+          stagedDir = quarantineDir;
           const jobId = downloadManager.createJob(downloadUrl, quarantineDir, chartName);
+          createdJobId = jobId;
 
           const promoteListener = (job: DownloadJob): void => {
             if (job.id !== jobId) {
@@ -883,6 +896,9 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             message: 'Download job created'
           });
         } catch (error) {
+          if (stagedDir !== null && createdJobId === null) {
+            cleanupQuarantineDir(stagedDir);
+          }
           console.error('Error creating download job:', error);
           res.status(500).json({
             success: false,
@@ -1652,10 +1668,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         // streamed here first, then atomically promoted on `finish`.
         // A crashed/aborted request leaves the partial files in the
         // quarantine for the startup sweep to wipe, never in basePath.
-        const quarantineDir = makeQuarantineDir(
-          app.getDataDirPath(),
-          `upload-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-        );
+        const quarantineDir = makeUniqueQuarantineDir(app.getDataDirPath(), 'upload');
         const uploadedFiles: string[] = [];
         const writePromises: Promise<void>[] = [];
         const fields: Record<string, string> = {};
@@ -2119,7 +2132,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           // the UI stuck waiting for status it would never get.
           let quarantineDir: string;
           try {
-            quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+            quarantineDir = makeUniqueQuarantineDir(app.getDataDirPath(), chartNumber);
           } catch (err) {
             res.status(500).json({
               success: false,
@@ -2236,6 +2249,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         return;
       }
 
+      // Setup-failure cleanup state for the direct-.mbtiles branch: see
+      // the download-chart-locker route. Once createJob has returned,
+      // the job's listeners own the dir and the catch must leave it be.
+      let stagedDir: string | null = null;
+      let createdJobId: string | null = null;
       try {
         const chartPath = props.chartPath || defaultChartsPath;
         const targetDir =
@@ -2346,12 +2364,16 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
             chartPath
           );
         } else {
-          // Direct .mbtiles download (or ZIP-of-.mbtiles): stage into the
-          // quarantine dir so a crash mid-download/extract never leaves a
-          // half-built file in the live chart library. Promotion runs on
-          // job-completed; failure / no-files paths drop the quarantine.
-          const quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+          // Direct .mbtiles download (or ZIP-of-.mbtiles): stage into a
+          // per-job quarantine dir so a crash mid-download/extract never
+          // leaves a half-built file in the live chart library, and so a
+          // re-download of the same chartNumber can't share (and wipe)
+          // a still-running job's dir. Promotion runs on job-completed;
+          // failure / no-files paths drop the quarantine.
+          const quarantineDir = makeUniqueQuarantineDir(app.getDataDirPath(), chartNumber);
+          stagedDir = quarantineDir;
           const jobId = downloadManager.createJob(url, quarantineDir, chartNumber);
+          createdJobId = jobId;
 
           trackInstall(chartNumber, catalogFile, zipfileDatetime ?? '', url);
 
@@ -2435,6 +2457,9 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           });
         }
       } catch (error) {
+        if (stagedDir !== null && createdJobId === null) {
+          cleanupQuarantineDir(stagedDir);
+        }
         console.error('Error creating catalog download job:', error);
         res.status(500).json({
           success: false,
@@ -2721,7 +2746,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       let quarantineDir: string | null = null;
 
       try {
-        quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+        quarantineDir = makeUniqueQuarantineDir(app.getDataDirPath(), chartNumber);
         const displayName = chartTitle ? cleanCatalogTitle(chartTitle) : undefined;
         const result = await processS57Zip(
           zipPath,
@@ -2837,7 +2862,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       let quarantineDir: string | null = null;
 
       try {
-        quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+        quarantineDir = makeUniqueQuarantineDir(app.getDataDirPath(), chartNumber);
         const result = await processRncZip(
           zipPath,
           quarantineDir,
@@ -2948,7 +2973,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       let quarantineDir: string | null = null;
 
       try {
-        quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+        quarantineDir = makeUniqueQuarantineDir(app.getDataDirPath(), chartNumber);
         const result = await processPilotTar(
           dlPath,
           quarantineDir,
@@ -3049,7 +3074,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       let quarantineDir: string | null = null;
 
       try {
-        quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+        quarantineDir = makeUniqueQuarantineDir(app.getDataDirPath(), chartNumber);
         const result = await processShpBasemap(
           dlPath,
           quarantineDir,
@@ -3126,7 +3151,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     void (async () => {
       let quarantineDir: string | null = null;
       try {
-        quarantineDir = makeQuarantineDir(app.getDataDirPath(), chartNumber);
+        quarantineDir = makeUniqueQuarantineDir(app.getDataDirPath(), chartNumber);
         const result = await processGshhg(
           tmpDir,
           quarantineDir,
@@ -3351,7 +3376,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         }
         setConvertingState(id, true);
         convertingFlagged = true;
-        quarantineDir = makeQuarantineDir(app.getDataDirPath(), id);
+        quarantineDir = makeUniqueQuarantineDir(app.getDataDirPath(), id);
         const conv = await processS57Directory(
           encDir,
           quarantineDir,

--- a/src/utils/download-manager.ts
+++ b/src/utils/download-manager.ts
@@ -330,7 +330,14 @@ class DownloadManager extends EventEmitter {
                         // keep 'finish' (where the job's failure is decided)
                         // from ever firing. Drain the entry so the stream
                         // keeps flowing and the job fails instead of hanging.
-                        entry.autodrain();
+                        // The drain stream's own errors must be observed too
+                        // — an unlistened 'error' on it would crash the
+                        // process; the parser's error handler already fails
+                        // the job for a corrupt archive.
+                        void entry
+                          .autodrain()
+                          .promise()
+                          .catch(() => undefined);
                         rejectExtract(err);
                       });
 
@@ -347,7 +354,10 @@ class DownloadManager extends EventEmitter {
                   extractPromise.catch(() => undefined);
                   extractionPromises.push(extractPromise);
                 } else {
-                  entry.autodrain();
+                  void entry
+                    .autodrain()
+                    .promise()
+                    .catch(() => undefined);
                 }
               })
               .on('finish', () => {

--- a/src/utils/download-manager.ts
+++ b/src/utils/download-manager.ts
@@ -309,21 +309,42 @@ class DownloadManager extends EventEmitter {
 
                   const extractPromise = new Promise<void>((resolveExtract, rejectExtract) => {
                     const writeStream = fs.createWriteStream(targetPath);
+                    // 'close' fires even after 'error' (emitClose default);
+                    // don't count a failed write as an extracted file.
+                    let writeFailed = false;
 
                     writeStream
                       .on('close', () => {
+                        if (writeFailed) {
+                          return;
+                        }
                         console.log(`[${job.id}] Extracted: ${fileName}`);
                         job.extractedFiles.push(path.basename(fileName));
                         resolveExtract();
                       })
                       .on('error', (err: Error) => {
+                        writeFailed = true;
                         console.error(`[${job.id}] Error writing ${fileName}:`, err);
+                        // pipe() unpipes on destination error and leaves the
+                        // entry paused, which would stall the zip parser and
+                        // keep 'finish' (where the job's failure is decided)
+                        // from ever firing. Drain the entry so the stream
+                        // keeps flowing and the job fails instead of hanging.
+                        entry.autodrain();
                         rejectExtract(err);
                       });
 
                     entry.pipe(writeStream);
                   });
 
+                  // Observe the rejection immediately: Promise.all() below
+                  // only attaches at the zip stream's 'finish', so an
+                  // earlier write failure would surface as a process-level
+                  // unhandled rejection (seen as plugin status "Unhandled
+                  // rejection: ENOENT ..." when the quarantine dir vanished
+                  // mid-extraction). The real error still propagates through
+                  // Promise.all on the original promise.
+                  extractPromise.catch(() => undefined);
                   extractionPromises.push(extractPromise);
                 } else {
                   entry.autodrain();

--- a/src/utils/quarantine.ts
+++ b/src/utils/quarantine.ts
@@ -11,7 +11,10 @@
  * - One subdir per chart number (`<dataDir>/in-progress/<chartNumber>/`).
  *   Multiple concurrent conversions of the same chartNumber can't
  *   collide because `cpuBudget.maxConcurrentConversions` is 1, but the
- *   subdir layout still keeps things tidy under inspection.
+ *   subdir layout still keeps things tidy under inspection. Download
+ *   jobs run concurrently (up to 3), so they use
+ *   `makeUniqueQuarantineDir` — a per-job suffix — instead of the
+ *   name-keyed variant.
  *
  * - `promote()` uses `fs.promises.rename` first (atomic when both
  *   sides are on the same filesystem) and falls back to copy+unlink
@@ -29,6 +32,18 @@ import { makeContainerWritable } from './container-fs.js';
 const QUARANTINE_ROOT_NAME = 'in-progress';
 
 /**
+ * Quarantine dirs created in this *process* lifetime that haven't been
+ * cleaned up yet. Module-level on purpose: a plugin restart (config save)
+ * re-runs `start()` — and its `sweepStaleQuarantineDirs()` call — while
+ * downloads and conversions from the previous plugin lifecycle are still
+ * running (`downloadManager` is a module singleton, converter promises
+ * aren't cancelled). The sweep must not delete those live workspaces;
+ * only dirs left by a previous *server* process (registry empty after a
+ * real restart) are stale.
+ */
+const activeQuarantineDirs = new Set<string>();
+
+/**
  * Resolve `<dataDir>/in-progress/<chartNumber>/` and create it. Idempotent.
  * Returns the absolute path so the caller can pass it as the converter's
  * `chartsDir` argument and the converter writes there instead of into the
@@ -38,6 +53,30 @@ export function makeQuarantineDir(dataDir: string, chartNumber: string): string 
   const dir = path.join(dataDir, QUARANTINE_ROOT_NAME, sanitizeIdSegment(chartNumber));
   fs.mkdirSync(dir, { recursive: true });
   makeContainerWritable(dir);
+  activeQuarantineDirs.add(dir);
+  return dir;
+}
+
+/**
+ * Like `makeQuarantineDir`, but with a per-call unique suffix so concurrent
+ * jobs staging under the same display name can never share (and therefore
+ * never delete) each other's workspace. Download jobs need this: the
+ * download manager runs up to 3 jobs at once, and each job's completion
+ * (or failure) listener wipes its quarantine dir — with a name-keyed dir,
+ * the first job to finish would rm -rf the directory a second job with the
+ * same chart name was still extracting into.
+ */
+export function makeUniqueQuarantineDir(dataDir: string, base: string): string {
+  const root = path.join(dataDir, QUARANTINE_ROOT_NAME);
+  fs.mkdirSync(root, { recursive: true });
+  // mkdtemp's exclusive create guarantees uniqueness even for two calls in
+  // the same instant. Truncate the sanitized base so the whole segment
+  // (base + '-' + 6 random chars) stays well under sanitizeIdSegment's
+  // 64-char cap.
+  const prefix = `${sanitizeIdSegment(base).slice(0, 40)}-`;
+  const dir = fs.mkdtempSync(path.join(root, prefix));
+  makeContainerWritable(dir);
+  activeQuarantineDirs.add(dir);
   return dir;
 }
 
@@ -187,6 +226,10 @@ export async function promoteQuarantine(
  * anything.
  */
 export function cleanupQuarantineDir(quarantineDir: string): void {
+  // Unregister first, even if the rm below fails: the caller is done with
+  // the dir either way, and leaving it out of the active set means the
+  // next startup sweep can remove whatever the failed rm left behind.
+  activeQuarantineDirs.delete(quarantineDir);
   try {
     fs.rmSync(quarantineDir, { recursive: true, force: true });
   } catch {
@@ -197,10 +240,12 @@ export function cleanupQuarantineDir(quarantineDir: string): void {
 }
 
 /**
- * Wipe every subdir under `<dataDir>/in-progress/` at startup.
- * Anything in there is from a prior server lifecycle that didn't
- * complete, so the contents are by definition stale and unsafe to
- * promote.
+ * Wipe stale subdirs under `<dataDir>/in-progress/` at startup.
+ * "Stale" means "not created in this process lifetime": `start()` runs on
+ * every plugin config save while downloads/conversions from the previous
+ * plugin lifecycle keep running, so any dir still in the active registry
+ * belongs to live work and is skipped. After a real server restart the
+ * registry is empty and everything on disk gets wiped, as before.
  *
  * Returns the count of dirs swept so callers can log it.
  */
@@ -212,8 +257,12 @@ export function sweepStaleQuarantineDirs(dataDir: string): number {
   let swept = 0;
   for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
     if (entry.isDirectory()) {
+      const dir = path.join(root, entry.name);
+      if (activeQuarantineDirs.has(dir)) {
+        continue;
+      }
       try {
-        fs.rmSync(path.join(root, entry.name), { recursive: true, force: true });
+        fs.rmSync(dir, { recursive: true, force: true });
         swept += 1;
       } catch {
         // Best-effort. Permissions / locked file shouldn't block

--- a/test/download-manager.test.ts
+++ b/test/download-manager.test.ts
@@ -8,6 +8,7 @@ import assert from 'node:assert';
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
+import zlib from 'node:zlib';
 import { fileURLToPath } from 'node:url';
 
 import { downloadManager } from '../dist/utils/download-manager.js';
@@ -66,6 +67,148 @@ function waitForTerminal(jobId: string): Promise<DownloadJob> {
     downloadManager.on('job-cancelled', check);
   });
 }
+
+// Build a minimal STORED (uncompressed) ZIP in memory so the zip tests
+// need no archiver dependency: local file headers + central directory +
+// end-of-central-directory, method 0 throughout.
+function storedZip(entries: { name: string; data: Buffer }[]): Buffer {
+  const chunks: Buffer[] = [];
+  const central: Buffer[] = [];
+  let offset = 0;
+  for (const { name, data } of entries) {
+    const nameBuf = Buffer.from(name, 'utf8');
+    const crc = zlib.crc32(data);
+
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0); // local file header signature
+    local.writeUInt16LE(20, 4); // version needed
+    local.writeUInt16LE(0, 8); // method: stored
+    local.writeUInt16LE(0x21, 12); // mod date (any valid DOS date)
+    local.writeUInt32LE(crc, 14);
+    local.writeUInt32LE(data.length, 18); // compressed size
+    local.writeUInt32LE(data.length, 22); // uncompressed size
+    local.writeUInt16LE(nameBuf.length, 26);
+    chunks.push(local, nameBuf, data);
+
+    const cen = Buffer.alloc(46);
+    cen.writeUInt32LE(0x02014b50, 0); // central directory signature
+    cen.writeUInt16LE(20, 4); // version made by
+    cen.writeUInt16LE(20, 6); // version needed
+    cen.writeUInt16LE(0, 10); // method: stored
+    cen.writeUInt16LE(0x21, 14); // mod date
+    cen.writeUInt32LE(crc, 16);
+    cen.writeUInt32LE(data.length, 20);
+    cen.writeUInt32LE(data.length, 24);
+    cen.writeUInt16LE(nameBuf.length, 28);
+    cen.writeUInt32LE(offset, 42); // local header offset
+    central.push(cen, nameBuf);
+
+    offset += 30 + nameBuf.length + data.length;
+  }
+  const cd = Buffer.concat(central);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0); // EOCD signature
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(cd.length, 12);
+  eocd.writeUInt32LE(offset, 16);
+  return Buffer.concat([...chunks, cd, eocd]);
+}
+
+describe('DownloadManager zip extraction', () => {
+  before(() => {
+    fs.mkdirSync(TMP, { recursive: true });
+  });
+
+  beforeEach(() => {
+    downloadManager.removeAllListeners();
+  });
+
+  after(() => {
+    downloadManager.removeAllListeners();
+    fs.rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('extracts every .mbtiles entry from a multi-chart ZIP and skips the rest', async () => {
+    const zip = storedZip([
+      { name: 'Kiribati/Gilbert Islands GoogleSat.mbtiles', data: Buffer.from('SAT-DATA') },
+      { name: 'Kiribati/readme.txt', data: Buffer.from('not a chart') },
+      { name: 'Kiribati/Gilbert Islands ArcGis.mbtiles', data: Buffer.from('ARC-DATA') }
+    ]);
+    const origin = await startOrigin((_hit, res) => {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/zip');
+      res.end(zip);
+    });
+
+    const dir = fs.mkdtempSync(path.join(TMP, 'zip-multi-'));
+    try {
+      const jobId = downloadManager.createJob(origin.url, dir, 'Kiribati');
+      const job = await waitForTerminal(jobId);
+
+      assert.strictEqual(job.status, 'completed', `expected completed, got ${job.error ?? ''}`);
+      assert.deepStrictEqual([...job.extractedFiles].sort(), [
+        'Gilbert Islands ArcGis.mbtiles',
+        'Gilbert Islands GoogleSat.mbtiles'
+      ]);
+      assert.strictEqual(
+        fs.readFileSync(path.join(dir, 'Gilbert Islands GoogleSat.mbtiles'), 'utf8'),
+        'SAT-DATA'
+      );
+      assert.strictEqual(
+        fs.readFileSync(path.join(dir, 'Gilbert Islands ArcGis.mbtiles'), 'utf8'),
+        'ARC-DATA'
+      );
+      assert.strictEqual(fs.existsSync(path.join(dir, 'readme.txt')), false);
+    } finally {
+      await origin.close();
+    }
+  });
+
+  it(
+    'fails cleanly when the target dir vanishes mid-extraction (no unhandled rejection, no hang)',
+    { timeout: 20000 },
+    async () => {
+      // Regression: the quarantine dir being rm -rf'd under a running
+      // extraction used to (a) leak the write-stream ENOENTs as
+      // process-level unhandled rejections and (b) stall the zip parser
+      // (pipe() unpipes on destination error), so the job never reached a
+      // terminal state.
+      const zip = storedZip([
+        { name: 'a.mbtiles', data: Buffer.from('AAA') },
+        { name: 'b.mbtiles', data: Buffer.from('BBB') }
+      ]);
+      const origin = await startOrigin((_hit, res) => {
+        res.statusCode = 200;
+        res.setHeader('content-type', 'application/zip');
+        res.end(zip);
+      });
+
+      const vanishedDir = path.join(TMP, 'vanished-quarantine'); // never created
+      let unhandled = 0;
+      const onUnhandled = (): void => {
+        unhandled += 1;
+      };
+      process.on('unhandledRejection', onUnhandled);
+      try {
+        const jobId = downloadManager.createJob(origin.url, vanishedDir, 'Kiribati');
+        const job = await waitForTerminal(jobId);
+
+        assert.strictEqual(job.status, 'failed');
+        assert.match(job.error ?? '', /ENOENT/);
+        // A failed write must not be counted as an extracted file (the
+        // write stream's 'close' fires even after 'error').
+        assert.deepStrictEqual(job.extractedFiles, []);
+        // Give any stray unhandled rejection a beat to surface.
+        await new Promise((r) => setTimeout(r, 100));
+        assert.strictEqual(unhandled, 0, 'write failures must not leak as unhandled rejections');
+      } finally {
+        process.removeListener('unhandledRejection', onUnhandled);
+        await origin.close();
+      }
+    }
+  );
+});
 
 describe('DownloadManager retry', () => {
   before(() => {

--- a/test/quarantine.test.ts
+++ b/test/quarantine.test.ts
@@ -7,6 +7,7 @@ import os from 'node:os';
 import {
   cleanupQuarantineDir,
   makeQuarantineDir,
+  makeUniqueQuarantineDir,
   promoteQuarantine,
   sweepStaleQuarantineDirs
 } from '../dist/utils/quarantine.js';
@@ -166,17 +167,20 @@ describe('quarantine helpers', () => {
     assert.strictEqual(fs.existsSync(q), false);
   });
 
-  it('sweepStaleQuarantineDirs wipes every subdir under in-progress/', () => {
+  it('sweepStaleQuarantineDirs wipes stale subdirs from a previous process lifecycle', () => {
     // Use a fresh dataDir so prior test cases' leftover subdirs don't
-    // get counted into this test's swept total.
+    // get counted into this test's swept total. Stale dirs are created
+    // directly on disk — that's what a previous server process leaves
+    // behind (this process's active registry has never seen them).
     const sweepDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-quarantine-sweep-'));
     try {
-      const a = makeQuarantineDir(sweepDir, 'stale-a');
-      const b = makeQuarantineDir(sweepDir, 'stale-b');
-      const c = makeQuarantineDir(sweepDir, 'stale-c');
-      fs.writeFileSync(path.join(a, 'half-built.mbtiles'), 'aaa');
-      fs.writeFileSync(path.join(b, 'half-built.mbtiles'), 'bbb');
-      fs.writeFileSync(path.join(c, 'half-built.mbtiles'), 'ccc');
+      const a = path.join(sweepDir, 'in-progress', 'stale-a');
+      const b = path.join(sweepDir, 'in-progress', 'stale-b');
+      const c = path.join(sweepDir, 'in-progress', 'stale-c');
+      for (const dir of [a, b, c]) {
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, 'half-built.mbtiles'), 'stale');
+      }
 
       const swept = sweepStaleQuarantineDirs(sweepDir);
       assert.strictEqual(swept, 3);
@@ -189,6 +193,54 @@ describe('quarantine helpers', () => {
     } finally {
       fs.rmSync(sweepDir, { recursive: true, force: true });
     }
+  });
+
+  it('sweepStaleQuarantineDirs skips dirs still active in this process (live downloads survive a plugin restart)', () => {
+    const sweepDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-quarantine-active-'));
+    try {
+      // A previous-lifecycle leftover, unknown to the registry.
+      const stale = path.join(sweepDir, 'in-progress', 'stale');
+      fs.mkdirSync(stale, { recursive: true });
+      // A live workspace created in this process — e.g. a download still
+      // extracting when a config save re-ran start()'s sweep.
+      const active = makeQuarantineDir(sweepDir, 'active-download');
+      fs.writeFileSync(path.join(active, 'streaming.mbtiles'), 'live');
+
+      const swept = sweepStaleQuarantineDirs(sweepDir);
+      assert.strictEqual(swept, 1);
+      assert.strictEqual(fs.existsSync(stale), false);
+      assert.strictEqual(fs.existsSync(active), true);
+      assert.strictEqual(fs.readFileSync(path.join(active, 'streaming.mbtiles'), 'utf8'), 'live');
+
+      // Once the job is done and cleaned up, the same path is no longer
+      // protected: a later recreation by a dead process would be swept.
+      cleanupQuarantineDir(active);
+      fs.mkdirSync(active, { recursive: true });
+      assert.strictEqual(sweepStaleQuarantineDirs(sweepDir), 1);
+      assert.strictEqual(fs.existsSync(active), false);
+    } finally {
+      fs.rmSync(sweepDir, { recursive: true, force: true });
+    }
+  });
+
+  it('makeUniqueQuarantineDir returns a distinct dir per call for the same base name', () => {
+    const a = makeUniqueQuarantineDir(dataDir, 'Kiribati');
+    const b = makeUniqueQuarantineDir(dataDir, 'Kiribati');
+    assert.notStrictEqual(a, b);
+    for (const dir of [a, b]) {
+      assert.ok(dir.startsWith(path.join(dataDir, 'in-progress') + path.sep));
+      assert.ok(path.basename(dir).startsWith('Kiribati-'));
+      assert.strictEqual(fs.existsSync(dir), true);
+    }
+  });
+
+  it('makeUniqueQuarantineDir keeps the unique suffix on very long base names', () => {
+    // sanitizeIdSegment caps segments at 64 chars; the suffix must survive.
+    const longBase = 'x'.repeat(200);
+    const a = makeUniqueQuarantineDir(dataDir, longBase);
+    const b = makeUniqueQuarantineDir(dataDir, longBase);
+    assert.notStrictEqual(a, b);
+    assert.ok(path.basename(a).length <= 64);
   });
 
   it('sweepStaleQuarantineDirs returns 0 when there is no in-progress root', () => {


### PR DESCRIPTION
## Problem

Downloading a zip with multiple .mbtiles charts (Download-from-URL tab) could fail with plugin status `Unhandled rejection: ENOENT ... in-progress/<name>/<chart>.mbtiles` — the staging (quarantine) directory was deleted while the zip was still being extracted into it.

## Root causes and fixes

**Quarantine dirs were keyed by chart name only.** Overlapping download jobs with the same name shared one `in-progress/<name>/` dir; the first job to reach a terminal state (success or failure) removed it recursively, yanking the workspace out from under the other job mid-extraction. Staging dirs are now per-job unique via a new `makeUniqueQuarantineDir()` (mkdtemp — atomic exclusive create), used by the download-chart-locker, catalog direct-mbtiles, and upload routes, and by all catalog conversion handlers (S-57, RNC, Pilot, SHP, GSHHG, convert-upload, chart sets). Only the chunked-upload route keeps a name-keyed dir, since all chunks of one file must land in the same place.

**The startup sweep wiped live jobs' dirs.** `start()` runs on every config save and swept all of `in-progress/`, but `downloadManager` is a module singleton whose in-flight jobs survive plugin restarts. `quarantine.ts` now tracks dirs created in the current process lifetime and the sweep skips them; after a full server restart the registry is empty and everything on disk is swept as before.

**Extraction write failures leaked as unhandled rejections and hung the job.** A zip entry's write error rejected its extraction promise before `Promise.all` attached at the parser's `finish` event (process-level unhandled rejection pinned on the plugin status), and `pipe()`'s auto-unpipe left the entry paused so the parser stalled and the job never reached a terminal state. Failures are now observed immediately, the failed entry is drained so the stream keeps flowing, and a failed write is no longer counted as extracted by the late `close` event.

Also hardened per review: if job setup throws after the quarantine dir is created but before the job owns it, the route's catch now removes the orphaned dir.

## Known pre-existing issues (out of scope, follow-ups)

- `/upload-chunk` stages by filename, so concurrent chunked uploads of the same filename share a dir; fixing this needs an upload-ID protocol change across UI and server.
- Catalog install tracking (`trackInstall`/`rollbackInstall`/`setInstallFilename`) is keyed by chartNumber and can race for concurrent same-chart jobs.

## Tested

- Unit suite: 427 pass, including new tests for multi-.mbtiles zip extraction, clean failure (no unhandled rejection, no hang) when the target dir vanishes mid-extraction, sweep skipping active dirs, and unique-dir creation.
- Playwright e2e: 14/14.
- Real-server e2e against master signalk-server with a throwaway `-c` dir: multi-chart zip download and promotion, two overlapping same-name downloads (both complete, no ENOENT), plugin config save mid-download (job survives the sweep and promotes), stale `in-progress/` leftover swept after a full server restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Uses per-job quarantine directories across download, catalog, upload, and conversion routes to prevent concurrent jobs from colliding; chunked uploads remain name-keyed.
- Tracks active quarantine directories and preserves them during startup cleanup, while removing stale directories from previous process lifetimes.
- Cleans up staging directories when route setup fails before job ownership is established.
- Handles ZIP extraction write failures immediately, drains failed entries, avoids false success reporting, and prevents unhandled rejections or stalled jobs.
- Adds coverage for overlapping workspaces, stale-directory cleanup, multi-file ZIP extraction, and mid-extraction failures.
- Validates with 427 unit tests, 14 Playwright tests, and real-server scenarios covering overlapping downloads, configuration saves, multi-chart archives, and stale cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->