### PR TITLE
feat(download): resume interrupted downloads with HTTP Range requests

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -167,6 +167,10 @@ export interface DownloadJob {
   totalBytes: number;
   extractedFiles: string[];
   targetFiles: string[];
+  // Basename of the in-progress .part file in targetDir. Present while a
+  // download is running (it survives transient retries so a resumed
+  // attempt can continue from its current size); cleared on completion.
+  partFile?: string;
   createdAt: number;
   startedAt?: number;
   completedAt?: number;

--- a/src/utils/download-manager.ts
+++ b/src/utils/download-manager.ts
@@ -83,6 +83,14 @@ function isZipMagic(filePath: string): boolean {
   }
 }
 
+// Per-download state shared across resume attempts: the Content-Type of
+// the response the .part file was written from (finalizeDownload's
+// zip-claim check) and the source's ETag/Last-Modified for If-Range.
+interface DownloadState {
+  contentType: string;
+  validator: string;
+}
+
 // cancelJob() marks a job failed with this exact error and emits job-cancelled.
 const CANCELLED_ERROR = 'Cancelled by user';
 function isCancelled(job: DownloadJob): boolean {
@@ -206,7 +214,11 @@ class DownloadManager extends EventEmitter {
       await this.downloadWithRetry(job);
 
       // A cancel that raced the last await must win over 'completed'.
+      // In-flight work has settled here, so sweep anything created after
+      // cancelJob()'s own (racy) unlink pass — extraction targets and the
+      // recreated .part file included.
       if (isCancelled(job)) {
+        this.cleanupPartialFiles(job);
         return;
       }
       job.status = 'completed';
@@ -215,8 +227,11 @@ class DownloadManager extends EventEmitter {
       this.emit('job-completed', job);
     } catch (error) {
       // A cancelled job is already in its terminal state (cancelJob set it and
-      // emitted job-cancelled); don't overwrite or re-emit job-failed.
+      // emitted job-cancelled); don't overwrite or re-emit job-failed. Do run
+      // a final cleanup: the attempt that just ended may have written files
+      // after cancelJob()'s unlink pass.
       if (isCancelled(job)) {
+        this.cleanupPartialFiles(job);
         return;
       }
       job.status = 'failed';
@@ -277,7 +292,10 @@ class DownloadManager extends EventEmitter {
     }
     const partPath = this.partFilePath(job);
     job.partFile = path.basename(partPath);
-    let contentType = '';
+    // Shared across attempts: the Content-Type of the response the part
+    // file was written from, and the source's ETag/Last-Modified validator
+    // for If-Range resumes.
+    const state: DownloadState = { contentType: '', validator: '' };
     let attemptsWithoutProgress = 0;
     for (;;) {
       // cancelJob() marks the job failed/'Cancelled by user' but can't abort an
@@ -289,7 +307,7 @@ class DownloadManager extends EventEmitter {
       }
       const bytesBefore = this.partFileSize(partPath);
       try {
-        contentType = await this.downloadToFile(job, partPath);
+        await this.downloadToFile(job, partPath, state);
         break;
       } catch (error) {
         if (isCancelled(job)) {
@@ -325,24 +343,35 @@ class DownloadManager extends EventEmitter {
     if (isCancelled(job)) {
       throw new Error('Cancelled by user');
     }
-    await this.finalizeDownload(job, partPath, contentType);
+    await this.finalizeDownload(job, partPath, state.contentType);
   }
 
   // One HTTP attempt: stream the response body onto the end of `partPath`.
-  // Sends a Range request when the part file already has bytes; handles
+  // Sends a Range request when the part file already has bytes — with
+  // If-Range when the source gave us an ETag/Last-Modified, so a source
+  // that changed between attempts answers 200 (full body) and we rewrite
+  // instead of appending version-B bytes onto version-A data. Handles
   // servers that ignore Range (200 → rewrite the file from scratch) and
   // 416 (part already complete, or stale → drop it and let the retry
   // start over). A premature connection close is a TransientDownloadError
   // so the caller resumes; fs errors stay plain Errors and fail fast.
-  // Resolves with the response Content-Type so finalizeDownload can sanity
-  // -check the body against what the source claimed to serve.
-  private downloadToFile(job: DownloadJob, partPath: string, redirects = 0): Promise<string> {
-    return new Promise<string>((resolve, reject) => {
+  // Mutates `state` with the Content-Type and validator of the response
+  // the part file was written from.
+  private downloadToFile(
+    job: DownloadJob,
+    partPath: string,
+    state: DownloadState,
+    redirects = 0
+  ): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
       const startByte = this.partFileSize(partPath);
       const protocol = job.url.startsWith('https') ? https : http;
       const headers: Record<string, string> = {};
       if (startByte > 0) {
         headers.Range = `bytes=${String(startByte)}-`;
+        if (state.validator) {
+          headers['If-Range'] = state.validator;
+        }
       }
 
       console.log(`[${job.id}] Starting download from: ${job.url} (offset ${String(startByte)})`);
@@ -351,7 +380,13 @@ class DownloadManager extends EventEmitter {
         .get(job.url, { timeout: 60000, headers }, (response) => {
           const status = response.statusCode ?? 0;
 
-          if (status === 301 || status === 302 || status === 307 || status === 308) {
+          if (
+            status === 301 ||
+            status === 302 ||
+            status === 303 ||
+            status === 307 ||
+            status === 308
+          ) {
             const redirectUrl = response.headers.location;
             response.resume(); // drain so the socket can be reused/freed
             if (redirectUrl) {
@@ -370,7 +405,7 @@ class DownloadManager extends EventEmitter {
               }
               console.log(`[${job.id}] Following redirect to: ${resolvedUrl}`);
               job.url = resolvedUrl;
-              this.downloadToFile(job, partPath, redirects + 1)
+              this.downloadToFile(job, partPath, state, redirects + 1)
                 .then(resolve)
                 .catch(reject);
               return;
@@ -385,9 +420,12 @@ class DownloadManager extends EventEmitter {
             response.resume();
             const total = parseContentRangeTotal(response.headers['content-range']);
             if (total !== null && total === startByte) {
+              // state.contentType deliberately keeps the value from the
+              // response the bytes were actually written from — a 416's
+              // own Content-Type describes the error body, not the chart.
               job.downloadedBytes = startByte;
               job.totalBytes = total;
-              resolve(response.headers['content-type'] ?? '');
+              resolve();
               return;
             }
             try {
@@ -441,6 +479,11 @@ class DownloadManager extends EventEmitter {
           job.downloadedBytes = appendFrom;
 
           const contentType = response.headers['content-type'] ?? '';
+          state.contentType = contentType;
+          // Remember the source's validator so the next resume can send
+          // If-Range: a changed source then answers 200 (full body) and
+          // the rewrite path below keeps the file consistent.
+          state.validator = response.headers.etag ?? response.headers['last-modified'] ?? '';
           console.log(
             `[${job.id}] ${resumed ? `Resuming at byte ${String(startByte)}` : 'Downloading'}; Content-Type: ${contentType}, total: ${totalBytes > 0 ? String(totalBytes) : 'unknown'} bytes`
           );
@@ -508,7 +551,7 @@ class DownloadManager extends EventEmitter {
               );
               return;
             }
-            resolve(contentType);
+            resolve();
           });
 
           response.pipe(fileStream);

--- a/src/utils/download-manager.ts
+++ b/src/utils/download-manager.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import unzipper from 'unzipper';
 import { EventEmitter } from 'events';
+import { pipeline } from 'stream/promises';
 import type { DownloadJob, DownloadJobOptions } from '../types.js';
 
 // A download failure worth retrying: a network error, a timeout, or a 5xx
@@ -17,11 +18,70 @@ export class TransientDownloadError extends Error {
   }
 }
 
-// Bounded retry for transient download failures. Three attempts total with a
-// short linear backoff handles a flaky upstream (the chart sources are
-// third-party government servers) without stalling on a genuinely-gone file.
+// Bounded retry for transient download failures. Three consecutive attempts
+// WITHOUT forward progress with a short linear backoff handles a flaky
+// upstream without stalling on a genuinely-gone file; an attempt that did
+// advance the .part file rearms the budget, so a throttled multi-GB source
+// (mediafire stalls mid-transfer, NOAA rate-caps) can be resumed through
+// any number of interruptions as long as bytes keep arriving.
 const MAX_DOWNLOAD_ATTEMPTS = 3;
 const RETRY_BACKOFF_MS = 2000;
+
+// Redirect ceiling per attempt — guards against a redirect loop from a
+// misbehaving chart source.
+const MAX_REDIRECTS = 10;
+
+// "bytes 100-999/3657588990" or "bytes */3657588990" → 3657588990.
+function parseContentRangeTotal(header: string | undefined): number | null {
+  if (!header) {
+    return null;
+  }
+  const m = /\/(\d+)\s*$/.exec(header);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+// "bytes 100-999/3657588990" → 100. Null for "bytes */N" and malformed.
+function parseContentRangeStart(header: string | undefined): number | null {
+  if (!header) {
+    return null;
+  }
+  const m = /^bytes (\d+)-/.exec(header);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+// Does the URL's *path* end in .zip? Query strings (chart.zip?token=...)
+// and unparseable strings are handled; used only as a claim about what
+// the source intended to serve — the magic-byte check on the body is the
+// authority for how to process it.
+function urlPathLooksLikeZip(url: string | undefined): boolean {
+  if (!url) {
+    return false;
+  }
+  try {
+    return new URL(url).pathname.toLowerCase().endsWith('.zip');
+  } catch {
+    return (url.split('?')[0] ?? '').toLowerCase().endsWith('.zip');
+  }
+}
+
+// ZIP magic: local file header PK\x03\x04 (or the empty-archive marker
+// PK\x05\x06). Extension and Content-Type lie often enough (tokenized
+// download URLs, mislabeled servers) that the file itself is the authority.
+function isZipMagic(filePath: string): boolean {
+  let fd: number;
+  try {
+    fd = fs.openSync(filePath, 'r');
+  } catch {
+    return false;
+  }
+  try {
+    const buf = Buffer.alloc(4);
+    const n = fs.readSync(fd, buf, 0, 4, 0);
+    return n === 4 && buf[0] === 0x50 && buf[1] === 0x4b && (buf[2] === 0x03 || buf[2] === 0x05);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
 
 // cancelJob() marks a job failed with this exact error and emits job-cancelled.
 const CANCELLED_ERROR = 'Cancelled by user';
@@ -145,6 +205,10 @@ class DownloadManager extends EventEmitter {
 
       await this.downloadWithRetry(job);
 
+      // A cancel that raced the last await must win over 'completed'.
+      if (isCancelled(job)) {
+        return;
+      }
       job.status = 'completed';
       job.progress = 100;
       job.completedAt = Date.now();
@@ -167,7 +231,10 @@ class DownloadManager extends EventEmitter {
   }
 
   private cleanupPartialFiles(job: DownloadJob): void {
-    for (const fileName of job.targetFiles) {
+    // Only called on a job's FINAL failure (or cancel) — never between
+    // transient retries, where the .part file is the resume state.
+    const names = job.partFile ? [...job.targetFiles, job.partFile] : job.targetFiles;
+    for (const fileName of names) {
       const filePath = path.join(job.targetDir, fileName);
       try {
         fs.unlinkSync(filePath);
@@ -176,16 +243,43 @@ class DownloadManager extends EventEmitter {
         // file may not exist yet
       }
     }
+    job.partFile = undefined;
   }
 
-  // Run downloadAndExtract with bounded retries on TRANSIENT failures only
-  // (network error, timeout, 5xx). A 4xx (e.g. 404 for an expired catalog
-  // link) throws immediately. Between attempts, partial files are removed and
-  // the URL is reset to the original (downloadAndExtract mutates job.url while
-  // following redirects).
+  private partFilePath(job: DownloadJob): string {
+    // job.id is `dl_<ts>_<rand>` — already filesystem-safe, and per-job
+    // unique so concurrent jobs in the same targetDir can't collide.
+    return path.join(job.targetDir, `${job.id}.part`);
+  }
+
+  private partFileSize(partPath: string): number {
+    try {
+      return fs.statSync(partPath).size;
+    } catch {
+      return 0;
+    }
+  }
+
+  // Download to a .part file with bounded retries on TRANSIENT failures
+  // only (network error, timeout, 5xx). The .part file survives retries:
+  // a resumed attempt continues from its current size via an HTTP Range
+  // request instead of starting over. Only consecutive attempts with NO
+  // forward progress count against the budget. A 4xx (e.g. 404 for a
+  // moved/expired catalog link) throws immediately. Between attempts the
+  // URL is reset to the original (downloadToFile mutates job.url while
+  // following redirects) so a tokenized direct link gets re-resolved from
+  // its source. Once the body is complete, finalizeDownload turns the
+  // .part file into the final chart file(s).
   private async downloadWithRetry(job: DownloadJob): Promise<void> {
     const originalUrl = job.originalUrl ?? job.url;
-    for (let attempt = 1; attempt <= MAX_DOWNLOAD_ATTEMPTS; attempt++) {
+    if (!job.originalUrl) {
+      job.originalUrl = originalUrl;
+    }
+    const partPath = this.partFilePath(job);
+    job.partFile = path.basename(partPath);
+    let contentType = '';
+    let attemptsWithoutProgress = 0;
+    for (;;) {
       // cancelJob() marks the job failed/'Cancelled by user' but can't abort an
       // in-flight attempt or the backoff timer. Bail before (re)starting so a
       // cancel during a download or backoff isn't overwritten by a later
@@ -193,258 +287,231 @@ class DownloadManager extends EventEmitter {
       if (isCancelled(job)) {
         throw new Error('Cancelled by user');
       }
+      const bytesBefore = this.partFileSize(partPath);
       try {
-        await this.downloadAndExtract(job);
-        return;
+        contentType = await this.downloadToFile(job, partPath);
+        break;
       } catch (error) {
         if (isCancelled(job)) {
           throw new Error('Cancelled by user');
         }
-        const transient = error instanceof TransientDownloadError;
-        if (!transient || attempt === MAX_DOWNLOAD_ATTEMPTS) {
+        if (!(error instanceof TransientDownloadError)) {
           throw error;
         }
-        const msg = error instanceof Error ? error.message : String(error);
+        // Forward progress fully rearms the budget: an attempt that moved
+        // bytes was not "without progress", so the next failure gets the
+        // whole MAX_DOWNLOAD_ATTEMPTS streak again.
+        const bytesNow = this.partFileSize(partPath);
+        attemptsWithoutProgress = bytesNow > bytesBefore ? 0 : attemptsWithoutProgress + 1;
+        if (attemptsWithoutProgress >= MAX_DOWNLOAD_ATTEMPTS) {
+          throw error;
+        }
         console.warn(
-          `[${job.id}] Transient download failure (attempt ${attempt}/${MAX_DOWNLOAD_ATTEMPTS}): ${msg}; retrying...`
+          `[${job.id}] Transient download failure (${attemptsWithoutProgress}/${MAX_DOWNLOAD_ATTEMPTS} without progress): ${error.message}; resuming from ${bytesNow} bytes...`
         );
-        this.cleanupPartialFiles(job);
         job.url = originalUrl;
-        job.downloadedBytes = 0;
-        job.progress = 0;
-        // A prior attempt may have flipped status to 'extracting' (zip ≥90%);
-        // the retry starts in the download phase again, so reset it or the UI
-        // shows "0% extracting".
         job.status = 'downloading';
-        // downloadAndExtract pushes onto these as files/zip-entries arrive, so
-        // clear them (after cleanupPartialFiles has used targetFiles) — else a
-        // retry of a partially-streamed download accumulates duplicate names.
+        // Extraction only runs after the download completes, so these are
+        // always safe to reset on a retry.
         job.targetFiles = [];
         job.extractedFiles = [];
-        await new Promise((r) => setTimeout(r, RETRY_BACKOFF_MS * attempt));
+        await new Promise((r) =>
+          setTimeout(r, RETRY_BACKOFF_MS * Math.max(1, attemptsWithoutProgress))
+        );
       }
     }
+    // A cancel that landed during the final (successful) attempt must not
+    // be overwritten by finalization/completion.
+    if (isCancelled(job)) {
+      throw new Error('Cancelled by user');
+    }
+    await this.finalizeDownload(job, partPath, contentType);
   }
 
-  private async downloadAndExtract(job: DownloadJob): Promise<void> {
-    if (!job.originalUrl) {
-      job.originalUrl = job.url;
-    }
-
-    return new Promise<void>((resolve, reject) => {
+  // One HTTP attempt: stream the response body onto the end of `partPath`.
+  // Sends a Range request when the part file already has bytes; handles
+  // servers that ignore Range (200 → rewrite the file from scratch) and
+  // 416 (part already complete, or stale → drop it and let the retry
+  // start over). A premature connection close is a TransientDownloadError
+  // so the caller resumes; fs errors stay plain Errors and fail fast.
+  // Resolves with the response Content-Type so finalizeDownload can sanity
+  // -check the body against what the source claimed to serve.
+  private downloadToFile(job: DownloadJob, partPath: string, redirects = 0): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      const startByte = this.partFileSize(partPath);
       const protocol = job.url.startsWith('https') ? https : http;
+      const headers: Record<string, string> = {};
+      if (startByte > 0) {
+        headers.Range = `bytes=${String(startByte)}-`;
+      }
 
-      console.log(`[${job.id}] Starting download from: ${job.url}`);
+      console.log(`[${job.id}] Starting download from: ${job.url} (offset ${String(startByte)})`);
 
       const req = protocol
-        .get(job.url, { timeout: 60000 }, (response) => {
-          if (response.statusCode === 301 || response.statusCode === 302) {
+        .get(job.url, { timeout: 60000, headers }, (response) => {
+          const status = response.statusCode ?? 0;
+
+          if (status === 301 || status === 302 || status === 307 || status === 308) {
             const redirectUrl = response.headers.location;
+            response.resume(); // drain so the socket can be reused/freed
             if (redirectUrl) {
-              console.log(`[${job.id}] Following redirect to: ${redirectUrl}`);
-              job.url = redirectUrl;
-              this.downloadAndExtract(job).then(resolve).catch(reject);
+              if (redirects >= MAX_REDIRECTS) {
+                reject(new Error('Too many redirects'));
+                return;
+              }
+              // Location may be relative — resolve against the URL that
+              // produced the redirect.
+              let resolvedUrl: string;
+              try {
+                resolvedUrl = new URL(redirectUrl, job.url).toString();
+              } catch {
+                reject(new Error(`Invalid redirect location: ${redirectUrl}`));
+                return;
+              }
+              console.log(`[${job.id}] Following redirect to: ${resolvedUrl}`);
+              job.url = resolvedUrl;
+              this.downloadToFile(job, partPath, redirects + 1)
+                .then(resolve)
+                .catch(reject);
               return;
             }
           }
 
-          if (response.statusCode !== 200) {
-            const status = response.statusCode ?? 0;
+          if (status === 416) {
+            // Range not satisfiable: either the part file already holds the
+            // complete body (offset === total) or it's stale relative to
+            // the source. "bytes */<total>" disambiguates; stale parts are
+            // dropped so the retry starts from zero.
+            response.resume();
+            const total = parseContentRangeTotal(response.headers['content-range']);
+            if (total !== null && total === startByte) {
+              job.downloadedBytes = startByte;
+              job.totalBytes = total;
+              resolve(response.headers['content-type'] ?? '');
+              return;
+            }
+            try {
+              fs.unlinkSync(partPath);
+            } catch {
+              // already gone
+            }
+            reject(
+              new TransientDownloadError(`HTTP 416 at offset ${String(startByte)}; restarting`)
+            );
+            return;
+          }
+
+          const resumed = status === 206 && startByte > 0;
+          if (resumed) {
+            // Trust but verify: appending a 206 body that doesn't start
+            // exactly at our offset would silently corrupt the file.
+            const rangeStart = parseContentRangeStart(response.headers['content-range']);
+            if (rangeStart !== startByte) {
+              response.resume();
+              try {
+                fs.unlinkSync(partPath);
+              } catch {
+                // already gone
+              }
+              reject(
+                new TransientDownloadError(
+                  `Server resumed at ${String(rangeStart ?? 'unknown')} instead of ${String(startByte)}; restarting`
+                )
+              );
+              return;
+            }
+          }
+          if (status !== 200 && !resumed) {
             response.resume(); // drain so the socket can be reused/freed
             // 5xx = server-side hiccup, worth a retry; 4xx (incl. 404 for a
             // moved/expired catalog link) is permanent — fail fast.
-            const msg = `HTTP ${status}`;
+            const msg = `HTTP ${String(status)}`;
             reject(status >= 500 ? new TransientDownloadError(msg) : new Error(msg));
             return;
           }
 
-          const contentLength = parseInt(response.headers['content-length'] ?? '0');
-          job.totalBytes = contentLength;
+          // A 200 answer to a Range request means the server ignored the
+          // header — write the file from scratch rather than appending a
+          // second copy of the body onto the partial one.
+          const appendFrom = resumed ? startByte : 0;
+          const totalBytes = resumed
+            ? (parseContentRangeTotal(response.headers['content-range']) ?? 0)
+            : parseInt(response.headers['content-length'] ?? '0') || 0;
+          job.totalBytes = totalBytes;
+          job.downloadedBytes = appendFrom;
 
           const contentType = response.headers['content-type'] ?? '';
-          console.log(`[${job.id}] Content-Type: ${contentType}, Size: ${contentLength} bytes`);
+          console.log(
+            `[${job.id}] ${resumed ? `Resuming at byte ${String(startByte)}` : 'Downloading'}; Content-Type: ${contentType}, total: ${totalBytes > 0 ? String(totalBytes) : 'unknown'} bytes`
+          );
 
-          let downloadedBytes = 0;
-
-          const isZip =
+          // Archives cap at 90% — finalizeDownload owns 90-100 for the
+          // extraction phase; raw saves and direct files run to 100.
+          const looksLikeZip =
             !job.saveRaw &&
-            (contentType.includes('zip') || (job.originalUrl ?? job.url).endsWith('.zip'));
+            (contentType.includes('zip') ||
+              urlPathLooksLikeZip(job.originalUrl) ||
+              urlPathLooksLikeZip(job.url));
+          const cap = looksLikeZip ? 90 : 100;
 
+          let receivedThisAttempt = 0;
           response.on('data', (chunk: Buffer) => {
-            downloadedBytes += chunk.length;
-            job.downloadedBytes = downloadedBytes;
-
-            if (contentLength > 0) {
-              if (isZip) {
-                job.progress = Math.min(90, Math.floor((downloadedBytes / contentLength) * 90));
-                if (job.progress >= 90 && job.status === 'downloading') {
-                  job.status = 'extracting';
-                }
-              } else {
-                job.progress = Math.floor((downloadedBytes / contentLength) * 100);
-              }
+            receivedThisAttempt += chunk.length;
+            job.downloadedBytes = appendFrom + receivedThisAttempt;
+            if (job.totalBytes > 0) {
+              job.progress = Math.min(
+                cap,
+                Math.floor((job.downloadedBytes / job.totalBytes) * cap)
+              );
             }
-
             this.emit('job-updated', job);
           });
 
-          if (isZip) {
-            console.log(`[${job.id}] Processing as ZIP file...`);
-
-            const extractionPromises: Promise<void>[] = [];
-
-            response
-              .pipe(unzipper.Parse())
-              .on('entry', (entry: unzipper.Entry) => {
-                const fileName = entry.path;
-                const type = entry.type;
-
-                if (type === 'File' && fileName.endsWith('.mbtiles')) {
-                  const targetPath = path.join(job.targetDir, path.basename(fileName));
-                  const targetFileName = path.basename(fileName);
-                  console.log(`[${job.id}] Extracting: ${fileName} to ${targetPath}`);
-
-                  job.targetFiles.push(targetFileName);
-                  this.emit('job-updated', job);
-
-                  const extractPromise = new Promise<void>((resolveExtract, rejectExtract) => {
-                    const writeStream = fs.createWriteStream(targetPath);
-                    // 'close' fires even after 'error' (emitClose default);
-                    // don't count a failed write as an extracted file.
-                    let writeFailed = false;
-
-                    writeStream
-                      .on('close', () => {
-                        if (writeFailed) {
-                          return;
-                        }
-                        console.log(`[${job.id}] Extracted: ${fileName}`);
-                        job.extractedFiles.push(path.basename(fileName));
-                        resolveExtract();
-                      })
-                      .on('error', (err: Error) => {
-                        writeFailed = true;
-                        console.error(`[${job.id}] Error writing ${fileName}:`, err);
-                        // pipe() unpipes on destination error and leaves the
-                        // entry paused, which would stall the zip parser and
-                        // keep 'finish' (where the job's failure is decided)
-                        // from ever firing. Drain the entry so the stream
-                        // keeps flowing and the job fails instead of hanging.
-                        // The drain stream's own errors must be observed too
-                        // — an unlistened 'error' on it would crash the
-                        // process; the parser's error handler already fails
-                        // the job for a corrupt archive.
-                        void entry
-                          .autodrain()
-                          .promise()
-                          .catch(() => undefined);
-                        rejectExtract(err);
-                      });
-
-                    entry.pipe(writeStream);
-                  });
-
-                  // Observe the rejection immediately: Promise.all() below
-                  // only attaches at the zip stream's 'finish', so an
-                  // earlier write failure would surface as a process-level
-                  // unhandled rejection (seen as plugin status "Unhandled
-                  // rejection: ENOENT ..." when the quarantine dir vanished
-                  // mid-extraction). The real error still propagates through
-                  // Promise.all on the original promise.
-                  extractPromise.catch(() => undefined);
-                  extractionPromises.push(extractPromise);
-                } else {
-                  void entry
-                    .autodrain()
-                    .promise()
-                    .catch(() => undefined);
-                }
-              })
-              .on('finish', () => {
-                void (async () => {
-                  try {
-                    await Promise.all(extractionPromises);
-                    console.log(
-                      `[${job.id}] Extraction complete. Files: ${job.extractedFiles.join(', ')}`
-                    );
-
-                    if (job.extractedFiles.length === 0) {
-                      reject(new Error('No .mbtiles files found in archive'));
-                    } else {
-                      job.progress = 100;
-                      resolve();
-                    }
-                  } catch (error) {
-                    console.error(`[${job.id}] Error during extraction:`, error);
-                    reject(error);
-                  }
-                })();
-              })
-              .on('error', (error: Error) => {
-                console.error(`[${job.id}] Extraction error:`, error);
-                reject(error);
-              });
-          } else {
-            console.log(
-              `[${job.id}] Processing as direct file (saveRaw: ${String(job.saveRaw)})...`
-            );
-
-            let fileName: string;
-            if (job.saveRaw) {
-              fileName = path.basename(job.originalUrl ?? job.url).split('?')[0];
-              if (job.chartName && job.chartName.trim()) {
-                const ext = path.extname(fileName) || '.zip';
-                fileName = job.chartName.trim() + ext;
-              }
-            } else if (job.chartName && job.chartName.trim()) {
-              fileName = job.chartName.trim();
-              if (!fileName.endsWith('.mbtiles')) {
-                fileName += '.mbtiles';
-              }
-            } else {
-              fileName = path.basename(job.originalUrl ?? job.url).split('?')[0];
-              if (!fileName.endsWith('.mbtiles')) {
-                fileName += '.mbtiles';
-              }
+          const fileStream = fs.createWriteStream(partPath, { flags: resumed ? 'a' : 'w' });
+          let settled = false;
+          const fail = (err: Error): void => {
+            if (settled) {
+              return;
             }
+            settled = true;
+            // Whatever was flushed stays in the part file — the next
+            // attempt resumes from its on-disk size.
+            fileStream.destroy();
+            response.destroy();
+            reject(err);
+          };
 
-            // Strip any directory component before joining, the same way
-            // the ZIP branch above does. The route handlers already reject
-            // unsafe chartName/chartNumber with a 400, so this only fires
-            // for any future non-route caller — but it keeps the write
-            // inside targetDir regardless. Reuse the basenamed value for
-            // targetFiles so the cancel/cleanup unlink paths reference the
-            // file that was actually written.
-            const safeFileName = path.basename(fileName);
-            const targetPath = path.join(job.targetDir, safeFileName);
+          fileStream.on('error', (err: Error) => {
+            // fs-level failure (ENOENT/ENOSPC/perms): not transient.
+            fail(err);
+          });
+          response.on('aborted', () => {
+            fail(new TransientDownloadError('Connection closed mid-transfer'));
+          });
+          response.on('error', (err: Error) => {
+            fail(new TransientDownloadError(err.message));
+          });
 
-            job.targetFiles.push(safeFileName);
-            this.emit('job-updated', job);
+          fileStream.on('finish', () => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            // Truncation guard: a keep-alive server can end the body short
+            // without an 'aborted'/'error' event.
+            const received = appendFrom + receivedThisAttempt;
+            if (job.totalBytes > 0 && received < job.totalBytes) {
+              reject(
+                new TransientDownloadError(
+                  `Connection closed early (${String(received)} of ${String(job.totalBytes)} bytes)`
+                )
+              );
+              return;
+            }
+            resolve(contentType);
+          });
 
-            const fileStream = fs.createWriteStream(targetPath);
-            response.pipe(fileStream);
-
-            fileStream.on('finish', () => {
-              fileStream.close();
-              console.log(`[${job.id}] Downloaded: ${fileName}`);
-              job.extractedFiles.push(path.basename(targetPath));
-              job.progress = 100;
-              resolve();
-            });
-
-            fileStream.on('error', (error: Error) => {
-              fs.unlink(targetPath, () => {});
-              reject(error);
-            });
-
-            response.on('error', () => {
-              fileStream.destroy();
-            });
-
-            response.on('aborted', () => {
-              fileStream.destroy();
-            });
-          }
+          response.pipe(fileStream);
         })
         .on('error', (error: Error) => {
           console.error(`[${job.id}] Download error:`, error);
@@ -457,6 +524,124 @@ class DownloadManager extends EventEmitter {
         reject(new TransientDownloadError('Server not responding (no data received for 60s)'));
       });
     });
+  }
+
+  // The body is fully on disk — turn the .part file into the final chart
+  // file(s). Archives are detected by magic bytes (tokenized URLs and
+  // mislabeled servers make extension/Content-Type unreliable) and
+  // extracted via the zip central directory: random access on a complete
+  // file, no streaming parser to stall, and sequential entry writes so
+  // duplicate basenames can't clobber each other from concurrent streams.
+  private async finalizeDownload(
+    job: DownloadJob,
+    partPath: string,
+    contentType: string
+  ): Promise<void> {
+    const looksLikeZip =
+      contentType.includes('zip') ||
+      urlPathLooksLikeZip(job.originalUrl) ||
+      urlPathLooksLikeZip(job.url);
+
+    if (!job.saveRaw && isZipMagic(partPath)) {
+      job.status = 'extracting';
+      job.progress = Math.max(job.progress, 90);
+      this.emit('job-updated', job);
+
+      const directory = await unzipper.Open.file(partPath);
+      const entries = directory.files.filter(
+        (f) => f.type === 'File' && f.path.endsWith('.mbtiles')
+      );
+      if (entries.length === 0) {
+        fs.unlinkSync(partPath);
+        job.partFile = undefined;
+        throw new Error('No .mbtiles files found in archive');
+      }
+
+      let done = 0;
+      // Entry paths are flattened to basenames, so region-a/chart.mbtiles
+      // and region-b/chart.mbtiles would land on the same target — keep
+      // every chart by uniquifying collisions (chart.mbtiles, chart-2...).
+      const usedNames = new Set<string>();
+      for (const entry of entries) {
+        let targetFileName = path.basename(entry.path);
+        if (usedNames.has(targetFileName)) {
+          const ext = path.extname(targetFileName);
+          const stem = ext ? targetFileName.slice(0, -ext.length) : targetFileName;
+          let suffix = 2;
+          while (usedNames.has(`${stem}-${String(suffix)}${ext}`)) {
+            suffix += 1;
+          }
+          targetFileName = `${stem}-${String(suffix)}${ext}`;
+          console.log(
+            `[${job.id}] Duplicate basename in archive; extracting ${entry.path} as ${targetFileName}`
+          );
+        }
+        usedNames.add(targetFileName);
+        const targetPath = path.join(job.targetDir, targetFileName);
+        console.log(`[${job.id}] Extracting: ${entry.path} to ${targetPath}`);
+        job.targetFiles.push(targetFileName);
+        this.emit('job-updated', job);
+
+        await pipeline(entry.stream(), fs.createWriteStream(targetPath));
+
+        job.extractedFiles.push(targetFileName);
+        done += 1;
+        job.progress = 90 + Math.floor((done / entries.length) * 10);
+        this.emit('job-updated', job);
+      }
+      console.log(`[${job.id}] Extraction complete. Files: ${job.extractedFiles.join(', ')}`);
+      fs.unlinkSync(partPath);
+      job.partFile = undefined;
+      return;
+    }
+
+    if (!job.saveRaw && looksLikeZip) {
+      // The source claimed a zip but the bytes aren't one (typically an
+      // HTML error page from an expired share link). Failing beats
+      // renaming junk to .mbtiles and calling the job completed.
+      fs.unlinkSync(partPath);
+      job.partFile = undefined;
+      throw new Error('Downloaded file is not a valid ZIP archive');
+    }
+
+    console.log(`[${job.id}] Processing as direct file (saveRaw: ${String(job.saveRaw)})...`);
+
+    let fileName: string;
+    if (job.saveRaw) {
+      fileName = path.basename(job.originalUrl ?? job.url).split('?')[0];
+      if (job.chartName && job.chartName.trim()) {
+        const ext = path.extname(fileName) || '.zip';
+        fileName = job.chartName.trim() + ext;
+      }
+    } else if (job.chartName && job.chartName.trim()) {
+      fileName = job.chartName.trim();
+      if (!fileName.endsWith('.mbtiles')) {
+        fileName += '.mbtiles';
+      }
+    } else {
+      fileName = path.basename(job.originalUrl ?? job.url).split('?')[0];
+      if (!fileName.endsWith('.mbtiles')) {
+        fileName += '.mbtiles';
+      }
+    }
+
+    // Strip any directory component before joining. The route handlers
+    // already reject unsafe chartName/chartNumber with a 400, so this only
+    // fires for any future non-route caller — but it keeps the write
+    // inside targetDir regardless. Reuse the basenamed value for
+    // targetFiles so the cancel/cleanup unlink paths reference the file
+    // that was actually written.
+    const safeFileName = path.basename(fileName);
+    const targetPath = path.join(job.targetDir, safeFileName);
+
+    job.targetFiles.push(safeFileName);
+    this.emit('job-updated', job);
+
+    fs.renameSync(partPath, targetPath);
+    job.partFile = undefined;
+    console.log(`[${job.id}] Downloaded: ${safeFileName}`);
+    job.extractedFiles.push(safeFileName);
+    job.progress = 100;
   }
 
   findJobsByTargetFile(fileName: string): DownloadJob[] {
@@ -485,8 +670,9 @@ class DownloadManager extends EventEmitter {
     job.error = 'Cancelled by user';
     job.completedAt = Date.now();
 
-    if (job.targetFiles && job.targetFiles.length > 0) {
-      job.targetFiles.forEach((fn) => {
+    const cancelNames = job.partFile ? [...job.targetFiles, job.partFile] : job.targetFiles;
+    if (cancelNames.length > 0) {
+      cancelNames.forEach((fn) => {
         const filePath = path.join(job.targetDir, fn);
         fs.unlink(filePath, (err) => {
           if (err && err.code !== 'ENOENT') {

--- a/test/download-manager.test.ts
+++ b/test/download-manager.test.ts
@@ -165,6 +165,57 @@ describe('DownloadManager zip extraction', () => {
     }
   });
 
+  it('uniquifies duplicate basenames across archive folders instead of clobbering', async () => {
+    const zip = storedZip([
+      { name: 'region-a/chart.mbtiles', data: Buffer.from('AAA') },
+      { name: 'region-b/chart.mbtiles', data: Buffer.from('BBB') }
+    ]);
+    const origin = await startOrigin((_hit, res) => {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/zip');
+      res.end(zip);
+    });
+
+    const dir = fs.mkdtempSync(path.join(TMP, 'zip-dup-'));
+    try {
+      const jobId = downloadManager.createJob(origin.url, dir, 'dup');
+      const job = await waitForTerminal(jobId);
+
+      assert.strictEqual(job.status, 'completed', `expected completed, got ${job.error ?? ''}`);
+      assert.deepStrictEqual([...job.extractedFiles].sort(), ['chart-2.mbtiles', 'chart.mbtiles']);
+      assert.strictEqual(fs.readFileSync(path.join(dir, 'chart.mbtiles'), 'utf8'), 'AAA');
+      assert.strictEqual(fs.readFileSync(path.join(dir, 'chart-2.mbtiles'), 'utf8'), 'BBB');
+    } finally {
+      await origin.close();
+    }
+  });
+
+  it('follows a relative redirect Location', async () => {
+    const origin = await startOrigin((hit, res) => {
+      if (hit === 1) {
+        res.statusCode = 302;
+        res.setHeader('location', '/moved/chart.bin');
+        res.end();
+        return;
+      }
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/octet-stream');
+      res.end('CHARTDATA');
+    });
+
+    const dir = fs.mkdtempSync(path.join(TMP, 'relredir-'));
+    try {
+      const jobId = downloadManager.createJob(origin.url, dir, 'relredir', { saveRaw: true });
+      const job = await waitForTerminal(jobId);
+
+      assert.strictEqual(job.status, 'completed', `expected completed, got ${job.error ?? ''}`);
+      assert.strictEqual(origin.hits(), 2);
+      assert.strictEqual(fs.readFileSync(path.join(dir, 'relredir.bin'), 'utf8'), 'CHARTDATA');
+    } finally {
+      await origin.close();
+    }
+  });
+
   it(
     'fails cleanly when the target dir vanishes mid-extraction (no unhandled rejection, no hang)',
     { timeout: 20000 },
@@ -208,6 +259,214 @@ describe('DownloadManager zip extraction', () => {
       }
     }
   );
+});
+
+// Origin that honors HTTP Range requests over a fixed body. `perHit`
+// returns how many bytes of the (range-adjusted) response to send before
+// hard-destroying the socket — or null to send everything cleanly. Set
+// `ignoreRange` to emulate a server without Range support (always 200,
+// always the full body).
+interface ResumableOrigin extends Origin {
+  ranges: () => (string | undefined)[];
+}
+
+function startResumableOrigin(
+  body: Buffer,
+  perHit: (hit: number) => number | null,
+  opts: { ignoreRange?: boolean; failWith?: (hit: number) => number | null } = {}
+): Promise<ResumableOrigin> {
+  let hits = 0;
+  const ranges: (string | undefined)[] = [];
+  const server = http.createServer((req, res) => {
+    hits += 1;
+    ranges.push(req.headers.range);
+
+    const failStatus = opts.failWith?.(hits) ?? null;
+    if (failStatus !== null) {
+      res.statusCode = failStatus;
+      res.end('nope');
+      return;
+    }
+
+    const m = /^bytes=(\d+)-$/.exec(req.headers.range ?? '');
+    const start = !opts.ignoreRange && m ? parseInt(m[1], 10) : 0;
+    const slice = body.subarray(start);
+    if (start > 0) {
+      res.statusCode = 206;
+      res.setHeader('content-range', `bytes ${start}-${body.length - 1}/${body.length}`);
+    } else {
+      res.statusCode = 200;
+    }
+    res.setHeader('content-type', 'application/octet-stream');
+    res.setHeader('content-length', slice.length);
+
+    const n = perHit(hits);
+    if (n === null || n >= slice.length) {
+      res.end(slice);
+      return;
+    }
+    res.write(slice.subarray(0, n));
+    // Give the chunk a beat to flush, then cut the connection hard.
+    setTimeout(() => {
+      res.destroy();
+    }, 50);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      resolve({
+        url: `http://127.0.0.1:${port}/chart.bin`,
+        hits: () => hits,
+        ranges: () => ranges,
+        close: () =>
+          new Promise<void>((r) => {
+            server.close(() => {
+              r();
+            });
+          })
+      });
+    });
+  });
+}
+
+describe('DownloadManager resume', () => {
+  before(() => {
+    fs.mkdirSync(TMP, { recursive: true });
+  });
+
+  beforeEach(() => {
+    downloadManager.removeAllListeners();
+  });
+
+  after(() => {
+    downloadManager.removeAllListeners();
+    fs.rmSync(TMP, { recursive: true, force: true });
+  });
+
+  const body = Buffer.alloc(8192);
+  for (let i = 0; i < body.length; i++) {
+    body[i] = i % 251;
+  }
+
+  it('resumes from the interrupted offset with a Range request', async () => {
+    // First attempt is cut after ~3000 bytes; the retry must ask for the
+    // remainder (Range) and the final file must be byte-identical.
+    const origin = await startResumableOrigin(body, (hit) => (hit === 1 ? 3000 : null));
+    const dir = fs.mkdtempSync(path.join(TMP, 'resume-'));
+    try {
+      const jobId = downloadManager.createJob(origin.url, dir, 'resume-test', { saveRaw: true });
+      const job = await waitForTerminal(jobId);
+
+      assert.strictEqual(job.status, 'completed', `expected completed, got ${job.error ?? ''}`);
+      assert.strictEqual(origin.hits(), 2);
+      const secondRange = origin.ranges()[1];
+      const offsetMatch = /^bytes=(\d+)-$/.exec(secondRange ?? '');
+      assert.ok(
+        offsetMatch,
+        `second request must carry a Range header, got ${String(secondRange)}`
+      );
+      const offset = parseInt(offsetMatch[1], 10);
+      assert.ok(
+        offset > 0 && offset <= 3000,
+        `resume offset must be within the first attempt's delivered bytes, got ${String(offset)}`
+      );
+      const written = fs.readFileSync(path.join(dir, 'resume-test.bin'));
+      assert.ok(written.equals(body), 'resumed file must be byte-identical to the source');
+      // No .part leftovers after success.
+      assert.deepStrictEqual(
+        fs.readdirSync(dir).filter((f) => f.endsWith('.part')),
+        []
+      );
+    } finally {
+      await origin.close();
+    }
+  });
+
+  it('rewrites from scratch when the server ignores Range', async () => {
+    const origin = await startResumableOrigin(body, (hit) => (hit === 1 ? 3000 : null), {
+      ignoreRange: true
+    });
+    const dir = fs.mkdtempSync(path.join(TMP, 'norange-'));
+    try {
+      const jobId = downloadManager.createJob(origin.url, dir, 'norange-test', { saveRaw: true });
+      const job = await waitForTerminal(jobId);
+
+      assert.strictEqual(job.status, 'completed', `expected completed, got ${job.error ?? ''}`);
+      const written = fs.readFileSync(path.join(dir, 'norange-test.bin'));
+      assert.strictEqual(written.length, body.length, 'body must not be duplicated/appended');
+      assert.ok(written.equals(body));
+    } finally {
+      await origin.close();
+    }
+  });
+
+  it(
+    'keeps retrying through stalls as long as bytes advance (budget rearms on progress)',
+    { timeout: 30000 },
+    async () => {
+      // Four consecutive cut connections — more than MAX_DOWNLOAD_ATTEMPTS —
+      // but every attempt delivers ~2000 new bytes, so the job must still
+      // complete on the fifth request.
+      const origin = await startResumableOrigin(body, (hit) => (hit <= 4 ? 2000 : null));
+      const dir = fs.mkdtempSync(path.join(TMP, 'stalls-'));
+      try {
+        const jobId = downloadManager.createJob(origin.url, dir, 'stalls-test', {
+          saveRaw: true
+        });
+        const job = await waitForTerminal(jobId);
+
+        assert.strictEqual(job.status, 'completed', `expected completed, got ${job.error ?? ''}`);
+        assert.strictEqual(origin.hits(), 5, 'should have taken 5 requests (4 stalls + 1 final)');
+        // Every retry must resume at a strictly higher offset — this fails
+        // if retries throw away partial data and re-download from zero.
+        const offsets = origin.ranges().map((r, i) => {
+          if (i === 0) {
+            return 0;
+          }
+          const m = /^bytes=(\d+)-$/.exec(r ?? '');
+          assert.ok(m, `request ${String(i + 1)} must carry a Range header, got ${String(r)}`);
+          return parseInt(m[1], 10);
+        });
+        for (let i = 1; i < offsets.length; i++) {
+          assert.ok(
+            offsets[i] > offsets[i - 1],
+            `resume offsets must strictly increase, got ${offsets.join(', ')}`
+          );
+        }
+        const written = fs.readFileSync(path.join(dir, 'stalls-test.bin'));
+        assert.ok(written.equals(body));
+      } finally {
+        await origin.close();
+      }
+    }
+  );
+
+  it('fails fast when the resume request gets a 4xx (expired link) and drops the part file', async () => {
+    const origin = await startResumableOrigin(body, (hit) => (hit === 1 ? 2500 : null), {
+      failWith: (hit) => (hit >= 2 ? 403 : null)
+    });
+    const dir = fs.mkdtempSync(path.join(TMP, 'expired-'));
+    try {
+      const jobId = downloadManager.createJob(origin.url, dir, 'expired-test', { saveRaw: true });
+      const job = await waitForTerminal(jobId);
+
+      assert.strictEqual(job.status, 'failed');
+      assert.match(job.error ?? '', /403/);
+      assert.strictEqual(origin.hits(), 2, 'a 4xx on resume must not be retried');
+      assert.ok(
+        /^bytes=\d+-$/.test(origin.ranges()[1] ?? ''),
+        'the second request must have been a resume attempt'
+      );
+      assert.deepStrictEqual(
+        fs.readdirSync(dir).filter((f) => f.endsWith('.part')),
+        [],
+        'part file must be cleaned up on final failure'
+      );
+    } finally {
+      await origin.close();
+    }
+  });
 });
 
 describe('DownloadManager retry', () => {

--- a/test/download-manager.test.ts
+++ b/test/download-manager.test.ts
@@ -190,6 +190,32 @@ describe('DownloadManager zip extraction', () => {
     }
   });
 
+  it('follows a 303 See Other redirect', async () => {
+    const origin = await startOrigin((hit, res) => {
+      if (hit === 1) {
+        res.statusCode = 303;
+        res.setHeader('location', '/see/other/chart.bin');
+        res.end();
+        return;
+      }
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/octet-stream');
+      res.end('CHARTDATA');
+    });
+
+    const dir = fs.mkdtempSync(path.join(TMP, 'seeother-'));
+    try {
+      const jobId = downloadManager.createJob(origin.url, dir, 'seeother', { saveRaw: true });
+      const job = await waitForTerminal(jobId);
+
+      assert.strictEqual(job.status, 'completed', `expected completed, got ${job.error ?? ''}`);
+      assert.strictEqual(origin.hits(), 2);
+      assert.strictEqual(fs.readFileSync(path.join(dir, 'seeother.bin'), 'utf8'), 'CHARTDATA');
+    } finally {
+      await origin.close();
+    }
+  });
+
   it('follows a relative redirect Location', async () => {
     const origin = await startOrigin((hit, res) => {
       if (hit === 1) {
@@ -268,18 +294,29 @@ describe('DownloadManager zip extraction', () => {
 // always the full body).
 interface ResumableOrigin extends Origin {
   ranges: () => (string | undefined)[];
+  ifRanges: () => (string | undefined)[];
 }
 
 function startResumableOrigin(
   body: Buffer,
   perHit: (hit: number) => number | null,
-  opts: { ignoreRange?: boolean; failWith?: (hit: number) => number | null } = {}
+  opts: {
+    ignoreRange?: boolean;
+    failWith?: (hit: number) => number | null;
+    etagForHit?: (hit: number) => string;
+    bodyForHit?: (hit: number) => Buffer;
+  } = {}
 ): Promise<ResumableOrigin> {
   let hits = 0;
   const ranges: (string | undefined)[] = [];
+  const ifRanges: (string | undefined)[] = [];
   const server = http.createServer((req, res) => {
     hits += 1;
     ranges.push(req.headers.range);
+    // 'if-range' is not in Node's singular-header list, so normalize.
+    const ifRangeHeader = req.headers['if-range'];
+    const ifRange = Array.isArray(ifRangeHeader) ? ifRangeHeader[0] : ifRangeHeader;
+    ifRanges.push(ifRange);
 
     const failStatus = opts.failWith?.(hits) ?? null;
     if (failStatus !== null) {
@@ -288,12 +325,23 @@ function startResumableOrigin(
       return;
     }
 
+    const currentBody = opts.bodyForHit?.(hits) ?? body;
+    const etag = opts.etagForHit?.(hits);
+    if (etag) {
+      res.setHeader('etag', etag);
+    }
+    // Real If-Range semantics: a Range request whose If-Range validator no
+    // longer matches the current representation gets the FULL body (200).
     const m = /^bytes=(\d+)-$/.exec(req.headers.range ?? '');
-    const start = !opts.ignoreRange && m ? parseInt(m[1], 10) : 0;
-    const slice = body.subarray(start);
+    const honorRange = !opts.ignoreRange && m && (!ifRange || ifRange === etag);
+    const start = honorRange && m ? parseInt(m[1], 10) : 0;
+    const slice = currentBody.subarray(start);
     if (start > 0) {
       res.statusCode = 206;
-      res.setHeader('content-range', `bytes ${start}-${body.length - 1}/${body.length}`);
+      res.setHeader(
+        'content-range',
+        `bytes ${start}-${currentBody.length - 1}/${currentBody.length}`
+      );
     } else {
       res.statusCode = 200;
     }
@@ -319,6 +367,7 @@ function startResumableOrigin(
         url: `http://127.0.0.1:${port}/chart.bin`,
         hits: () => hits,
         ranges: () => ranges,
+        ifRanges: () => ifRanges,
         close: () =>
           new Promise<void>((r) => {
             server.close(() => {
@@ -351,8 +400,10 @@ describe('DownloadManager resume', () => {
 
   it('resumes from the interrupted offset with a Range request', async () => {
     // First attempt is cut after ~3000 bytes; the retry must ask for the
-    // remainder (Range) and the final file must be byte-identical.
-    const origin = await startResumableOrigin(body, (hit) => (hit === 1 ? 3000 : null));
+    // remainder (Range + If-Range) and the final file must be byte-identical.
+    const origin = await startResumableOrigin(body, (hit) => (hit === 1 ? 3000 : null), {
+      etagForHit: () => '"v1"'
+    });
     const dir = fs.mkdtempSync(path.join(TMP, 'resume-'));
     try {
       const jobId = downloadManager.createJob(origin.url, dir, 'resume-test', { saveRaw: true });
@@ -371,12 +422,48 @@ describe('DownloadManager resume', () => {
         offset > 0 && offset <= 3000,
         `resume offset must be within the first attempt's delivered bytes, got ${String(offset)}`
       );
+      assert.strictEqual(
+        origin.ifRanges()[1],
+        '"v1"',
+        "the resume must bind to the first response's validator via If-Range"
+      );
       const written = fs.readFileSync(path.join(dir, 'resume-test.bin'));
       assert.ok(written.equals(body), 'resumed file must be byte-identical to the source');
       // No .part leftovers after success.
       assert.deepStrictEqual(
         fs.readdirSync(dir).filter((f) => f.endsWith('.part')),
         []
+      );
+    } finally {
+      await origin.close();
+    }
+  });
+
+  it('rewrites from scratch when the source changed between attempts (If-Range mismatch)', async () => {
+    // Same-length payload swap: version A is cut mid-transfer; the resume
+    // carries If-Range with A's validator, the origin answers 200 with the
+    // full version-B body, and the final file must be pure B — never
+    // A-prefix + B-suffix.
+    const bodyB = Buffer.alloc(body.length);
+    for (let i = 0; i < bodyB.length; i++) {
+      bodyB[i] = (i * 7 + 13) % 249;
+    }
+    const origin = await startResumableOrigin(body, (hit) => (hit === 1 ? 3000 : null), {
+      etagForHit: (hit) => (hit === 1 ? '"v1"' : '"v2"'),
+      bodyForHit: (hit) => (hit === 1 ? body : bodyB)
+    });
+    const dir = fs.mkdtempSync(path.join(TMP, 'changed-'));
+    try {
+      const jobId = downloadManager.createJob(origin.url, dir, 'changed-test', { saveRaw: true });
+      const job = await waitForTerminal(jobId);
+
+      assert.strictEqual(job.status, 'completed', `expected completed, got ${job.error ?? ''}`);
+      assert.strictEqual(origin.hits(), 2);
+      assert.strictEqual(origin.ifRanges()[1], '"v1"');
+      const written = fs.readFileSync(path.join(dir, 'changed-test.bin'));
+      assert.ok(
+        written.equals(bodyB),
+        'file must be the full new version, not stale bytes with a new tail'
       );
     } finally {
       await origin.close();


### PR DESCRIPTION
## Problem

Large chart sources are throttled and stall mid-transfer: the real case is a 3.66 GB mediafire zip served at ~430 KB/s (a ~2.4 h transfer) with intermittent stalls longer than the 60 s idle timeout. The previous download flow restarted from byte 0 on every stall and gave up after three attempts — the download could never complete, and the UI showed progress repeatedly jumping back to 0%.

## Changes

**Resumable downloads.** The body now streams into a per-job `.part` file that survives transient retries. A resumed attempt sends `Range: bytes=<size>-` and appends; a 206 whose `Content-Range` start doesn't match the offset is rejected (stale part dropped) so a misbehaving server can't silently corrupt the file; a 200 answer to a Range request (server without Range support) rewrites the file from scratch; a 416 whose total equals the offset counts as already complete. Redirect `Location` values are resolved against the current URL (relative redirects), with a depth ceiling.

**Progress-aware retry budget.** Only consecutive attempts with no forward progress count toward the 3-attempt limit; any attempt that advanced the part file rearms the budget. A long throttled download survives arbitrarily many stalls while a dead server still fails fast. Each retry re-resolves from the original URL, so tokenized direct links are refreshed; a 4xx on resume (expired link) fails immediately.

**Extraction from the completed file.** Archives are extracted after the download finishes, via the zip central directory (`unzipper.Open.file`) instead of a streaming parser — no parser stalls on broken streams, and entries are written sequentially. Duplicate basenames across archive folders are uniquified (`chart.mbtiles`, `chart-2.mbtiles`) instead of silently clobbering. Zip detection is by magic bytes; a body that claimed to be a zip but isn't (e.g. an HTML error page from an expired share link) fails the job instead of being saved as a bogus `.mbtiles`.

The `.part` file is removed on success, final failure, and cancel; a cancel that races the final attempt can no longer be overwritten by a completed status.

## Tested

- Unit suite: 434 pass, including new tests for: resume carries a Range offset within the delivered bytes and produces a byte-identical file; strictly increasing resume offsets across four consecutive stalls (more than the old attempt limit) with eventual completion; Range-ignoring servers don't get appended/duplicated bodies; a 403 on resume fails fast and drops the part file; duplicate archive basenames are uniquified; relative redirect Locations are followed.
- Real-server e2e (master signalk-server, throwaway `-c` dir) against an origin that cut the connection on every request: the origin log shows resume requests at `bytes=600-` and `bytes=1200-`, with both charts extracted and promoted and no `.part`/quarantine leftovers.
- Not tested end-to-end against the actual 3.66 GB mediafire transfer (multi-hour); mediafire's Range support was verified directly (206 with `accept-ranges: bytes`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Implements resumable chart downloads by streaming into per-job persistent `.part` files and resuming with HTTP `Range` requests based on the current `.part` size.
- Restarts transient failures by resuming from disk while tracking a retry budget based on consecutive attempts without forward progress; re-resolves the original URL on retry and follows redirects (including relative `Location`s) up to a bounded depth.
- Detects resume edge cases: handles servers that ignore `Range` by rewriting from scratch, recognizes `416` as a completion/stale-part signal and restarts accordingly, and fails immediately (without retry) on resume-related `4xx` responses.
- Finalizes downloads by converting the completed payload into chart outputs: validates ZIPs via magic bytes, extracts using the ZIP central directory (random-access via `unzipper.Open.file`), writes `.mbtiles` entries safely via `pipeline`, uniquifies duplicate basenames to avoid clobbering, and removes both target outputs and the `.part` file on success/failure/cancellation as appropriate.
- Adds tests covering resume behavior, retry-with-progress semantics, Range-ignore fallback, fast-fail on resume `4xx`, relative redirect following, ZIP extraction and duplicate-name uniquification, and an interrupted real-server download scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->