### PR TITLE
chore(release): 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release 2.5.0.

Minor bump: adds a user-facing feature with no breaking changes.

## What's in it

**Upload ZIP in Manage Charts** (#170) — a new control next to the existing Upload button (and in the empty state). Picking a `.zip` uploads it to the selected folder, where every `.mbtiles` inside is extracted, enabled, and served. Nested folders are flattened, non-chart entries ignored, name collisions disambiguated rather than overwritten.

Large archives are the normal case for chart bundles, so anything over 50 MB uploads in chunks via the new `PUT /upload-zip-chunk`. A single 6 GB request cannot finish inside Node's 300 s `server.requestTimeout` unless the link sustains ~21 MB/s — fine on wired gigabit, not on boat WiFi. Every path streams, so memory stays flat regardless of archive size: a verified 6 GB round-trip peaked at 504 MB RSS (6.8% of the archive) and landed byte-exact. Extraction needs roughly twice the archive size free on disk, reported as its own 507 when it isn't.

Extraction also moved into a shared `utils/zip-extract.ts`, replacing the private copy in `custom-catalog-download.ts`, and gained zip-bomb protection the previous path did not have — the size budget is enforced while streaming, since a DEFLATE entry can declare 1 KB and expand to gigabytes.

## Tested

452 unit tests, 16 Playwright e2e tests, green across the CI matrix (Linux/Windows/macOS, arm64, Node 22/24, Signal K integration).