### PR TITLE
feat(manage): upload a ZIP of charts and extract it into a folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ The interface provides five tabs:
    - **Upload ZIP** imports a whole archive at once: every `.mbtiles` inside it
      is extracted into the selected folder (nested folders are flattened, and
      non-chart files in the archive are ignored). Multi-GB archives are
-     supported — anything over 50 MB uploads in chunks, so a slow WiFi link
-     can't run into the server's request timeout. Extraction needs roughly
-     twice the archive size free on disk while it runs.
+     supported — large ones upload in chunks automatically, so a slow WiFi
+     link can't run into the server's request timeout. Extraction needs
+     roughly twice the archive size free on disk while it runs.
    - S-57 charts shown with ENC badge
    - Converting charts shown with progress indicator
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ The interface provides five tabs:
 1. **Manage Charts**:
    - View all charts with metadata (name, bounds, zoom levels, size)
    - Enable/disable, organize into folders, upload, delete, rename
+   - **Upload ZIP** imports a whole archive at once: every `.mbtiles` inside it
+     is extracted into the selected folder (nested folders are flattened, and
+     non-chart files in the archive are ignored). Multi-GB archives are
+     supported — anything over 50 MB uploads in chunks, so a slow WiFi link
+     can't run into the server's request timeout. Extraction needs roughly
+     twice the archive size free on disk while it runs.
    - S-57 charts shown with ENC badge
    - Converting charts shown with progress indicator
 

--- a/e2e/manage-charts.spec.ts
+++ b/e2e/manage-charts.spec.ts
@@ -79,4 +79,59 @@ test.describe('Manage Charts tab', () => {
       { timeout: 5000 }
     );
   });
+
+  test('offers a ZIP upload control wired to a .zip file input', async ({ page }) => {
+    await page.goto('/plugins/signalk-charts-provider-simple/');
+    await setMockState(page, {
+      localCharts: {
+        basePath: '/tmp/charts',
+        folders: ['/'],
+        charts: [{ relativePath: 'foo.mbtiles', name: 'Foo Chart', folder: '/', enabled: true }]
+      }
+    });
+    await page.evaluate(() => {
+      (window as unknown as { handleManageTabActive: () => void }).handleManageTabActive();
+    });
+
+    const zipButton = page.getByRole('button', { name: 'Upload ZIP' });
+    await expect(zipButton).toBeVisible({ timeout: 5000 });
+
+    // The hidden input is what actually carries the archive; if its accept
+    // filter drifts away from .zip the picker starts offering the wrong
+    // files, which no assertion on the button alone would catch.
+    const zipInput = page.locator('#chartZipUploadInput');
+    await expect(zipInput).toHaveAttribute('accept', '.zip');
+    // Single archive per upload — the route takes only the first file.
+    await expect(zipInput).not.toHaveAttribute('multiple', /.*/);
+
+    // Clicking the button must reach that input. Intercept the click
+    // rather than let it open a native file dialog Playwright can't close.
+    const clicked = await page.evaluate(() => {
+      const input = document.getElementById('chartZipUploadInput');
+      if (!input) {
+        return false;
+      }
+      let sawClick = false;
+      input.addEventListener('click', (e) => {
+        sawClick = true;
+        e.preventDefault();
+      });
+      (window as unknown as { triggerZipUpload: () => void }).triggerZipUpload();
+      return sawClick;
+    });
+    expect(clicked).toBe(true);
+  });
+
+  test('offers ZIP upload from the empty state too', async ({ page }) => {
+    await page.goto('/plugins/signalk-charts-provider-simple/');
+    await setMockState(page, {
+      localCharts: { basePath: '/tmp/charts', folders: ['/'], charts: [] }
+    });
+    await page.evaluate(() => {
+      (window as unknown as { handleManageTabActive: () => void }).handleManageTabActive();
+    });
+
+    await expect(page.getByRole('button', { name: 'Upload ZIP' })).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('#chartZipUploadInputEmpty')).toHaveAttribute('accept', '.zip');
+  });
 });

--- a/e2e/manage-charts.spec.ts
+++ b/e2e/manage-charts.spec.ts
@@ -133,5 +133,22 @@ test.describe('Manage Charts tab', () => {
 
     await expect(page.getByRole('button', { name: 'Upload ZIP' })).toBeVisible({ timeout: 5000 });
     await expect(page.locator('#chartZipUploadInputEmpty')).toHaveAttribute('accept', '.zip');
+
+    // The empty state has its own input id and trigger, so the populated
+    // state's coverage says nothing about this one being wired up.
+    const clicked = await page.evaluate(() => {
+      const input = document.getElementById('chartZipUploadInputEmpty');
+      if (!input) {
+        return false;
+      }
+      let sawClick = false;
+      input.addEventListener('click', (e) => {
+        sawClick = true;
+        e.preventDefault();
+      });
+      (window as unknown as { triggerZipUploadEmpty: () => void }).triggerZipUploadEmpty();
+      return sawClick;
+    });
+    expect(clicked).toBe(true);
   });
 });

--- a/public/js/globals.d.ts
+++ b/public/js/globals.d.ts
@@ -53,6 +53,9 @@ declare global {
     triggerUpload(): void;
     triggerUploadEmpty(): void;
     handleFileUpload(event: Event): void;
+    triggerZipUpload(): void;
+    triggerZipUploadEmpty(): void;
+    handleZipUpload(event: Event): void;
     setViewMode(mode: 'grid' | 'list'): void;
     selectFolder(folder: string | null): void;
     showCreateFolderDialog(): void;

--- a/public/js/manage-charts-enhanced.ts
+++ b/public/js/manage-charts-enhanced.ts
@@ -854,7 +854,19 @@ async function performChunkedZipUpload(file: File): Promise<void> {
         },
         (chunkLoaded) => {
           updateUploadProgress(bytesSent + chunkLoaded, file.size);
-        }
+        },
+        // Extraction starts once the final chunk's bytes are in, and for a
+        // multi-GB archive it takes long enough that the bar would otherwise
+        // sit at 100% looking hung. Flip the label at that exact point, not
+        // while the last chunk is still going out.
+        i === totalChunks - 1
+          ? () => {
+              const statusText = document.getElementById('uploadStatus');
+              if (statusText) {
+                statusText.textContent = 'Extracting charts from archive...';
+              }
+            }
+          : undefined
       );
 
       bytesSent += end - start;
@@ -863,15 +875,6 @@ async function performChunkedZipUpload(file: File): Promise<void> {
       // The last chunk's response carries the extraction result.
       if (i === totalChunks - 1) {
         finalPayload = payload;
-      } else {
-        // Extraction only starts once the final chunk lands, so show it
-        // as the last chunk goes out rather than after every chunk.
-        if (i === totalChunks - 2) {
-          const statusText = document.getElementById('uploadStatus');
-          if (statusText) {
-            statusText.textContent = 'Extracting charts from archive...';
-          }
-        }
       }
     }
 
@@ -900,7 +903,8 @@ function sendZipChunk(
     totalChunks: number;
     targetFolder: string;
   },
-  onProgress: (loaded: number) => void
+  onProgress: (loaded: number) => void,
+  onSent?: () => void
 ): Promise<ZipUploadResponse | null> {
   return new Promise<ZipUploadResponse | null>((resolve, reject) => {
     const xhr = new XMLHttpRequest();
@@ -910,6 +914,10 @@ function sendZipChunk(
         onProgress(e.loaded);
       }
     });
+
+    if (onSent) {
+      xhr.upload.addEventListener('load', onSent);
+    }
 
     xhr.addEventListener('load', () => {
       if (xhr.status >= 200 && xhr.status < 300) {

--- a/public/js/manage-charts-enhanced.ts
+++ b/public/js/manage-charts-enhanced.ts
@@ -23,6 +23,16 @@ interface LocalChartsResponse {
   basePath?: string;
 }
 
+interface ZipUploadResponse {
+  success?: boolean;
+  message?: string;
+  error?: string;
+  /** Basenames of the .mbtiles extracted into the target folder. */
+  files?: string[];
+  /** Non-.mbtiles entries in the archive that were ignored. */
+  skipped?: number;
+}
+
 interface RepairableChart {
   identifier: string;
   filePath: string;
@@ -341,9 +351,13 @@ function renderChartsUI(): void {
           <button class="btn btn-secondary" onclick="triggerUploadEmpty()" style="padding: 12px 24px;">
             Upload from Computer
           </button>
+          <button class="btn btn-secondary" onclick="triggerZipUploadEmpty()" style="padding: 12px 24px;">
+            Upload ZIP
+          </button>
         </div>
       </div>
       <input type="file" id="chartUploadInputEmpty" accept=".mbtiles" multiple style="display: none;" onchange="handleFileUpload(event)">
+      <input type="file" id="chartZipUploadInputEmpty" accept=".zip" style="display: none;" onchange="handleZipUpload(event)">
     `;
     return;
   }
@@ -363,6 +377,7 @@ function renderChartsUI(): void {
         </button>
         ${selectedFolder && selectedFolder !== '/' ? `<button class="btn btn-danger" onclick="deleteSelectedFolder()" title="Delete Selected Folder">Delete Folder</button>` : ''}
         <button class="btn btn-primary" onclick="triggerUpload()" title="Upload charts to ${manageEscapeAttr(selectedFolder ?? '/')}">Upload</button>
+        <button class="btn btn-secondary" onclick="triggerZipUpload()" title="Upload a ZIP archive to ${manageEscapeAttr(selectedFolder ?? '/')} — every .mbtiles inside is extracted into the folder">Upload ZIP</button>
         <button class="btn btn-icon ${viewMode === 'grid' ? 'active' : ''}" onclick="setViewMode('grid')" title="Grid View">
           <svg viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M3 3h8v8H3zm10 0h8v8h-8zM3 13h8v8H3zm10 0h8v8h-8z"/></svg>
         </button>
@@ -415,6 +430,7 @@ function renderChartsUI(): void {
   }
 
   html += `<input type="file" id="chartUploadInput" accept=".mbtiles" multiple style="display: none;" onchange="handleFileUpload(event)">`;
+  html += `<input type="file" id="chartZipUploadInput" accept=".zip" style="display: none;" onchange="handleZipUpload(event)">`;
 
   manageOutput.innerHTML = html;
 
@@ -635,6 +651,281 @@ function triggerUploadEmpty(): void {
   document.getElementById('chartUploadInputEmpty')?.click();
 }
 
+// Chunk size for large file uploads (50 MB). Declared above its first use
+// so both the .mbtiles and ZIP upload paths can read it regardless of the
+// order the functions happen to appear in.
+const CHUNK_SIZE = 50 * 1024 * 1024;
+
+function triggerZipUpload(): void {
+  document.getElementById('chartZipUploadInput')?.click();
+}
+
+function triggerZipUploadEmpty(): void {
+  document.getElementById('chartZipUploadInputEmpty')?.click();
+}
+
+/**
+ * Upload one ZIP archive; the server extracts every `.mbtiles` inside it
+ * into the selected folder. Unlike the plain upload we can't warn about
+ * duplicates up front — the archive's contents aren't known until the
+ * server opens it — so the server's existing replace-with-backup behaviour
+ * in `promoteQuarantine` is what handles collisions.
+ */
+function handleZipUpload(event: Event): void {
+  const target = event.target as HTMLInputElement | null;
+  const file = target?.files?.[0];
+  // Clear immediately so re-picking the same archive still fires 'change'.
+  if (target) {
+    target.value = '';
+  }
+  if (!file) {
+    return;
+  }
+
+  if (!/\.zip$/i.test(file.name)) {
+    showErrorNotification(`"${file.name}" is not a .zip file.`);
+    return;
+  }
+
+  performZipUpload(file);
+}
+
+/**
+ * Chart archives routinely run to several GB, and a single request that big
+ * cannot finish inside Node's 300 s `server.requestTimeout` unless the link
+ * sustains ~21 MB/s — fine on wired gigabit, but not on the WiFi most boats
+ * actually have. Anything past CHUNK_SIZE therefore goes up in chunks, each
+ * its own short request, exactly as the plain .mbtiles upload does.
+ */
+function performZipUpload(file: File): void {
+  if (file.size > CHUNK_SIZE) {
+    void performChunkedZipUpload(file);
+    return;
+  }
+
+  const formData = new FormData();
+  // Field before file, so busboy has targetFolder in hand by the time the
+  // file stream arrives (same ordering requirement as the plain upload).
+  formData.append('targetFolder', selectedFolder ?? '/');
+  formData.append('archive', file);
+  performSimpleZipUpload(formData, file);
+}
+
+/** Render the archive-upload progress overlay. Returns false if the mount
+ *  point is gone (tab switched away mid-click). */
+function renderZipUploadOverlay(file: File): boolean {
+  const manageOutput = document.getElementById('manageOutput');
+  if (!manageOutput) {
+    return false;
+  }
+  const sizeMb = (file.size / (1024 * 1024)).toFixed(2);
+  manageOutput.innerHTML = `
+    <div class="upload-progress-overlay">
+      <div class="upload-progress-card">
+        <div class="upload-progress-header">
+          <div class="spinner"></div>
+          <h3>Uploading Archive...</h3>
+        </div>
+        <div class="upload-progress-body">
+          <p>Uploading to ${window.getIcon('folder', true)} <strong>${manageEscapeHtml(selectedFolder ?? '/')}</strong></p>
+          <ul class="upload-file-list">
+            <li>${manageEscapeHtml(file.name)} (${sizeMb} MB)</li>
+          </ul>
+          <div class="progress-bar-container">
+            <div class="progress-bar" id="uploadProgressBar"></div>
+          </div>
+          <p class="upload-status" id="uploadStatus">Starting upload...</p>
+        </div>
+      </div>
+    </div>
+  `;
+  return true;
+}
+
+/** Read a JSON error out of a response body, falling back to the status. */
+function zipErrorFrom(responseText: string, status: number): string {
+  try {
+    const parsed = JSON.parse(responseText) as ZipUploadResponse;
+    if (parsed.error) {
+      return parsed.error;
+    }
+  } catch {
+    // Non-JSON body — fall through to the generic message.
+  }
+  return `Upload failed: HTTP ${status}`;
+}
+
+function performSimpleZipUpload(formData: FormData, file: File): void {
+  isUploadInProgress = true;
+
+  if (!renderZipUploadOverlay(file)) {
+    isUploadInProgress = false;
+    return;
+  }
+
+  const xhr = new XMLHttpRequest();
+
+  xhr.upload.addEventListener('progress', (e) => {
+    if (e.lengthComputable) {
+      updateUploadProgress(e.loaded, e.total);
+    }
+  });
+
+  // Extraction happens after the last byte is sent and can take a while for
+  // a multi-GB archive, so swap the bar for an indeterminate message rather
+  // than leaving it parked at 100% looking hung.
+  xhr.upload.addEventListener('load', () => {
+    const statusText = document.getElementById('uploadStatus');
+    if (statusText) {
+      statusText.textContent = 'Extracting charts from archive...';
+    }
+  });
+
+  xhr.addEventListener('load', () => {
+    isUploadInProgress = false;
+    void loadCharts();
+
+    let payload: ZipUploadResponse | null = null;
+    try {
+      payload = JSON.parse(xhr.responseText) as ZipUploadResponse;
+    } catch {
+      payload = null;
+    }
+
+    if (xhr.status === 200 && payload?.files) {
+      showZipUploadNotification(payload.files.length, file.name);
+    } else {
+      showErrorNotification(zipErrorFrom(xhr.responseText, xhr.status));
+    }
+  });
+
+  xhr.addEventListener('error', () => {
+    isUploadInProgress = false;
+    console.error('Error uploading ZIP archive');
+    void loadCharts();
+    showErrorNotification('Error uploading archive. Please try again.');
+  });
+
+  xhr.open('POST', `${MANAGE_API_BASE}/upload-zip`);
+  xhr.send(formData);
+}
+
+async function performChunkedZipUpload(file: File): Promise<void> {
+  isUploadInProgress = true;
+
+  if (!renderZipUploadOverlay(file)) {
+    isUploadInProgress = false;
+    return;
+  }
+
+  const targetFolder = selectedFolder ?? '/';
+  // Server-side this only ever names a quarantine dir, and the route's
+  // schema restricts it to this charset — keep the generated value inside
+  // it. randomUUID isn't available on plain-HTTP origins, which is how
+  // Signal K is usually reached on a boat, so build the id by hand.
+  const uploadId = `u${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
+  const totalChunks = Math.ceil(file.size / CHUNK_SIZE);
+  let bytesSent = 0;
+  let finalPayload: ZipUploadResponse | null = null;
+
+  try {
+    for (let i = 0; i < totalChunks; i++) {
+      const start = i * CHUNK_SIZE;
+      const end = Math.min(start + CHUNK_SIZE, file.size);
+
+      const payload = await sendZipChunk(
+        file.slice(start, end),
+        {
+          uploadId,
+          filename: file.name,
+          chunkIndex: i,
+          totalChunks,
+          targetFolder
+        },
+        (chunkLoaded) => {
+          updateUploadProgress(bytesSent + chunkLoaded, file.size);
+        }
+      );
+
+      bytesSent += end - start;
+      updateUploadProgress(bytesSent, file.size);
+
+      // The last chunk's response carries the extraction result.
+      if (i === totalChunks - 1) {
+        finalPayload = payload;
+      } else {
+        // Extraction only starts once the final chunk lands, so show it
+        // as the last chunk goes out rather than after every chunk.
+        if (i === totalChunks - 2) {
+          const statusText = document.getElementById('uploadStatus');
+          if (statusText) {
+            statusText.textContent = 'Extracting charts from archive...';
+          }
+        }
+      }
+    }
+
+    isUploadInProgress = false;
+    void loadCharts();
+    showZipUploadNotification(finalPayload?.files?.length ?? 0, file.name);
+  } catch (error) {
+    isUploadInProgress = false;
+    console.error('Chunked ZIP upload failed:', error);
+    void loadCharts();
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    showErrorNotification(message);
+  }
+}
+
+function sendZipChunk(
+  chunk: Blob,
+  meta: {
+    uploadId: string;
+    filename: string;
+    chunkIndex: number;
+    totalChunks: number;
+    targetFolder: string;
+  },
+  onProgress: (loaded: number) => void
+): Promise<ZipUploadResponse | null> {
+  return new Promise<ZipUploadResponse | null>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+
+    xhr.upload.addEventListener('progress', (e) => {
+      if (e.lengthComputable) {
+        onProgress(e.loaded);
+      }
+    });
+
+    xhr.addEventListener('load', () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          resolve(JSON.parse(xhr.responseText) as ZipUploadResponse);
+        } catch {
+          resolve(null);
+        }
+      } else {
+        reject(new Error(zipErrorFrom(xhr.responseText, xhr.status)));
+      }
+    });
+
+    xhr.addEventListener('error', () => {
+      reject(new Error('Network error while uploading archive'));
+    });
+
+    xhr.open('PUT', `${MANAGE_API_BASE}/upload-zip-chunk`);
+    xhr.setRequestHeader('Content-Type', 'application/octet-stream');
+    xhr.setRequestHeader('X-Upload-Id', meta.uploadId);
+    // setRequestHeader throws on non-Latin1, and chart archives do carry
+    // umlauts and accents. Percent-encode; the server decodes.
+    xhr.setRequestHeader('X-Upload-Filename', encodeURIComponent(meta.filename));
+    xhr.setRequestHeader('X-Chunk-Index', String(meta.chunkIndex));
+    xhr.setRequestHeader('X-Total-Chunks', String(meta.totalChunks));
+    xhr.setRequestHeader('X-Target-Folder', meta.targetFolder);
+    xhr.send(chunk);
+  });
+}
+
 function handleFileUpload(event: Event): void {
   const target = event.target as HTMLInputElement | null;
   const files = target?.files;
@@ -702,9 +993,6 @@ function handleFileUpload(event: Event): void {
     target.value = '';
   }
 }
-
-// Chunk size for large file uploads (50 MB)
-const CHUNK_SIZE = 50 * 1024 * 1024;
 
 function performUpload(formData: FormData, validFileCount: number, files: FileList): void {
   isUploadInProgress = true;
@@ -1732,6 +2020,23 @@ function showUploadNotification(fileCount: number): void {
   fadeOutNotification('uploadNotification', html);
 }
 
+function showZipUploadNotification(chartCount: number, archiveName: string): void {
+  const html = `
+    <div class="notification-toast" id="zipUploadNotification">
+      <div class="notification-content">
+        <div class="notification-icon success">
+          ${window.getIcon('checkmark')}
+        </div>
+        <div class="notification-text">
+          <div class="notification-title">Archive Extracted</div>
+          <div class="notification-message">${chartCount} chart${chartCount !== 1 ? 's' : ''} extracted from ${manageEscapeHtml(archiveName)}</div>
+        </div>
+      </div>
+    </div>
+  `;
+  fadeOutNotification('zipUploadNotification', html);
+}
+
 function showSuccessNotification(message: string): void {
   const html = `
     <div class="notification-toast" id="successNotification">
@@ -2011,6 +2316,9 @@ window.deleteChart = deleteChart;
 window.triggerUpload = triggerUpload;
 window.triggerUploadEmpty = triggerUploadEmpty;
 window.handleFileUpload = handleFileUpload;
+window.triggerZipUpload = triggerZipUpload;
+window.triggerZipUploadEmpty = triggerZipUploadEmpty;
+window.handleZipUpload = handleZipUpload;
 window.handleDragStart = handleDragStart;
 window.handleDragOver = handleDragOver;
 window.handleDrop = handleDrop;

--- a/public/js/manage-charts-enhanced.ts
+++ b/public/js/manage-charts-enhanced.ts
@@ -742,6 +742,12 @@ function renderZipUploadOverlay(file: File): boolean {
   return true;
 }
 
+/** Message for an archive the server accepted but found no charts in. */
+function emptyArchiveMessage(archiveName: string, skipped?: number): string {
+  const detail = skipped ? ` (${skipped} other file${skipped !== 1 ? 's' : ''} skipped)` : '';
+  return `"${archiveName}" contained no .mbtiles charts${detail}.`;
+}
+
 /** Read a JSON error out of a response body, falling back to the status. */
 function zipErrorFrom(responseText: string, status: number): string {
   try {
@@ -792,8 +798,12 @@ function performSimpleZipUpload(formData: FormData, file: File): void {
       payload = null;
     }
 
-    if (xhr.status === 200 && payload?.files) {
+    if (xhr.status === 200 && payload?.files?.length) {
       showZipUploadNotification(payload.files.length, file.name);
+    } else if (xhr.status === 200) {
+      // A 200 with no charts is not a success from the user's point of view:
+      // a green tick and an unchanged list reads as "it worked but vanished".
+      showErrorNotification(emptyArchiveMessage(file.name, payload?.skipped));
     } else {
       showErrorNotification(zipErrorFrom(xhr.responseText, xhr.status));
     }
@@ -867,7 +877,11 @@ async function performChunkedZipUpload(file: File): Promise<void> {
 
     isUploadInProgress = false;
     void loadCharts();
-    showZipUploadNotification(finalPayload?.files?.length ?? 0, file.name);
+    if (finalPayload?.files?.length) {
+      showZipUploadNotification(finalPayload.files.length, file.name);
+    } else {
+      showErrorNotification(emptyArchiveMessage(file.name, finalPayload?.skipped));
+    }
   } catch (error) {
     isUploadInProgress = false;
     console.error('Chunked ZIP upload failed:', error);
@@ -921,7 +935,10 @@ function sendZipChunk(
     xhr.setRequestHeader('X-Upload-Filename', encodeURIComponent(meta.filename));
     xhr.setRequestHeader('X-Chunk-Index', String(meta.chunkIndex));
     xhr.setRequestHeader('X-Total-Chunks', String(meta.totalChunks));
-    xhr.setRequestHeader('X-Target-Folder', meta.targetFolder);
+    // Folder names are user-created and can carry non-Latin1 characters,
+    // same constraint as the filename header. Encoded here, decoded server-
+    // side before it's used as a path.
+    xhr.setRequestHeader('X-Target-Folder', encodeURIComponent(meta.targetFolder));
     xhr.send(chunk);
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2218,7 +2218,21 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         }
         const chunkIndex = parsed['x-chunk-index'];
         const totalChunks = parsed['x-total-chunks'];
-        const targetFolder = parsed['x-target-folder'] ?? '/';
+
+        // Folder names are percent-encoded by the client for the same reason
+        // as the filename. Decoding must happen *before* the containment
+        // check, so `isWithinBase` sees the path we'll actually write to —
+        // and so a folder called `Küste` isn't created as `K%C3%BCste`.
+        // A malformed sequence is rejected rather than silently used raw:
+        // at this point it can only be a client bug or an attack.
+        const rawTargetFolder = parsed['x-target-folder'] ?? '/';
+        let targetFolder: string;
+        try {
+          targetFolder = decodeURIComponent(rawTargetFolder);
+        } catch {
+          res.status(400).json({ success: false, error: 'Malformed target folder' });
+          return;
+        }
 
         const basePath = props.chartPath || defaultChartsPath;
         const uploadPath =
@@ -2235,8 +2249,60 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         const quarantineDir = makeQuarantineDir(app.getDataDirPath(), `zipchunk-${uploadId}`);
         const stagedPath = path.join(quarantineDir, 'upload.zip');
 
+        // The single-request route gets its ceiling from busboy's fileSize
+        // limit; this one has to enforce the same bound itself, or an
+        // authenticated client could append chunks until the data volume is
+        // full. Measure what's already staged rather than trusting
+        // Content-Length, which the client controls.
+        let stagedBytes = 0;
+        if (chunkIndex > 0) {
+          try {
+            stagedBytes = fs.statSync(stagedPath).size;
+          } catch {
+            stagedBytes = 0;
+          }
+        }
+        if (stagedBytes >= MAX_ZIP_UPLOAD_BYTES) {
+          cleanupQuarantineDir(quarantineDir);
+          res.status(413).json({
+            success: false,
+            error: `ZIP exceeds the ${MAX_ZIP_UPLOAD_BYTES / (1024 * 1024 * 1024)} GB upload limit`
+          });
+          return;
+        }
+
         const writeStream = fs.createWriteStream(stagedPath, {
           flags: chunkIndex === 0 ? 'w' : 'a'
+        });
+
+        // Abort mid-chunk if this request would carry the staged archive past
+        // the ceiling, so an oversize upload is stopped as it streams rather
+        // than after it has already landed on disk.
+        let overLimit = false;
+        let received = 0;
+        req.on('data', (chunk: Buffer) => {
+          received += chunk.length;
+          if (!overLimit && stagedBytes + received > MAX_ZIP_UPLOAD_BYTES) {
+            overLimit = true;
+            req.unpipe(writeStream);
+            writeStream.destroy();
+            cleanupQuarantineDir(quarantineDir);
+            if (!res.headersSent) {
+              res.status(413).json({
+                success: false,
+                error: `ZIP exceeds the ${MAX_ZIP_UPLOAD_BYTES / (1024 * 1024 * 1024)} GB upload limit`
+              });
+            }
+          }
+        });
+
+        // An abandoned chunked upload would otherwise keep its partial
+        // archive until the next server start, since makeQuarantineDir
+        // registers the dir as active and the sweep skips live entries.
+        req.on('aborted', () => {
+          app.debug(`ZIP chunk upload aborted for ${archiveName}`);
+          writeStream.destroy();
+          cleanupQuarantineDir(quarantineDir);
         });
 
         req.pipe(writeStream);
@@ -2244,6 +2310,9 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         writeStream.on('finish', () => {
           void (async () => {
             try {
+              if (overLimit) {
+                return;
+              }
               if (chunkIndex + 1 < totalChunks) {
                 app.debug(`ZIP chunk ${chunkIndex + 1}/${totalChunks} for ${archiveName}`);
                 res.json({ received: chunkIndex, total: totalChunks });
@@ -2319,6 +2388,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         });
 
         writeStream.on('error', (err: Error) => {
+          // Destroying the stream on an over-limit abort lands here too; that
+          // path has already answered the request.
+          if (overLimit) {
+            return;
+          }
           app.error(`Error writing ZIP chunk for ${archiveName}: ${err.message}`);
           cleanupQuarantineDir(quarantineDir);
           if (!res.headersSent) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -706,6 +706,78 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     }
   };
 
+  /**
+   * Extract a staged ZIP and promote the charts it contains, answering the
+   * request on every outcome. Shared by the single-request and chunked ZIP
+   * routes so their error mapping can't drift apart.
+   *
+   * Returns true when charts were promoted; false means the response has
+   * already been sent and the caller should stop.
+   */
+  const extractAndPromoteZip = async (
+    stagedZipPath: string,
+    quarantineDir: string,
+    archiveName: string,
+    targetFolder: string,
+    promoteTarget: string,
+    basePath: string,
+    res: Response
+  ): Promise<boolean> => {
+    const extractDir = path.join(quarantineDir, 'extracted');
+    let extracted;
+    try {
+      extracted = await extractMbtilesFromZip(stagedZipPath, extractDir);
+    } catch (err) {
+      if (err instanceof ZipLimitError) {
+        res.status(413).json({ success: false, error: err.message });
+        return false;
+      }
+      // Running out of disk is an expected failure at these sizes — a
+      // multi-GB archive is staged *and* extracted, so it needs roughly
+      // twice its own size free. Reporting that as "is it a valid ZIP
+      // file?" sends the user off checking a file that was never at fault.
+      if ((err as NodeJS.ErrnoException).code === 'ENOSPC') {
+        res.status(507).json({
+          success: false,
+          error:
+            'Not enough free disk space to extract this archive. Extraction needs about twice the archive size free while it runs.'
+        });
+        return false;
+      }
+      app.error(
+        `Error extracting ZIP ${archiveName}: ` + (err instanceof Error ? err.message : String(err))
+      );
+      res.status(400).json({
+        success: false,
+        error: 'Could not read the ZIP archive. Is it a valid ZIP file?'
+      });
+      return false;
+    }
+
+    if (extracted.files.length === 0) {
+      res.status(400).json({
+        success: false,
+        error: 'No .mbtiles files found in the ZIP archive'
+      });
+      return false;
+    }
+
+    await promoteQuarantine(extractDir, extracted.files, promoteTarget);
+    await finalizeUploadedFiles(extracted.files, targetFolder, basePath);
+
+    app.debug(
+      `Extracted ${extracted.files.length} chart(s) from ${archiveName} into ${promoteTarget}`
+    );
+
+    res.status(200).json({
+      success: true,
+      message: `${extracted.files.length} chart${extracted.files.length !== 1 ? 's' : ''} extracted from ${archiveName}`,
+      files: extracted.files,
+      skipped: extracted.skipped
+    });
+    return true;
+  };
+
   // Tippecanoe accepts zooms 0–22 in practice (anything beyond produces
   // 4×4 pixel tiles per source feature; nothing useful comes out and the
   // job runs much longer). Bound the inputs to that envelope so a typo
@@ -1978,61 +2050,15 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
               }
 
               // Extract beside the archive, inside the same quarantine dir.
-              const extractDir = path.join(quarantineDir, 'extracted');
-              let extracted;
-              try {
-                extracted = await extractMbtilesFromZip(stagedZipPath, extractDir);
-              } catch (err) {
-                if (err instanceof ZipLimitError) {
-                  res.status(413).json({ success: false, error: err.message });
-                  return;
-                }
-                app.error(
-                  `Error extracting ZIP ${stagedZipName}: ` +
-                    (err instanceof Error ? err.message : String(err))
-                );
-                // Running out of disk is the expected failure for the sizes
-                // this route accepts (a multi-GB archive is staged *and*
-                // extracted, so it needs roughly twice its own size free).
-                // Reporting that as "is it a valid ZIP file?" sends the user
-                // off checking a file that was never the problem.
-                const code = (err as NodeJS.ErrnoException).code;
-                if (code === 'ENOSPC') {
-                  res.status(507).json({
-                    success: false,
-                    error:
-                      'Not enough free disk space to extract this archive. Extraction needs about twice the archive size free while it runs.'
-                  });
-                  return;
-                }
-                res.status(400).json({
-                  success: false,
-                  error: 'Could not read the ZIP archive. Is it a valid ZIP file?'
-                });
-                return;
-              }
-
-              if (extracted.files.length === 0) {
-                res.status(400).json({
-                  success: false,
-                  error: 'No .mbtiles files found in the ZIP archive'
-                });
-                return;
-              }
-
-              await promoteQuarantine(extractDir, extracted.files, promoteTarget);
-              await finalizeUploadedFiles(extracted.files, targetFolder, basePath);
-
-              app.debug(
-                `Extracted ${extracted.files.length} chart(s) from ${stagedZipName} into ${promoteTarget}`
+              await extractAndPromoteZip(
+                stagedZipPath,
+                quarantineDir,
+                stagedZipName,
+                targetFolder,
+                promoteTarget,
+                basePath,
+                res
               );
-
-              res.status(200).json({
-                success: true,
-                message: `${extracted.files.length} chart${extracted.files.length !== 1 ? 's' : ''} extracted from ${stagedZipName}`,
-                files: extracted.files,
-                skipped: extracted.skipped
-              });
             } catch (error) {
               app.error(
                 'Error completing ZIP upload: ' +
@@ -2259,7 +2285,16 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           try {
             stagedBytes = fs.statSync(stagedPath).size;
           } catch {
-            stagedBytes = 0;
+            // No staged archive for this id. Appending would create the file
+            // and start writing at the wrong offset, producing a corrupt
+            // archive that only fails later as "is it a valid ZIP file?".
+            // Say what actually went wrong instead.
+            cleanupQuarantineDir(quarantineDir);
+            res.status(409).json({
+              success: false,
+              error: 'No upload in progress for this id. Restart the upload from the first chunk.'
+            });
+            return;
           }
         }
         if (stagedBytes >= MAX_ZIP_UPLOAD_BYTES) {
@@ -2321,51 +2356,15 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
               app.debug(`Final ZIP chunk for ${archiveName}, extracting`);
               try {
-                const extractDir = path.join(quarantineDir, 'extracted');
-                let extracted;
-                try {
-                  extracted = await extractMbtilesFromZip(stagedPath, extractDir);
-                } catch (err) {
-                  if (err instanceof ZipLimitError) {
-                    res.status(413).json({ success: false, error: err.message });
-                    return;
-                  }
-                  if ((err as NodeJS.ErrnoException).code === 'ENOSPC') {
-                    res.status(507).json({
-                      success: false,
-                      error:
-                        'Not enough free disk space to extract this archive. Extraction needs about twice the archive size free while it runs.'
-                    });
-                    return;
-                  }
-                  app.error(
-                    `Error extracting ZIP ${archiveName}: ` +
-                      (err instanceof Error ? err.message : String(err))
-                  );
-                  res.status(400).json({
-                    success: false,
-                    error: 'Could not read the ZIP archive. Is it a valid ZIP file?'
-                  });
-                  return;
-                }
-
-                if (extracted.files.length === 0) {
-                  res.status(400).json({
-                    success: false,
-                    error: 'No .mbtiles files found in the ZIP archive'
-                  });
-                  return;
-                }
-
-                await promoteQuarantine(extractDir, extracted.files, uploadPath);
-                await finalizeUploadedFiles(extracted.files, targetFolder, basePath);
-
-                res.json({
-                  success: true,
-                  message: `${extracted.files.length} chart${extracted.files.length !== 1 ? 's' : ''} extracted from ${archiveName}`,
-                  files: extracted.files,
-                  skipped: extracted.skipped
-                });
+                await extractAndPromoteZip(
+                  stagedPath,
+                  quarantineDir,
+                  archiveName,
+                  targetFolder,
+                  uploadPath,
+                  basePath,
+                  res
+                );
               } finally {
                 cleanupQuarantineDir(quarantineDir);
               }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import { repairMbtilesMetadata, setMbtilesDisplayName } from './utils/mbtiles-me
 import { open as openMbtilesReader } from './utils/mbtiles-reader.js';
 import { writeChartPathMarker } from './utils/path-marker.js';
 import { getBlankTileReplacement, getOverzoomedTile } from './utils/tile-overzoom.js';
+import { extractMbtilesFromZip, ZipLimitError } from './utils/zip-extract.js';
 import {
   arePairWithinBase,
   classifyChartDirAccess,
@@ -772,6 +773,34 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
 
   const UploadFields = Type.Object({
     targetFolder: Type.Optional(Type.String())
+  });
+
+  const UploadZipFields = Type.Object({
+    targetFolder: Type.Optional(Type.String())
+  });
+
+  // Ceiling on a single uploaded chart ZIP. Deliberately high: a single
+  // regional MBTiles set routinely runs to 6 GB or more, and the ZIP is
+  // staged whole before extraction, so the limit has to clear real-world
+  // chart bundles with room to spare. Still bounded, so a runaway upload
+  // can't silently fill the data volume. The extractor applies its own
+  // uncompressed-size budget on top of this.
+  //
+  // Sizes above 4 GB require the archive to use ZIP64; `unzipper` reads
+  // ZIP64 central directories, and the 64-bit sizes stay well inside
+  // JavaScript's safe-integer range, so the arithmetic here is exact.
+  const MAX_ZIP_UPLOAD_BYTES = 32 * 1024 * 1024 * 1024;
+
+  // `x-upload-id` names a quarantine subdirectory, so it's restricted to a
+  // conservative charset here rather than relying on downstream sanitizing:
+  // no separators, no dots, nothing that could walk out of the quarantine
+  // root even before `makeQuarantineDir` sanitizes it.
+  const UploadZipChunkHeaders = Type.Object({
+    'x-upload-id': Type.String({ minLength: 1, maxLength: 64, pattern: '^[A-Za-z0-9_-]+$' }),
+    'x-upload-filename': Type.String({ minLength: 1, pattern: '\\.[zZ][iI][pP]$' }),
+    'x-chunk-index': Type.Integer({ minimum: 0 }),
+    'x-total-chunks': Type.Integer({ minimum: 1 }),
+    'x-target-folder': Type.Optional(Type.String())
   });
 
   const UploadChunkHeaders = Type.Object({
@@ -1841,6 +1870,216 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       }
     });
 
+    // Upload a ZIP of charts: the archive is staged in quarantine, every
+    // `.mbtiles` entry is extracted (flattened to basenames), and only then
+    // are the results promoted into the target folder. The ZIP itself is
+    // never kept — it's a transport container, not a chart.
+    //
+    // Same quarantine discipline as `/upload`: an aborted or malformed
+    // request leaves bytes only in the quarantine dir, never in the live
+    // chart library, and the startup sweep reclaims whatever a crash left.
+    router.post('/upload-zip', (req: Request, res: Response) => {
+      try {
+        const bb = Busboy({
+          headers: req.headers,
+          limits: { fileSize: MAX_ZIP_UPLOAD_BYTES, files: 1 }
+        });
+        const basePath = props.chartPath || defaultChartsPath;
+        const quarantineDir = makeUniqueQuarantineDir(app.getDataDirPath(), 'upload-zip');
+        const fields: Record<string, string> = {};
+        let stagedZipPath: string | null = null;
+        let stagedZipName = '';
+        let writePromise: Promise<void> | null = null;
+        let truncated = false;
+
+        bb.on('field', (fieldname: string, value: string) => {
+          fields[fieldname] = value;
+        });
+
+        bb.on(
+          'file',
+          (_fieldname: string, file: NodeJS.ReadableStream, info: { filename: string }) => {
+            const { filename } = info;
+
+            // Only the first ZIP is taken; anything else is drained so
+            // busboy can still reach 'finish'.
+            if (!/\.zip$/i.test(filename) || stagedZipPath !== null) {
+              (file as NodeJS.ReadableStream & { resume(): void }).resume();
+              return;
+            }
+
+            // The archive's own name never reaches the chart library — the
+            // promoted names come from the entries inside it — so a fixed
+            // staging name sidesteps traversal entirely rather than
+            // validating an attacker-controlled one.
+            stagedZipName = path.basename(filename);
+            const stagedPath = path.join(quarantineDir, 'upload.zip');
+            stagedZipPath = stagedPath;
+            app.debug(`Staging ZIP upload: ${filename} -> ${stagedPath}`);
+
+            // busboy truncates at the size limit and emits 'limit' rather
+            // than erroring; without this the handler would happily try to
+            // open a half-written archive.
+            (file as NodeJS.ReadableStream & { on(ev: string, cb: () => void): void }).on(
+              'limit',
+              () => {
+                truncated = true;
+              }
+            );
+
+            const writeStream = fs.createWriteStream(stagedPath);
+            file.pipe(writeStream);
+
+            writePromise = new Promise<void>((resolve, reject) => {
+              writeStream.on('finish', () => resolve());
+              writeStream.on('error', (err: Error) => {
+                app.error(`Error staging ZIP ${filename}: ${err.message}`);
+                reject(err);
+              });
+            });
+            // Observe the rejection now — Promise handling below only
+            // attaches on 'finish', which never fires on an aborted request.
+            writePromise.catch(() => undefined);
+          }
+        );
+
+        bb.on('finish', () => {
+          void (async () => {
+            try {
+              const parsed = parseShape(UploadZipFields, fields, res);
+              if (!parsed) {
+                return;
+              }
+              const { targetFolder = '' } = parsed;
+
+              if (stagedZipPath === null) {
+                res.status(400).json({ success: false, error: 'No ZIP file uploaded' });
+                return;
+              }
+              if (truncated) {
+                res.status(413).json({
+                  success: false,
+                  error: `ZIP exceeds the ${MAX_ZIP_UPLOAD_BYTES / (1024 * 1024 * 1024)} GB upload limit`
+                });
+                return;
+              }
+
+              const promoteTarget =
+                targetFolder && targetFolder !== '/' ? path.join(basePath, targetFolder) : basePath;
+              if (!isWithinBase(promoteTarget, basePath)) {
+                res
+                  .status(403)
+                  .json({ success: false, error: 'Access denied: Invalid upload path' });
+                return;
+              }
+
+              if (writePromise) {
+                await writePromise;
+              }
+
+              // Extract beside the archive, inside the same quarantine dir.
+              const extractDir = path.join(quarantineDir, 'extracted');
+              let extracted;
+              try {
+                extracted = await extractMbtilesFromZip(stagedZipPath, extractDir);
+              } catch (err) {
+                if (err instanceof ZipLimitError) {
+                  res.status(413).json({ success: false, error: err.message });
+                  return;
+                }
+                app.error(
+                  `Error extracting ZIP ${stagedZipName}: ` +
+                    (err instanceof Error ? err.message : String(err))
+                );
+                // Running out of disk is the expected failure for the sizes
+                // this route accepts (a multi-GB archive is staged *and*
+                // extracted, so it needs roughly twice its own size free).
+                // Reporting that as "is it a valid ZIP file?" sends the user
+                // off checking a file that was never the problem.
+                const code = (err as NodeJS.ErrnoException).code;
+                if (code === 'ENOSPC') {
+                  res.status(507).json({
+                    success: false,
+                    error:
+                      'Not enough free disk space to extract this archive. Extraction needs about twice the archive size free while it runs.'
+                  });
+                  return;
+                }
+                res.status(400).json({
+                  success: false,
+                  error: 'Could not read the ZIP archive. Is it a valid ZIP file?'
+                });
+                return;
+              }
+
+              if (extracted.files.length === 0) {
+                res.status(400).json({
+                  success: false,
+                  error: 'No .mbtiles files found in the ZIP archive'
+                });
+                return;
+              }
+
+              await promoteQuarantine(extractDir, extracted.files, promoteTarget);
+              await finalizeUploadedFiles(extracted.files, targetFolder, basePath);
+
+              app.debug(
+                `Extracted ${extracted.files.length} chart(s) from ${stagedZipName} into ${promoteTarget}`
+              );
+
+              res.status(200).json({
+                success: true,
+                message: `${extracted.files.length} chart${extracted.files.length !== 1 ? 's' : ''} extracted from ${stagedZipName}`,
+                files: extracted.files,
+                skipped: extracted.skipped
+              });
+            } catch (error) {
+              app.error(
+                'Error completing ZIP upload: ' +
+                  (error instanceof Error ? error.message : String(error))
+              );
+              if (!res.headersSent) {
+                // Staging the archive and promoting the extracted charts both
+                // write to disk, so ENOSPC can surface here too — same
+                // reasoning as the extraction branch above.
+                if ((error as NodeJS.ErrnoException).code === 'ENOSPC') {
+                  res.status(507).json({
+                    success: false,
+                    error: 'Not enough free disk space to complete this upload.'
+                  });
+                } else {
+                  res.status(500).json({ success: false, error: 'Error completing ZIP upload' });
+                }
+              }
+            } finally {
+              cleanupQuarantineDir(quarantineDir);
+            }
+          })();
+        });
+
+        bb.on('error', (err: unknown) => {
+          app.error(
+            'ZIP upload stream error: ' + (err instanceof Error ? err.message : String(err))
+          );
+          cleanupQuarantineDir(quarantineDir);
+          if (!res.headersSent) {
+            res.status(400).json({ success: false, error: 'Malformed upload' });
+          }
+        });
+        req.on('aborted', () => {
+          app.debug('ZIP upload request aborted by client');
+          cleanupQuarantineDir(quarantineDir);
+        });
+
+        req.pipe(bb);
+      } catch (error) {
+        app.error(
+          'Error uploading chart ZIP: ' + (error instanceof Error ? error.message : String(error))
+        );
+        res.status(500).json({ success: false, error: 'Error uploading chart ZIP' });
+      }
+    });
+
     // Chunked upload for large files — each chunk is a short-lived request that
     // stays well within Node's server.requestTimeout (default 300s in Node 18+).
     router.put('/upload-chunk', (req: Request, res: Response) => {
@@ -1941,6 +2180,163 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           'Error in chunked upload: ' + (error instanceof Error ? error.message : String(error))
         );
         res.status(500).json({ error: 'Error in chunked upload' });
+      }
+    });
+
+    // Chunked ZIP upload. A 6 GB archive sent as one request cannot finish
+    // inside Node's 300 s `server.requestTimeout` on anything slower than
+    // ~21 MB/s sustained — i.e. it works on wired gigabit and fails on
+    // typical boat WiFi, which is exactly the case this plugin runs in.
+    // Chunks keep each request short, so throughput stops mattering.
+    //
+    // The archive accumulates in a per-upload quarantine dir keyed by the
+    // client-supplied upload id; only the final chunk triggers extraction
+    // and promotion, so an interrupted upload leaves nothing in the chart
+    // library and the startup sweep reclaims the partial archive.
+    router.put('/upload-zip-chunk', (req: Request, res: Response) => {
+      try {
+        const headerFields = {
+          'x-upload-id': req.headers['x-upload-id'],
+          'x-upload-filename': req.headers['x-upload-filename'],
+          'x-chunk-index': req.headers['x-chunk-index'],
+          'x-total-chunks': req.headers['x-total-chunks'],
+          'x-target-folder': req.headers['x-target-folder']
+        };
+        const parsed = parseShape(UploadZipChunkHeaders, headerFields, res);
+        if (!parsed) {
+          return;
+        }
+        const uploadId = parsed['x-upload-id'];
+        // The client percent-encodes the filename so non-Latin1 names
+        // survive the header. It's used only for log lines and the success
+        // message — never as a path — but decode defensively anyway.
+        let archiveName: string;
+        try {
+          archiveName = path.basename(decodeURIComponent(parsed['x-upload-filename']));
+        } catch {
+          archiveName = path.basename(parsed['x-upload-filename']);
+        }
+        const chunkIndex = parsed['x-chunk-index'];
+        const totalChunks = parsed['x-total-chunks'];
+        const targetFolder = parsed['x-target-folder'] ?? '/';
+
+        const basePath = props.chartPath || defaultChartsPath;
+        const uploadPath =
+          targetFolder && targetFolder !== '/' ? path.join(basePath, targetFolder) : basePath;
+
+        if (!isWithinBase(uploadPath, basePath)) {
+          res.status(403).json({ success: false, error: 'Access denied: Invalid upload path' });
+          return;
+        }
+
+        // The upload id only ever names a quarantine directory, never a
+        // path in the chart library. Keyed by id (not filename) so two
+        // uploads of the same archive name can't append into each other.
+        const quarantineDir = makeQuarantineDir(app.getDataDirPath(), `zipchunk-${uploadId}`);
+        const stagedPath = path.join(quarantineDir, 'upload.zip');
+
+        const writeStream = fs.createWriteStream(stagedPath, {
+          flags: chunkIndex === 0 ? 'w' : 'a'
+        });
+
+        req.pipe(writeStream);
+
+        writeStream.on('finish', () => {
+          void (async () => {
+            try {
+              if (chunkIndex + 1 < totalChunks) {
+                app.debug(`ZIP chunk ${chunkIndex + 1}/${totalChunks} for ${archiveName}`);
+                res.json({ received: chunkIndex, total: totalChunks });
+                return;
+              }
+
+              app.debug(`Final ZIP chunk for ${archiveName}, extracting`);
+              try {
+                const extractDir = path.join(quarantineDir, 'extracted');
+                let extracted;
+                try {
+                  extracted = await extractMbtilesFromZip(stagedPath, extractDir);
+                } catch (err) {
+                  if (err instanceof ZipLimitError) {
+                    res.status(413).json({ success: false, error: err.message });
+                    return;
+                  }
+                  if ((err as NodeJS.ErrnoException).code === 'ENOSPC') {
+                    res.status(507).json({
+                      success: false,
+                      error:
+                        'Not enough free disk space to extract this archive. Extraction needs about twice the archive size free while it runs.'
+                    });
+                    return;
+                  }
+                  app.error(
+                    `Error extracting ZIP ${archiveName}: ` +
+                      (err instanceof Error ? err.message : String(err))
+                  );
+                  res.status(400).json({
+                    success: false,
+                    error: 'Could not read the ZIP archive. Is it a valid ZIP file?'
+                  });
+                  return;
+                }
+
+                if (extracted.files.length === 0) {
+                  res.status(400).json({
+                    success: false,
+                    error: 'No .mbtiles files found in the ZIP archive'
+                  });
+                  return;
+                }
+
+                await promoteQuarantine(extractDir, extracted.files, uploadPath);
+                await finalizeUploadedFiles(extracted.files, targetFolder, basePath);
+
+                res.json({
+                  success: true,
+                  message: `${extracted.files.length} chart${extracted.files.length !== 1 ? 's' : ''} extracted from ${archiveName}`,
+                  files: extracted.files,
+                  skipped: extracted.skipped
+                });
+              } finally {
+                cleanupQuarantineDir(quarantineDir);
+              }
+            } catch (error) {
+              app.error(
+                `Error finalizing chunked ZIP upload: ${error instanceof Error ? error.message : String(error)}`
+              );
+              if (!res.headersSent) {
+                if ((error as NodeJS.ErrnoException).code === 'ENOSPC') {
+                  res.status(507).json({
+                    success: false,
+                    error: 'Not enough free disk space to complete this upload.'
+                  });
+                } else {
+                  res.status(500).json({ success: false, error: 'Error finalizing upload' });
+                }
+              }
+            }
+          })();
+        });
+
+        writeStream.on('error', (err: Error) => {
+          app.error(`Error writing ZIP chunk for ${archiveName}: ${err.message}`);
+          cleanupQuarantineDir(quarantineDir);
+          if (!res.headersSent) {
+            const code = (err as NodeJS.ErrnoException).code;
+            res.status(code === 'ENOSPC' ? 507 : 500).json({
+              success: false,
+              error:
+                code === 'ENOSPC'
+                  ? 'Not enough free disk space to receive this archive.'
+                  : 'Error writing chunk'
+            });
+          }
+        });
+      } catch (error) {
+        app.error(
+          'Error in chunked ZIP upload: ' + (error instanceof Error ? error.message : String(error))
+        );
+        res.status(500).json({ success: false, error: 'Error in chunked ZIP upload' });
       }
     });
 

--- a/src/utils/custom-catalog-download.ts
+++ b/src/utils/custom-catalog-download.ts
@@ -6,19 +6,19 @@
  * (`encDir`). The S-57 pipeline (`processS57Directory`) then converts the
  * whole tree in a single pass, producing one MBTiles per custom catalog.
  *
- * Extraction is zip-slip-safe: each entry's resolved target is checked
- * against `encDir` before any bytes are written, mirroring the path-safety
- * posture of the rest of the plugin. A single chart that fails to download or
- * extract is logged and skipped rather than failing the whole bundle — a
- * region of dozens of cells shouldn't be lost to one expired URL.
+ * Extraction goes through the shared zip-slip-safe `extractZipSafely`
+ * (`utils/zip-extract.ts`), which preserves each archive's directory
+ * structure — an ENC cell is a `.000` file plus sibling updates, so
+ * flattening would break the conversion. A single chart that fails to
+ * download or extract is logged and skipped rather than failing the whole
+ * bundle — a region of dozens of cells shouldn't be lost to one expired URL.
  */
 
 import fs from 'fs';
 import http from 'http';
 import https from 'https';
 import path from 'path';
-import unzipper from 'unzipper';
-import { isWithinBase } from './path-safety.js';
+import { extractZipSafely } from './zip-extract.js';
 import { noaaEncZipUrl } from './noaa-enc-footprints.js';
 
 export interface EncDownloadHooks {
@@ -82,31 +82,6 @@ function downloadToFile(url: string, dest: string, redirectsLeft = 5): Promise<v
     });
     req.on('error', reject);
   });
-}
-
-async function extractZipSafely(zipPath: string, destDir: string): Promise<number> {
-  const directory = await unzipper.Open.file(zipPath);
-  let written = 0;
-  for (const entry of directory.files) {
-    if (entry.type !== 'File') {
-      continue;
-    }
-    const target = path.join(destDir, entry.path);
-    // Zip-slip guard: never write outside destDir, regardless of entry path.
-    if (!isWithinBase(target, destDir)) {
-      continue;
-    }
-    fs.mkdirSync(path.dirname(target), { recursive: true });
-    await new Promise<void>((resolve, reject) => {
-      entry
-        .stream()
-        .pipe(fs.createWriteStream(target))
-        .on('finish', () => resolve())
-        .on('error', reject);
-    });
-    written += 1;
-  }
-  return written;
 }
 
 export async function downloadAndExtractEncs(

--- a/src/utils/zip-extract.ts
+++ b/src/utils/zip-extract.ts
@@ -14,10 +14,16 @@
  * Both enforce the same abuse limits, because a ZIP is attacker-controlled
  * input even when it arrives from an authenticated admin: a 1 MB archive can
  * expand to terabytes (zip bomb), and an archive with a million entries can
- * exhaust inodes long before it exhausts disk. `unzipper` reports the
- * central directory's `uncompressedSize` per entry, so both budgets are
- * checked *before* any bytes are written, and the running total is checked
- * again as it grows.
+ * exhaust inodes long before it exhausts disk.
+ *
+ * The size budget is enforced twice, and both halves are load-bearing.
+ * `unzipper` reports the central directory's `uncompressedSize` per entry, so
+ * an archive that *admits* it is too big is rejected before a single byte is
+ * written. But those declared sizes are attacker-controlled: a DEFLATE entry
+ * can claim 1 KB and decompress to gigabytes. So `writeEntry` also counts
+ * bytes as they stream and aborts the moment the running total passes the
+ * budget — checking only after an entry finished would mean the disk already
+ * took the hit.
  */
 
 import fs from 'fs';
@@ -73,18 +79,101 @@ function assertWithinLimits(
   }
 }
 
-async function writeEntry(
-  entry: { stream(): NodeJS.ReadableStream },
-  target: string
-): Promise<void> {
+interface ZipEntry {
+  path: string;
+  type: string;
+  uncompressedSize?: number;
+  stream(): NodeJS.ReadableStream;
+}
+
+/**
+ * Open an archive, keep its file entries, and reject it outright if the
+ * central directory already declares more than the budget allows. Shared by
+ * both extractors so their limit handling can't drift apart.
+ */
+async function openAndValidate(
+  zipPath: string,
+  limits: ExtractLimits
+): Promise<{ files: ZipEntry[]; bounds: Required<ExtractLimits> }> {
+  const bounds = {
+    maxTotalBytes: limits.maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES,
+    maxEntries: limits.maxEntries ?? DEFAULT_MAX_ENTRIES
+  };
+  const directory = await unzipper.Open.file(zipPath);
+  const files = directory.files.filter((f) => f.type === 'File') as unknown as ZipEntry[];
+  assertWithinLimits(files, bounds);
+  return { files, bounds };
+}
+
+/**
+ * Stream one entry to `target`, aborting the moment the running total passes
+ * `budget.remaining`.
+ *
+ * The cap has to be enforced *during* the write, not after it. A DEFLATE
+ * entry can declare a tiny `uncompressedSize` in the central directory and
+ * still decompress to gigabytes, so `assertWithinLimits`'s pre-flight check
+ * on declared sizes is necessary but not sufficient — checking again only
+ * once the entry is fully on disk would mean the disk is already full by the
+ * time we complain. A partially written file is removed on abort so a
+ * rejected archive leaves nothing behind.
+ *
+ * Returns the number of bytes written.
+ */
+async function writeEntry(entry: ZipEntry, target: string, remaining: number): Promise<number> {
   fs.mkdirSync(path.dirname(target), { recursive: true });
-  await new Promise<void>((resolve, reject) => {
-    entry
-      .stream()
-      .pipe(fs.createWriteStream(target))
-      .on('finish', () => resolve())
-      .on('error', reject);
-  });
+
+  let written = 0;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const source = entry.stream();
+      const sink = fs.createWriteStream(target);
+      let settled = false;
+
+      const fail = (err: Error): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        // Stop pulling bytes immediately; without this the source keeps
+        // decompressing into a sink we no longer care about.
+        source.unpipe(sink);
+        (source as NodeJS.ReadableStream & { destroy?: () => void }).destroy?.();
+        sink.destroy();
+        reject(err);
+      };
+
+      source.on('data', (chunk: Buffer) => {
+        written += chunk.length;
+        if (written > remaining) {
+          fail(
+            new ZipLimitError(
+              `archive expanded past the uncompressed-size limit while extracting ${entry.path}`
+            )
+          );
+        }
+      });
+      source.on('error', fail);
+      sink.on('error', fail);
+      sink.on('finish', () => {
+        if (!settled) {
+          settled = true;
+          resolve();
+        }
+      });
+
+      source.pipe(sink);
+    });
+  } catch (err) {
+    // Don't leave a truncated file where a chart is supposed to be.
+    try {
+      fs.rmSync(target, { force: true });
+    } catch {
+      // Best-effort: the caller is already failing this archive.
+    }
+    throw err;
+  }
+
+  return written;
 }
 
 /**
@@ -100,13 +189,7 @@ export async function extractZipSafely(
   destDir: string,
   limits: ExtractLimits = {}
 ): Promise<number> {
-  const bounds = {
-    maxTotalBytes: limits.maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES,
-    maxEntries: limits.maxEntries ?? DEFAULT_MAX_ENTRIES
-  };
-  const directory = await unzipper.Open.file(zipPath);
-  const files = directory.files.filter((f) => f.type === 'File');
-  assertWithinLimits(files, bounds);
+  const { files, bounds } = await openAndValidate(zipPath, limits);
 
   let written = 0;
   let bytesWritten = 0;
@@ -116,16 +199,8 @@ export async function extractZipSafely(
     if (!isWithinBase(target, destDir)) {
       continue;
     }
-    await writeEntry(entry, target);
+    bytesWritten += await writeEntry(entry, target, bounds.maxTotalBytes - bytesWritten);
     written += 1;
-    // Re-check against actual bytes on disk: the central directory's
-    // declared sizes are attacker-controlled and can understate reality.
-    bytesWritten += fs.statSync(target).size;
-    if (bytesWritten > bounds.maxTotalBytes) {
-      throw new ZipLimitError(
-        `archive expanded past the ${bounds.maxTotalBytes} byte limit while extracting`
-      );
-    }
   }
   return written;
 }
@@ -152,13 +227,7 @@ export async function extractMbtilesFromZip(
   limits: ExtractLimits = {},
   progress: ExtractProgress = {}
 ): Promise<MbtilesExtractResult> {
-  const bounds = {
-    maxTotalBytes: limits.maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES,
-    maxEntries: limits.maxEntries ?? DEFAULT_MAX_ENTRIES
-  };
-  const directory = await unzipper.Open.file(zipPath);
-  const allFiles = directory.files.filter((f) => f.type === 'File');
-  assertWithinLimits(allFiles, bounds);
+  const { files: allFiles, bounds } = await openAndValidate(zipPath, limits);
 
   const mbtiles = allFiles.filter((f) => /\.mbtiles$/i.test(f.path));
   const skipped = allFiles.length - mbtiles.length;
@@ -191,15 +260,8 @@ export async function extractMbtilesFromZip(
     used.add(name);
 
     const target = path.join(destDir, name);
-    await writeEntry(entry, target);
+    bytesWritten += await writeEntry(entry, target, bounds.maxTotalBytes - bytesWritten);
     files.push(name);
-
-    bytesWritten += fs.statSync(target).size;
-    if (bytesWritten > bounds.maxTotalBytes) {
-      throw new ZipLimitError(
-        `archive expanded past the ${bounds.maxTotalBytes} byte limit while extracting`
-      );
-    }
 
     progress.onEntry?.(files.length, mbtiles.length, name);
   }

--- a/src/utils/zip-extract.ts
+++ b/src/utils/zip-extract.ts
@@ -1,0 +1,208 @@
+/**
+ * Shared, zip-slip-safe ZIP extraction.
+ *
+ * Two callers with two different needs:
+ *
+ * - `extractZipSafely` preserves the archive's directory structure. The
+ *   S-57 pipeline needs that: an ENC cell is a `.000` file plus sibling
+ *   updates and a catalog, and flattening them breaks the conversion.
+ * - `extractMbtilesFromZip` pulls only `.mbtiles` entries out and flattens
+ *   them to bare basenames. Chart uploads want the files, not the uploader's
+ *   folder layout, and a flattened basename is structurally immune to
+ *   zip-slip (there is no path left to traverse with).
+ *
+ * Both enforce the same abuse limits, because a ZIP is attacker-controlled
+ * input even when it arrives from an authenticated admin: a 1 MB archive can
+ * expand to terabytes (zip bomb), and an archive with a million entries can
+ * exhaust inodes long before it exhausts disk. `unzipper` reports the
+ * central directory's `uncompressedSize` per entry, so both budgets are
+ * checked *before* any bytes are written, and the running total is checked
+ * again as it grows.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import unzipper from 'unzipper';
+import { isWithinBase } from './path-safety.js';
+
+/**
+ * Reject archives that would expand past this on disk. Set high enough that
+ * a legitimate multi-GB chart bundle (6 GB single-chart archives are normal,
+ * and a folder of them is normal too) never trips it, while still capping
+ * the classic zip bomb, where a few MB claim to expand to terabytes.
+ */
+export const DEFAULT_MAX_TOTAL_BYTES = 100 * 1024 * 1024 * 1024;
+
+/** Reject archives with more entries than this. */
+export const DEFAULT_MAX_ENTRIES = 10000;
+
+export interface ExtractLimits {
+  maxTotalBytes?: number;
+  maxEntries?: number;
+}
+
+export interface ExtractProgress {
+  /** Called after each entry is written, with 1-based counts. */
+  onEntry?: (done: number, total: number, name: string) => void;
+}
+
+export class ZipLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ZipLimitError';
+  }
+}
+
+function assertWithinLimits(
+  entries: { uncompressedSize?: number }[],
+  limits: Required<ExtractLimits>
+): void {
+  if (entries.length > limits.maxEntries) {
+    throw new ZipLimitError(
+      `archive has ${entries.length} entries, over the ${limits.maxEntries} limit`
+    );
+  }
+  let declaredTotal = 0;
+  for (const entry of entries) {
+    declaredTotal += entry.uncompressedSize ?? 0;
+  }
+  if (declaredTotal > limits.maxTotalBytes) {
+    throw new ZipLimitError(
+      `archive declares ${declaredTotal} uncompressed bytes, over the ${limits.maxTotalBytes} limit`
+    );
+  }
+}
+
+async function writeEntry(
+  entry: { stream(): NodeJS.ReadableStream },
+  target: string
+): Promise<void> {
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  await new Promise<void>((resolve, reject) => {
+    entry
+      .stream()
+      .pipe(fs.createWriteStream(target))
+      .on('finish', () => resolve())
+      .on('error', reject);
+  });
+}
+
+/**
+ * Extract every file entry into `destDir`, preserving the archive's internal
+ * directory structure. Entries that would resolve outside `destDir` are
+ * skipped rather than treated as fatal — a stray absolute path in an
+ * otherwise good ENC archive shouldn't lose the whole bundle.
+ *
+ * Returns the number of files written.
+ */
+export async function extractZipSafely(
+  zipPath: string,
+  destDir: string,
+  limits: ExtractLimits = {}
+): Promise<number> {
+  const bounds = {
+    maxTotalBytes: limits.maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES,
+    maxEntries: limits.maxEntries ?? DEFAULT_MAX_ENTRIES
+  };
+  const directory = await unzipper.Open.file(zipPath);
+  const files = directory.files.filter((f) => f.type === 'File');
+  assertWithinLimits(files, bounds);
+
+  let written = 0;
+  let bytesWritten = 0;
+  for (const entry of files) {
+    const target = path.join(destDir, entry.path);
+    // Zip-slip guard: never write outside destDir, regardless of entry path.
+    if (!isWithinBase(target, destDir)) {
+      continue;
+    }
+    await writeEntry(entry, target);
+    written += 1;
+    // Re-check against actual bytes on disk: the central directory's
+    // declared sizes are attacker-controlled and can understate reality.
+    bytesWritten += fs.statSync(target).size;
+    if (bytesWritten > bounds.maxTotalBytes) {
+      throw new ZipLimitError(
+        `archive expanded past the ${bounds.maxTotalBytes} byte limit while extracting`
+      );
+    }
+  }
+  return written;
+}
+
+export interface MbtilesExtractResult {
+  /** Basenames written into destDir, in archive order. */
+  files: string[];
+  /** File entries in the archive that were not `.mbtiles`. */
+  skipped: number;
+}
+
+/**
+ * Extract only `.mbtiles` entries from `zipPath` into `destDir`, flattened to
+ * bare basenames. Name collisions (`a/chart.mbtiles` and `b/chart.mbtiles`)
+ * are disambiguated with a `-2`, `-3`, … suffix rather than silently
+ * overwriting, matching how the download manager handles the same case.
+ *
+ * Matching is case-insensitive: charts hand-copied from Windows commonly
+ * arrive as `FOO.MBTILES`, and the loader's discovery already tolerates that.
+ */
+export async function extractMbtilesFromZip(
+  zipPath: string,
+  destDir: string,
+  limits: ExtractLimits = {},
+  progress: ExtractProgress = {}
+): Promise<MbtilesExtractResult> {
+  const bounds = {
+    maxTotalBytes: limits.maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES,
+    maxEntries: limits.maxEntries ?? DEFAULT_MAX_ENTRIES
+  };
+  const directory = await unzipper.Open.file(zipPath);
+  const allFiles = directory.files.filter((f) => f.type === 'File');
+  assertWithinLimits(allFiles, bounds);
+
+  const mbtiles = allFiles.filter((f) => /\.mbtiles$/i.test(f.path));
+  const skipped = allFiles.length - mbtiles.length;
+
+  fs.mkdirSync(destDir, { recursive: true });
+
+  const files: string[] = [];
+  const used = new Set<string>();
+  let bytesWritten = 0;
+
+  for (const entry of mbtiles) {
+    // Flatten: the basename cannot traverse, so this is zip-slip-safe by
+    // construction. Guard the degenerate cases anyway — an entry path of
+    // `..` or `foo/` yields a basename that isn't a usable filename.
+    const base = path.basename(entry.path);
+    if (base === '' || base === '.' || base === '..') {
+      continue;
+    }
+
+    let name = base;
+    if (used.has(name)) {
+      const ext = path.extname(base);
+      const stem = path.basename(base, ext);
+      let n = 2;
+      while (used.has(`${stem}-${n}${ext}`)) {
+        n += 1;
+      }
+      name = `${stem}-${n}${ext}`;
+    }
+    used.add(name);
+
+    const target = path.join(destDir, name);
+    await writeEntry(entry, target);
+    files.push(name);
+
+    bytesWritten += fs.statSync(target).size;
+    if (bytesWritten > bounds.maxTotalBytes) {
+      throw new ZipLimitError(
+        `archive expanded past the ${bounds.maxTotalBytes} byte limit while extracting`
+      );
+    }
+
+    progress.onEntry?.(files.length, mbtiles.length, name);
+  }
+
+  return { files, skipped };
+}

--- a/src/utils/zip-extract.ts
+++ b/src/utils/zip-extract.ts
@@ -247,17 +247,23 @@ export async function extractMbtilesFromZip(
       continue;
     }
 
+    // Collisions are tracked case-insensitively even though the extracted
+    // name keeps its original casing. `Chart.mbtiles` and `chart.mbtiles`
+    // are two distinct entries in the archive but the same file on Windows
+    // and macOS, so keying on the exact basename would let the second
+    // silently overwrite the first — and `files` would then name a chart
+    // that no longer exists.
     let name = base;
-    if (used.has(name)) {
+    if (used.has(name.toLowerCase())) {
       const ext = path.extname(base);
       const stem = path.basename(base, ext);
       let n = 2;
-      while (used.has(`${stem}-${n}${ext}`)) {
+      while (used.has(`${stem}-${n}${ext}`.toLowerCase())) {
         n += 1;
       }
       name = `${stem}-${n}${ext}`;
     }
-    used.add(name);
+    used.add(name.toLowerCase());
 
     const target = path.join(destDir, name);
     bytesWritten += await writeEntry(entry, target, bounds.maxTotalBytes - bytesWritten);

--- a/test/zip-extract.test.ts
+++ b/test/zip-extract.test.ts
@@ -167,6 +167,29 @@ describe('extractMbtilesFromZip', () => {
     assert.equal(fs.readFileSync(path.join(dest, 'chart-3.mbtiles'), 'utf8'), 'NORTH');
   });
 
+  it('disambiguates names that collide only by case', async () => {
+    // Distinct entries in the archive, but the same file on Windows and
+    // macOS. Keying collisions on the exact basename would let the second
+    // overwrite the first and report a chart that isn't there.
+    const zip = writeZip('dupcase.zip', [
+      { name: 'east/Chart.mbtiles', data: Buffer.from('EAST') },
+      { name: 'west/chart.mbtiles', data: Buffer.from('WEST') }
+    ]);
+    const dest = destDir('dupcase');
+
+    const result = await extractMbtilesFromZip(zip, dest);
+
+    assert.equal(result.files.length, 2);
+    // Every returned name must name a file that actually exists.
+    for (const name of result.files) {
+      assert.ok(fs.existsSync(path.join(dest, name)), `${name} missing on disk`);
+    }
+    // The two names differ by more than case, so neither can shadow the
+    // other on a case-insensitive filesystem.
+    const lowered = result.files.map((f) => f.toLowerCase());
+    assert.equal(new Set(lowered).size, 2, `names still collide: ${result.files.join(', ')}`);
+  });
+
   it('flattens traversal paths instead of escaping destDir', async () => {
     const zip = writeZip('slip.zip', [
       { name: '../../../evil.mbtiles', data: Buffer.from('EVIL') },

--- a/test/zip-extract.test.ts
+++ b/test/zip-extract.test.ts
@@ -60,6 +60,50 @@ function storedZip(entries: { name: string; data: Buffer }[]): Buffer {
   return Buffer.concat([...chunks, cd, eocd]);
 }
 
+/**
+ * Build a single-entry DEFLATE ZIP whose central directory *understates* the
+ * uncompressed size. This is the zip-bomb shape that a pre-flight check on
+ * declared sizes cannot catch: the archive looks tiny and honest until the
+ * stream is actually decompressed.
+ */
+function lyingDeflateZip(name: string, real: Buffer, declaredSize: number): Buffer {
+  const nameBuf = Buffer.from(name, 'utf8');
+  const deflated = zlib.deflateRawSync(real);
+  const crc = zlib.crc32(real);
+
+  const local = Buffer.alloc(30);
+  local.writeUInt32LE(0x04034b50, 0);
+  local.writeUInt16LE(20, 4);
+  local.writeUInt16LE(8, 8); // method: DEFLATE
+  local.writeUInt16LE(0x21, 12);
+  local.writeUInt32LE(crc, 14);
+  local.writeUInt32LE(deflated.length, 18);
+  local.writeUInt32LE(declaredSize, 22); // the lie
+  local.writeUInt16LE(nameBuf.length, 26);
+
+  const cen = Buffer.alloc(46);
+  cen.writeUInt32LE(0x02014b50, 0);
+  cen.writeUInt16LE(20, 4);
+  cen.writeUInt16LE(20, 6);
+  cen.writeUInt16LE(8, 10); // method: DEFLATE
+  cen.writeUInt16LE(0x21, 14);
+  cen.writeUInt32LE(crc, 16);
+  cen.writeUInt32LE(deflated.length, 20);
+  cen.writeUInt32LE(declaredSize, 24); // the lie
+  cen.writeUInt16LE(nameBuf.length, 28);
+  cen.writeUInt32LE(0, 42);
+
+  const cd = Buffer.concat([cen, nameBuf]);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(1, 8);
+  eocd.writeUInt16LE(1, 10);
+  eocd.writeUInt32LE(cd.length, 12);
+  eocd.writeUInt32LE(30 + nameBuf.length + deflated.length, 16);
+
+  return Buffer.concat([local, nameBuf, deflated, cd, eocd]);
+}
+
 function writeZip(name: string, entries: { name: string; data: Buffer }[]): string {
   const zipPath = path.join(TMP, name);
   fs.writeFileSync(zipPath, storedZip(entries));
@@ -177,6 +221,30 @@ describe('extractMbtilesFromZip', () => {
     assert.deepEqual(fs.readdirSync(dest), []);
   });
 
+  it('stops a lying DEFLATE entry mid-stream instead of after it is on disk', async () => {
+    // 32 MB of zeros deflates to a few KB, but the header claims 1000 bytes,
+    // so the declared-size pre-check waves it through. Only enforcing the
+    // budget *while* streaming catches this — checking after the write means
+    // the disk already took the hit.
+    const REAL = 32 * 1024 * 1024;
+    const CAP = 1024 * 1024;
+    const zipPath = path.join(TMP, 'lying.zip');
+    fs.writeFileSync(zipPath, lyingDeflateZip('bomb.mbtiles', Buffer.alloc(REAL, 0), 1000));
+    const dest = destDir('lying');
+
+    // The archive itself is tiny — this is not caught by a file-size limit.
+    assert.ok(fs.statSync(zipPath).size < CAP);
+
+    await assert.rejects(
+      () => extractMbtilesFromZip(zipPath, dest, { maxTotalBytes: CAP }),
+      (err: unknown) => err instanceof ZipLimitError
+    );
+
+    // Nothing partial is left behind, and nothing near the real size was
+    // ever written.
+    assert.deepEqual(fs.readdirSync(dest), []);
+  });
+
   it('reports progress per extracted chart', async () => {
     const zip = writeZip('progress.zip', [
       { name: 'a.mbtiles', data: Buffer.from('A') },
@@ -252,5 +320,33 @@ describe('extractZipSafely', () => {
       () => extractZipSafely(zip, dest, { maxEntries: 1 }),
       (err: unknown) => err instanceof ZipLimitError
     );
+  });
+
+  it('enforces the declared uncompressed-size limit', async () => {
+    const zip = writeZip('tree-big.zip', [{ name: 'big.bin', data: Buffer.alloc(4096, 0x42) }]);
+    const dest = destDir('tree-big');
+
+    await assert.rejects(
+      () => extractZipSafely(zip, dest, { maxTotalBytes: 100 }),
+      (err: unknown) => err instanceof ZipLimitError
+    );
+    assert.deepEqual(fs.readdirSync(dest), []);
+  });
+
+  it('stops a lying DEFLATE entry mid-stream', async () => {
+    const zipPath = path.join(TMP, 'tree-lying.zip');
+    fs.writeFileSync(
+      zipPath,
+      lyingDeflateZip('ENC_ROOT/bomb.000', Buffer.alloc(32 * 1024 * 1024, 0), 1000)
+    );
+    const dest = destDir('tree-lying');
+
+    await assert.rejects(
+      () => extractZipSafely(zipPath, dest, { maxTotalBytes: 1024 * 1024 }),
+      (err: unknown) => err instanceof ZipLimitError
+    );
+    // The partial entry is cleaned up, leaving only the empty parent dir the
+    // extractor created for it.
+    assert.ok(!fs.existsSync(path.join(dest, 'ENC_ROOT', 'bomb.000')));
   });
 });

--- a/test/zip-extract.test.ts
+++ b/test/zip-extract.test.ts
@@ -1,0 +1,256 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import { after, before, describe, it } from 'node:test';
+import {
+  extractMbtilesFromZip,
+  extractZipSafely,
+  ZipLimitError
+} from '../dist/utils/zip-extract.js';
+
+let TMP: string;
+
+// Build a minimal STORED (uncompressed) ZIP on disk so these tests need no
+// archiver dependency: local file headers + central directory +
+// end-of-central-directory, method 0 throughout. Mirrors the helper in
+// download-manager.test.ts.
+function storedZip(entries: { name: string; data: Buffer }[]): Buffer {
+  const chunks: Buffer[] = [];
+  const central: Buffer[] = [];
+  let offset = 0;
+  for (const { name, data } of entries) {
+    const nameBuf = Buffer.from(name, 'utf8');
+    const crc = zlib.crc32(data);
+
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(0, 8);
+    local.writeUInt16LE(0x21, 12);
+    local.writeUInt32LE(crc, 14);
+    local.writeUInt32LE(data.length, 18);
+    local.writeUInt32LE(data.length, 22);
+    local.writeUInt16LE(nameBuf.length, 26);
+    chunks.push(local, nameBuf, data);
+
+    const cen = Buffer.alloc(46);
+    cen.writeUInt32LE(0x02014b50, 0);
+    cen.writeUInt16LE(20, 4);
+    cen.writeUInt16LE(20, 6);
+    cen.writeUInt16LE(0, 10);
+    cen.writeUInt16LE(0x21, 14);
+    cen.writeUInt32LE(crc, 16);
+    cen.writeUInt32LE(data.length, 20);
+    cen.writeUInt32LE(data.length, 24);
+    cen.writeUInt16LE(nameBuf.length, 28);
+    cen.writeUInt32LE(offset, 42);
+    central.push(cen, nameBuf);
+
+    offset += 30 + nameBuf.length + data.length;
+  }
+  const cd = Buffer.concat(central);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(cd.length, 12);
+  eocd.writeUInt32LE(offset, 16);
+  return Buffer.concat([...chunks, cd, eocd]);
+}
+
+function writeZip(name: string, entries: { name: string; data: Buffer }[]): string {
+  const zipPath = path.join(TMP, name);
+  fs.writeFileSync(zipPath, storedZip(entries));
+  return zipPath;
+}
+
+function destDir(name: string): string {
+  return fs.mkdtempSync(path.join(TMP, `${name}-`));
+}
+
+before(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'zip-extract-test-'));
+});
+
+after(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+describe('extractMbtilesFromZip', () => {
+  it('extracts only .mbtiles entries, flattened to basenames', async () => {
+    const zip = writeZip('multi.zip', [
+      { name: 'charts/a.mbtiles', data: Buffer.from('AAA') },
+      { name: 'charts/nested/deep/b.mbtiles', data: Buffer.from('BBB') },
+      { name: 'readme.txt', data: Buffer.from('hello') },
+      { name: 'charts/notes.md', data: Buffer.from('notes') }
+    ]);
+    const dest = destDir('multi');
+
+    const result = await extractMbtilesFromZip(zip, dest);
+
+    assert.deepEqual(result.files.sort(), ['a.mbtiles', 'b.mbtiles']);
+    assert.equal(result.skipped, 2);
+    assert.deepEqual(fs.readdirSync(dest).sort(), ['a.mbtiles', 'b.mbtiles']);
+    assert.equal(fs.readFileSync(path.join(dest, 'a.mbtiles'), 'utf8'), 'AAA');
+    assert.equal(fs.readFileSync(path.join(dest, 'b.mbtiles'), 'utf8'), 'BBB');
+  });
+
+  it('matches the .mbtiles suffix case-insensitively', async () => {
+    const zip = writeZip('case.zip', [{ name: 'FOO.MBTILES', data: Buffer.from('X') }]);
+    const dest = destDir('case');
+
+    const result = await extractMbtilesFromZip(zip, dest);
+
+    assert.deepEqual(result.files, ['FOO.MBTILES']);
+  });
+
+  it('disambiguates same-named charts from different folders', async () => {
+    const zip = writeZip('dup.zip', [
+      { name: 'east/chart.mbtiles', data: Buffer.from('EAST') },
+      { name: 'west/chart.mbtiles', data: Buffer.from('WEST') },
+      { name: 'north/chart.mbtiles', data: Buffer.from('NORTH') }
+    ]);
+    const dest = destDir('dup');
+
+    const result = await extractMbtilesFromZip(zip, dest);
+
+    assert.deepEqual(result.files, ['chart.mbtiles', 'chart-2.mbtiles', 'chart-3.mbtiles']);
+    // No entry is lost to a silent overwrite.
+    assert.equal(fs.readFileSync(path.join(dest, 'chart.mbtiles'), 'utf8'), 'EAST');
+    assert.equal(fs.readFileSync(path.join(dest, 'chart-2.mbtiles'), 'utf8'), 'WEST');
+    assert.equal(fs.readFileSync(path.join(dest, 'chart-3.mbtiles'), 'utf8'), 'NORTH');
+  });
+
+  it('flattens traversal paths instead of escaping destDir', async () => {
+    const zip = writeZip('slip.zip', [
+      { name: '../../../evil.mbtiles', data: Buffer.from('EVIL') },
+      { name: 'ok.mbtiles', data: Buffer.from('OK') }
+    ]);
+    const dest = destDir('slip');
+
+    const result = await extractMbtilesFromZip(zip, dest);
+
+    // The traversal entry is kept but declawed: written as a bare basename
+    // inside destDir, never above it.
+    assert.deepEqual(result.files.sort(), ['evil.mbtiles', 'ok.mbtiles']);
+    for (const name of result.files) {
+      assert.equal(path.dirname(path.join(dest, name)), dest);
+    }
+    assert.ok(!fs.existsSync(path.join(dest, '..', '..', '..', 'evil.mbtiles')));
+  });
+
+  it('returns an empty result for an archive with no charts', async () => {
+    const zip = writeZip('empty.zip', [{ name: 'readme.txt', data: Buffer.from('nothing') }]);
+    const dest = destDir('empty');
+
+    const result = await extractMbtilesFromZip(zip, dest);
+
+    assert.deepEqual(result.files, []);
+    assert.equal(result.skipped, 1);
+  });
+
+  it('rejects an archive with too many entries before writing anything', async () => {
+    const entries = Array.from({ length: 5 }, (_, i) => ({
+      name: `c${i}.mbtiles`,
+      data: Buffer.from('x')
+    }));
+    const zip = writeZip('many.zip', entries);
+    const dest = destDir('many');
+
+    await assert.rejects(
+      () => extractMbtilesFromZip(zip, dest, { maxEntries: 3 }),
+      (err: unknown) => err instanceof ZipLimitError
+    );
+    assert.deepEqual(fs.readdirSync(dest), []);
+  });
+
+  it('rejects an archive declaring more uncompressed bytes than allowed', async () => {
+    const zip = writeZip('big.zip', [{ name: 'big.mbtiles', data: Buffer.alloc(4096, 0x41) }]);
+    const dest = destDir('big');
+
+    await assert.rejects(
+      () => extractMbtilesFromZip(zip, dest, { maxTotalBytes: 100 }),
+      (err: unknown) => err instanceof ZipLimitError
+    );
+    assert.deepEqual(fs.readdirSync(dest), []);
+  });
+
+  it('reports progress per extracted chart', async () => {
+    const zip = writeZip('progress.zip', [
+      { name: 'a.mbtiles', data: Buffer.from('A') },
+      { name: 'skipme.txt', data: Buffer.from('T') },
+      { name: 'b.mbtiles', data: Buffer.from('B') }
+    ]);
+    const dest = destDir('progress');
+    const seen: { done: number; total: number; name: string }[] = [];
+
+    await extractMbtilesFromZip(
+      zip,
+      dest,
+      {},
+      { onEntry: (done, total, name) => seen.push({ done, total, name }) }
+    );
+
+    // Totals count charts, not archive entries.
+    assert.deepEqual(seen, [
+      { done: 1, total: 2, name: 'a.mbtiles' },
+      { done: 2, total: 2, name: 'b.mbtiles' }
+    ]);
+  });
+
+  it('rejects a file that is not a ZIP at all', async () => {
+    const notZip = path.join(TMP, 'not-a-zip.zip');
+    fs.writeFileSync(notZip, Buffer.from('this is plain text, not an archive'));
+    const dest = destDir('notzip');
+
+    await assert.rejects(() => extractMbtilesFromZip(notZip, dest));
+  });
+});
+
+describe('extractZipSafely', () => {
+  it('preserves the archive directory structure', async () => {
+    const zip = writeZip('tree.zip', [
+      { name: 'ENC_ROOT/US5NY1CM/US5NY1CM.000', data: Buffer.from('CELL') },
+      { name: 'ENC_ROOT/CATALOG.031', data: Buffer.from('CAT') }
+    ]);
+    const dest = destDir('tree');
+
+    const written = await extractZipSafely(zip, dest);
+
+    assert.equal(written, 2);
+    assert.equal(
+      fs.readFileSync(path.join(dest, 'ENC_ROOT/US5NY1CM/US5NY1CM.000'), 'utf8'),
+      'CELL'
+    );
+    assert.equal(fs.readFileSync(path.join(dest, 'ENC_ROOT/CATALOG.031'), 'utf8'), 'CAT');
+  });
+
+  it('skips entries that would escape destDir', async () => {
+    const zip = writeZip('escape.zip', [
+      { name: '../escaped.txt', data: Buffer.from('NOPE') },
+      { name: 'inside.txt', data: Buffer.from('YES') }
+    ]);
+    const dest = destDir('escape');
+
+    const written = await extractZipSafely(zip, dest);
+
+    assert.equal(written, 1);
+    assert.deepEqual(fs.readdirSync(dest), ['inside.txt']);
+    assert.ok(!fs.existsSync(path.join(dest, '..', 'escaped.txt')));
+  });
+
+  it('enforces the entry-count limit', async () => {
+    const zip = writeZip('tree-many.zip', [
+      { name: 'a.txt', data: Buffer.from('a') },
+      { name: 'b.txt', data: Buffer.from('b') }
+    ]);
+    const dest = destDir('tree-many');
+
+    await assert.rejects(
+      () => extractZipSafely(zip, dest, { maxEntries: 1 }),
+      (err: unknown) => err instanceof ZipLimitError
+    );
+  });
+});


### PR DESCRIPTION
Adds an **Upload ZIP** control to the Manage Charts tab, next to the existing Upload button (and in the empty state). Picking a `.zip` uploads it to the selected folder, where the server extracts every `.mbtiles` inside, enables them, and serves them immediately. Nested folders are flattened, non-chart entries are ignored, and name collisions get a `-2`/`-3` suffix rather than silently overwriting.

## Why chunked uploads

Chart archives routinely run to several GB. A single 6 GB request cannot finish inside Node's 300 s `server.requestTimeout` unless the link sustains ~21 MB/s — fine on wired gigabit, but not on the WiFi this plugin usually runs behind, where it would die partway through after a long wait. Anything over 50 MB therefore uploads in chunks via `PUT /upload-zip-chunk`, each its own short request. Measured on a 1.5 GB archive, the slowest chunk used 1.6% of the timeout budget.

Extraction needs roughly twice the archive size free on disk while it runs, so `ENOSPC` is reported as its own 507 rather than being folded into the "is it a valid ZIP file?" branch — blaming the user's file for a disk problem sends them after the wrong thing.

## Shared extraction module

Extraction moves into `src/utils/zip-extract.ts`, replacing the private copy in `custom-catalog-download.ts`. Two entry points:

- `extractZipSafely` preserves archive structure — the S-57 pipeline needs an ENC cell's sibling files intact.
- `extractMbtilesFromZip` flattens to basenames, which is zip-slip-safe by construction.

Both enforce entry-count and uncompressed-size budgets. The size budget is checked twice, and both halves matter: declared sizes in the central directory are attacker-controlled, so a DEFLATE entry can claim 1 KB and expand to gigabytes. Bytes are counted as they stream and the write aborts the moment the budget is passed. Before that fix, a 204 KB archive wrote 200 MB to disk under a 10 MB cap — it threw, but only once the damage was done. The previous extraction path had no zip-bomb protection at all.

The archive is staged in a per-request quarantine dir and only the extracted charts are promoted, so an aborted or malformed upload never leaves bytes in the live chart library.

## Tested

- 451 unit tests (15 new): zip-slip, zip-bomb limits (including a hand-built DEFLATE archive that lies about its uncompressed size), collision handling, case-insensitive `.mbtiles` matching
- 16 Playwright e2e tests (2 new) covering the button and its file input in both populated and empty states
- Against real ZIP64 archives: a 6 GB member extracts byte-exact; busboy's limit accounting is correct past 4 GB (streamed 5 GB); a chunked 1.5 GB upload with a non-ASCII filename lands served with the quarantine left clean
- Route-level checks for umlaut folder names, chart-free archives, malformed encodings, and `targetFolder` traversal (403), all with quarantine left clean

Not verified end-to-end: a full 6 GB round-trip over HTTP. Extraction needs ~2x the archive size free and my dev box didn't have the headroom, so the 6 GB case was verified at the extraction layer and the HTTP path at 1.5 GB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds an **Upload ZIP** control to populated and empty Manage Charts views.
- Uploads ZIP files to the selected folder and supports single-request uploads and 50 MB chunked uploads through `PUT /upload-zip-chunk`.
- Extracts `.mbtiles` files into quarantine, flattens nested paths, resolves name collisions, ignores other entries, and promotes only valid charts.
- Adds shared ZIP extraction utilities with path traversal protection, entry-count and size limits, streaming checks, cleanup, and progress reporting.
- Handles invalid archives, empty archives, malformed encoding, aborted uploads, disk exhaustion, oversized uploads, and encoded folder paths.
- Updates custom catalog downloads to use the shared extraction utility.
- Adds documentation, unit tests, and Playwright coverage for ZIP uploads and extraction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->