### PR TITLE
feat(folders): enable/disable chart folders as groups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ This is a Signal K server plugin. The single entry is `src/index.ts`, which expo
    - `charts-loader.ts` walks the configured `chartPath` recursively and produces a `Record<string, ChartProvider>` keyed by identifier. It handles both `.mbtiles` files and tilemap directories (with `tilemapresource.xml`).
    - `utils/mbtiles-reader.ts` opens MBTiles via `node:sqlite`. `utils/mbtiles-metadata.ts` reads/writes the `metadata` table (used for chart rename, which marks tiles "USER MODIFIED").
    - `ChartProvider` exposes both `v1` and `v2` shapes (see `src/types.ts`) so the plugin works on Signal K v1 and v2 servers; `serverMajorVersion` is sniffed from `app.config.version`.
-   - `utils/chart-state.ts` persists per-chart enable/disable in the plugin data dir; `utils/file-scanner.ts` enumerates folders for the management UI.
+   - `utils/chart-state.ts` persists per-chart enable/disable in the plugin data dir; `utils/folder-state.ts` does the same per folder (a disabled folder hides all descendant folders' charts; effective visibility is chart-enabled AND folder-path-enabled); `utils/file-scanner.ts` enumerates folders for the management UI.
 
 2. **Convert charts on demand** (write path, requires Docker/Podman via the `signalk-container` plugin — see the integration section below for the API contract).
    - `utils/container-manager.ts` is the discovery + waiting layer for the `signalk-container` plugin's manager API. Converters call `getContainerManager()` after `start()` has resolved it; they never import `dockerode` directly.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A lightweight Signal K server plugin for managing local nautical charts, written
 ## Features
 
 - **Local Chart Management**: MBTiles (raster and vector), with folder organization and enable/disable toggles
+- **Folder Groups**: Enable/disable whole chart folders at once (OpenCPN-style groups, including nested folders); clients like Freeboard-SK see the change live via `resources.charts` deltas
 - **Download Manager**: Built-in download queue with progress tracking and ZIP extraction
 - **Chart Catalog**: Browse and download charts from [chartcatalogs.github.io](https://chartcatalogs.github.io/) with automatic update notifications
 - **NOAA Charts**: Draw a coverage region on a map from NOAA band-4 chart footprints; the plugin bundles the overlapping band-3/4/5 ENCs and converts them into a single vector MBTiles named after your chart set

--- a/e2e/manage-charts.spec.ts
+++ b/e2e/manage-charts.spec.ts
@@ -80,6 +80,90 @@ test.describe('Manage Charts tab', () => {
     );
   });
 
+  test('renders a disabled folder and its charts grayed out', async ({ page }) => {
+    await page.goto('/plugins/signalk-charts-provider-simple/');
+    await setMockState(page, {
+      localCharts: {
+        basePath: '/tmp/charts',
+        folders: ['/', 'Netherlands'],
+        folderStates: {
+          '/': { enabled: true, effectiveEnabled: true },
+          Netherlands: { enabled: false, effectiveEnabled: false }
+        },
+        charts: [
+          {
+            relativePath: 'Netherlands/nl.mbtiles',
+            name: 'NL Chart',
+            folder: 'Netherlands',
+            enabled: true,
+            folderEnabled: false
+          }
+        ]
+      }
+    });
+    await page.evaluate(() => {
+      (window as unknown as { handleManageTabActive: () => void }).handleManageTabActive();
+    });
+
+    await expect(page.locator('.folder-btn.folder-disabled')).toHaveCount(1, { timeout: 5000 });
+    await expect(page.locator('.folder-btn.folder-disabled')).toContainText('Netherlands');
+    // The initial (pre-seed) empty load auto-selects the root folder, which
+    // would hide the Netherlands chart — switch back to the all-folders view.
+    await page.getByRole('button', { name: 'All Folders' }).click();
+    await expect(page.locator('.chart-card.folder-off')).toHaveCount(1);
+    await expect(page.locator('.folder-off-badge')).toContainText('Folder disabled');
+    // The root pseudo-folder is never toggleable, so only one toggle renders.
+    await expect(page.locator('.folder-toggle')).toHaveCount(1);
+  });
+
+  test('folder toggle POSTs to /folders/toggle without selecting the folder', async ({ page }) => {
+    await page.goto('/plugins/signalk-charts-provider-simple/');
+    await setMockState(page, {
+      localCharts: {
+        basePath: '/tmp/charts',
+        folders: ['/', 'Netherlands'],
+        folderStates: {
+          '/': { enabled: true, effectiveEnabled: true },
+          Netherlands: { enabled: true, effectiveEnabled: true }
+        },
+        charts: [
+          {
+            relativePath: 'Netherlands/nl.mbtiles',
+            name: 'NL Chart',
+            folder: 'Netherlands',
+            enabled: true,
+            folderEnabled: true
+          }
+        ]
+      }
+    });
+    await page.evaluate(() => {
+      (window as unknown as { handleManageTabActive: () => void }).handleManageTabActive();
+    });
+
+    const toggle = page.locator('.folder-toggle');
+    await expect(toggle).toBeVisible({ timeout: 5000 });
+    // The initial (pre-seed) empty load auto-selects the root folder, which
+    // would hide the Netherlands chart — switch back to the all-folders view.
+    await page.getByRole('button', { name: 'All Folders' }).click();
+
+    const requestPromise = page.waitForRequest(
+      (request) => request.url().includes('/folders/toggle') && request.method() === 'POST'
+    );
+    await toggle.click();
+    const request = await requestPromise;
+    expect(request.postDataJSON()).toEqual({ folderPath: 'Netherlands', enabled: false });
+
+    // The UI refetches /local-charts; the mock cascaded the state, so the
+    // chart card grays out and the folder button gets the disabled style.
+    await expect(page.locator('.chart-card.folder-off')).toHaveCount(1, { timeout: 5000 });
+    await expect(page.locator('.folder-btn.folder-disabled')).toHaveCount(1);
+    // stopPropagation: clicking the toggle must not select the folder — the
+    // "All Folders" pseudo-entry stays the active one.
+    await expect(page.locator('.folder-btn.active')).toHaveCount(1);
+    await expect(page.locator('.folder-btn.active')).toContainText('All Folders');
+  });
+
   test('offers a ZIP upload control wired to a .zip file input', async ({ page }) => {
     await page.goto('/plugins/signalk-charts-provider-simple/');
     await setMockState(page, {

--- a/e2e/mock-server.ts
+++ b/e2e/mock-server.ts
@@ -81,10 +81,12 @@ interface MockState {
       name: string;
       folder: string;
       enabled: boolean;
+      folderEnabled?: boolean;
       downloading?: boolean;
       converting?: boolean;
     }[];
     folders: string[];
+    folderStates?: Record<string, { enabled: boolean; effectiveEnabled: boolean }>;
     basePath: string;
   };
   downloadJobs: {
@@ -132,7 +134,12 @@ const initialState: MockState = {
   converting: {},
   conversions: {},
   catalogs: {},
-  localCharts: { charts: [], folders: ['/'], basePath: '/tmp/charts' },
+  localCharts: {
+    charts: [],
+    folders: ['/'],
+    folderStates: { '/': { enabled: true, effectiveEnabled: true } },
+    basePath: '/tmp/charts'
+  },
   downloadJobs: [],
   catalogUpdates: [],
   downloadFailStatus: null,
@@ -188,6 +195,39 @@ export function startMockServer(
   // current mock state says; the test sets state ahead of time.
   router.get(`${PLUGIN_BASE}/local-charts`, (_req, res) => {
     res.json(state.localCharts);
+  });
+
+  // POST /folders/toggle → flip a folder's enabled flag and cascade the
+  // effective state to descendant folders and their charts, mirroring the
+  // real plugin's ancestor-aware semantics closely enough for UI tests.
+  router.post(`${PLUGIN_BASE}/folders/toggle`, (req, res) => {
+    const { folderPath, enabled } = req.body as { folderPath?: string; enabled?: boolean };
+    if (!folderPath || typeof enabled !== 'boolean') {
+      res.status(400).json({ error: 'folderPath and enabled required' });
+      return;
+    }
+    const folderStates = (state.localCharts.folderStates ??= {});
+    const prior = folderStates[folderPath] ?? { enabled: true, effectiveEnabled: true };
+    folderStates[folderPath] = { enabled, effectiveEnabled: enabled && prior.effectiveEnabled };
+    let chartsAffected = 0;
+    for (const [folder, folderState] of Object.entries(folderStates)) {
+      if (folder === folderPath || folder.startsWith(`${folderPath}/`)) {
+        folderState.effectiveEnabled = enabled && folderState.enabled;
+      }
+    }
+    for (const chart of state.localCharts.charts) {
+      if (chart.folder === folderPath || chart.folder.startsWith(`${folderPath}/`)) {
+        chart.folderEnabled = enabled;
+        chartsAffected++;
+      }
+    }
+    res.json({
+      success: true,
+      message: `Folder ${enabled ? 'enabled' : 'disabled'}`,
+      folderPath,
+      enabled,
+      chartsAffected
+    });
   });
 
   router.get(`${PLUGIN_BASE}/catalog-registry`, (_req, res) => {

--- a/e2e/mock-server.ts
+++ b/e2e/mock-server.ts
@@ -208,18 +208,33 @@ export function startMockServer(
     }
     const folderStates = (state.localCharts.folderStates ??= {});
     const prior = folderStates[folderPath] ?? { enabled: true, effectiveEnabled: true };
-    folderStates[folderPath] = { enabled, effectiveEnabled: enabled && prior.effectiveEnabled };
-    let chartsAffected = 0;
-    for (const [folder, folderState] of Object.entries(folderStates)) {
-      if (folder === folderPath || folder.startsWith(`${folderPath}/`)) {
-        folderState.effectiveEnabled = enabled && folderState.enabled;
+    folderStates[folderPath] = { ...prior, enabled };
+    // Recompute effective state from the raw flag of every ancestor, same
+    // as the real plugin's isFolderPathEnabled() — the requested flag alone
+    // is wrong when a parent folder is itself disabled.
+    const isPathEnabled = (folder: string): boolean => {
+      if (folder === '/') {
+        return true;
       }
+      let prefix = '';
+      for (const segment of folder.split('/')) {
+        prefix = prefix === '' ? segment : `${prefix}/${segment}`;
+        if (!folderStates[prefix]?.enabled) {
+          return false;
+        }
+      }
+      return true;
+    };
+    for (const [folder, folderState] of Object.entries(folderStates)) {
+      folderState.effectiveEnabled = isPathEnabled(folder);
     }
+    let chartsAffected = 0;
     for (const chart of state.localCharts.charts) {
-      if (chart.folder === folderPath || chart.folder.startsWith(`${folderPath}/`)) {
-        chart.folderEnabled = enabled;
+      const nextEnabled = isPathEnabled(chart.folder);
+      if ((chart.folderEnabled ?? true) !== nextEnabled) {
         chartsAffected++;
       }
+      chart.folderEnabled = nextEnabled;
     }
     res.json({
       success: true,

--- a/public/css/manage-charts.css
+++ b/public/css/manage-charts.css
@@ -110,6 +110,61 @@
     transform: scale(1.05);
 }
 
+.folder-btn.folder-disabled {
+    opacity: 0.55;
+    border-style: dashed;
+}
+
+.folder-btn.folder-disabled.active {
+    opacity: 0.75;
+}
+
+.folder-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 24px;
+    min-height: 24px;
+    margin-left: 4px;
+    border-radius: 50%;
+    transition: background 0.2s ease;
+}
+
+.folder-toggle:hover {
+    background: rgba(128, 128, 128, 0.25);
+}
+
+.folder-toggle.enabled {
+    color: var(--success-color, #28a745);
+}
+
+.folder-toggle.disabled {
+    color: var(--danger-color, #dc3545);
+}
+
+.folder-btn.active .folder-toggle {
+    color: white;
+}
+
+.chart-card.folder-off,
+.chart-list-item.folder-off {
+    opacity: 0.5;
+    filter: grayscale(0.6);
+}
+
+.folder-off-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    margin-left: 6px;
+    border-radius: 10px;
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    font-size: 0.7rem;
+    font-weight: 500;
+    vertical-align: middle;
+    white-space: nowrap;
+}
+
 /* Context Menu */
 .context-menu {
     position: fixed;

--- a/public/js/globals.d.ts
+++ b/public/js/globals.d.ts
@@ -76,6 +76,7 @@ declare global {
     confirmDuplicate(): void;
     toggleChart(relativePath: string): Promise<void>;
     toggleFolderEnabled(event: Event, folder: string): Promise<void>;
+    toggleFolderKeydown(event: KeyboardEvent, folder: string): void;
     handleDragStart(event: DragEvent, chartPath: string): void;
     handleDragOver(event: DragEvent): void;
     handleFolderDragOver(event: DragEvent): void;

--- a/public/js/globals.d.ts
+++ b/public/js/globals.d.ts
@@ -75,6 +75,7 @@ declare global {
     closeDuplicateModal(event?: Event): void;
     confirmDuplicate(): void;
     toggleChart(relativePath: string): Promise<void>;
+    toggleFolderEnabled(event: Event, folder: string): Promise<void>;
     handleDragStart(event: DragEvent, chartPath: string): void;
     handleDragOver(event: DragEvent): void;
     handleFolderDragOver(event: DragEvent): void;

--- a/public/js/manage-charts-enhanced.ts
+++ b/public/js/manage-charts-enhanced.ts
@@ -11,15 +11,25 @@ interface ManageChart {
   dateCreated: number;
   dateModified: number;
   enabled: boolean;
+  /** False when the chart's folder (or an ancestor) is disabled. */
+  folderEnabled?: boolean;
   type?: string;
   isDirectory?: boolean;
   downloading?: boolean;
   converting?: boolean;
 }
 
+interface FolderStateInfo {
+  /** Raw flag for this folder only. */
+  enabled: boolean;
+  /** False when this folder or any ancestor is disabled. */
+  effectiveEnabled: boolean;
+}
+
 interface LocalChartsResponse {
   charts?: ManageChart[];
   folders?: string[];
+  folderStates?: Record<string, FolderStateInfo>;
   basePath?: string;
 }
 
@@ -90,6 +100,7 @@ interface DuplicateWarningOptions {
 let chartsData: ManageChart[] = [];
 let repairableData: RepairableChart[] = [];
 let foldersData: string[] = [];
+let folderStatesData: Record<string, FolderStateInfo> = {};
 let basePath = '';
 let selectedFolder: string | null = null; // null means show all folders
 let viewMode: 'grid' | 'list' = 'grid';
@@ -127,6 +138,7 @@ async function loadCharts(silent = false): Promise<void> {
 
     chartsData = data.charts ?? [];
     foldersData = data.folders ?? [];
+    folderStatesData = data.folderStates ?? {};
     basePath = data.basePath ?? '';
 
     // Surface charts the loader dropped for missing bounds but that can be
@@ -399,8 +411,16 @@ function renderChartsUI(): void {
     html += `<button class="folder-btn ${selectedFolder === null ? 'active' : ''}" onclick="selectFolder(null)">All Folders</button>`;
     foldersData.forEach((folder) => {
       const isActive = selectedFolder === folder;
-      html += `<button class="folder-btn ${isActive ? 'active' : ''}" onclick="selectFolder('${manageEscapeAttr(folder)}')" ondragover="handleFolderDragOver(event)" ondrop="handleDropOnFolder(event, '${manageEscapeAttr(folder)}')" ondragleave="handleFolderDragLeave(event)">
-        ${folderIcon} ${manageEscapeHtml(folder)}
+      const state = folderStatesData[folder] ?? { enabled: true, effectiveEnabled: true };
+      // The root '/' is not toggleable; per-chart toggles cover its charts.
+      const folderToggle =
+        folder === '/'
+          ? ''
+          : `<span class="folder-toggle ${state.enabled ? 'enabled' : 'disabled'}" role="button" tabindex="0" title="${state.enabled ? 'Disable' : 'Enable'} all charts in this folder" onclick="toggleFolderEnabled(event, '${manageEscapeAttr(folder)}')">
+              ${state.enabled ? window.getIcon('checkmark') : window.getIcon('cross')}
+            </span>`;
+      html += `<button class="folder-btn ${isActive ? 'active' : ''} ${state.effectiveEnabled ? '' : 'folder-disabled'}" onclick="selectFolder('${manageEscapeAttr(folder)}')" ondragover="handleFolderDragOver(event)" ondrop="handleDropOnFolder(event, '${manageEscapeAttr(folder)}')" ondragleave="handleFolderDragLeave(event)">
+        ${folderIcon} ${manageEscapeHtml(folder)}${folderToggle}
       </button>`;
     });
     html += `</div>`;
@@ -468,16 +488,19 @@ function renderChartCard(chart: ManageChart): string {
   const attrFolder = manageEscapeAttr(chart.folder);
   const attrName = manageEscapeAttr(chart.name);
 
+  const folderOff = chart.folderEnabled === false;
+  const folderOffBadge = folderOff ? `<span class="folder-off-badge">Folder disabled</span>` : '';
+
   if (viewMode === 'grid') {
     return `
-      <div class="chart-card ${chart.enabled ? '' : 'disabled'} ${chart.downloading || chart.converting ? 'downloading' : ''}" draggable="true" ondragstart="handleDragStart(event, '${attrPath}')" ondragover="handleDragOver(event)" ondrop="handleDrop(event, '${attrFolder}')" data-chart-path="${attrPath}">
+      <div class="chart-card ${chart.enabled ? '' : 'disabled'} ${folderOff ? 'folder-off' : ''} ${chart.downloading || chart.converting ? 'downloading' : ''}" draggable="true" ondragstart="handleDragStart(event, '${attrPath}')" ondragover="handleDragOver(event)" ondrop="handleDrop(event, '${attrFolder}')" data-chart-path="${attrPath}">
         <div class="chart-card-header">
           <div class="chart-status">
             <button class="btn-toggle ${chart.enabled ? 'enabled' : 'disabled'}" onclick="toggleChart('${attrPath}')" title="${chart.enabled ? 'Disable' : 'Enable'} chart">
               ${chart.enabled ? window.getIcon('checkmark') : window.getIcon('cross')}
             </button>
           </div>
-          <h4>${escName} ${downloadingBadge}</h4>
+          <h4>${escName} ${downloadingBadge}${folderOffBadge}</h4>
         </div>
         <div class="chart-card-body">
           ${
@@ -533,14 +556,14 @@ function renderChartCard(chart: ManageChart): string {
     `;
   } else {
     return `
-      <div class="chart-list-item ${chart.enabled ? '' : 'disabled'} ${chart.downloading || chart.converting ? 'downloading' : ''}" draggable="true" ondragstart="handleDragStart(event, '${attrPath}')" data-chart-path="${attrPath}">
+      <div class="chart-list-item ${chart.enabled ? '' : 'disabled'} ${folderOff ? 'folder-off' : ''} ${chart.downloading || chart.converting ? 'downloading' : ''}" draggable="true" ondragstart="handleDragStart(event, '${attrPath}')" data-chart-path="${attrPath}">
         <div class="chart-list-status">
           <button class="btn-toggle ${chart.enabled ? 'enabled' : 'disabled'}" onclick="toggleChart('${attrPath}')" title="${chart.enabled ? 'Disable' : 'Enable'} chart">
             ${chart.enabled ? window.getIcon('checkmark') : window.getIcon('cross')}
           </button>
         </div>
         <div class="chart-list-info">
-          <div class="chart-list-name">${escName} ${downloadingBadge}</div>
+          <div class="chart-list-name">${escName} ${downloadingBadge}${folderOffBadge}</div>
           <div class="chart-list-meta">
             ${displaySize ? `<span>${manageEscapeHtml(displaySize)}</span>` : ''}
             <span>${manageEscapeHtml(folderDisplay)}</span>
@@ -609,6 +632,36 @@ async function toggleChart(relativePath: string): Promise<void> {
     console.error('Error toggling chart:', error);
     const message = error instanceof Error ? error.message : String(error);
     alert('Error toggling chart: ' + message);
+  }
+}
+
+async function toggleFolderEnabled(event: Event, folder: string): Promise<void> {
+  // The toggle sits inside the folder button — don't also select the folder.
+  event.stopPropagation();
+
+  const currentEnabled = folderStatesData[folder]?.enabled ?? true;
+  const newEnabledState = !currentEnabled;
+
+  try {
+    const response = await fetch(`${MANAGE_API_BASE}/folders/toggle`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ folderPath: folder, enabled: newEnabledState })
+    });
+
+    if (response.ok) {
+      showFolderToggleNotification(folder, newEnabledState);
+      // Refetch instead of updating optimistically: the toggle cascades to
+      // descendant folders and their charts, which the server computes.
+      await loadCharts(true);
+    } else {
+      const errorText = await response.text();
+      showErrorNotification(`Failed to toggle folder: ${errorText}`);
+    }
+  } catch (error) {
+    console.error('Error toggling folder:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    alert('Error toggling folder: ' + message);
   }
 }
 
@@ -1977,6 +2030,23 @@ function showToggleNotification(chartName: string, enabled: boolean): void {
   fadeOutNotification('toggleNotification', html);
 }
 
+function showFolderToggleNotification(folderName: string, enabled: boolean): void {
+  const html = `
+    <div class="notification-toast" id="folderToggleNotification">
+      <div class="notification-content">
+        <div class="notification-icon ${enabled ? 'success' : 'warning'}">
+          ${enabled ? window.getIcon('checkmark') : window.getIcon('circle')}
+        </div>
+        <div class="notification-text">
+          <div class="notification-title">${enabled ? 'Folder Enabled' : 'Folder Disabled'}</div>
+          <div class="notification-message">${manageEscapeHtml(folderName)}</div>
+        </div>
+      </div>
+    </div>
+  `;
+  fadeOutNotification('folderToggleNotification', html);
+}
+
 function showErrorNotification(message: string): void {
   const html = `
     <div class="notification-toast error" id="errorNotification">
@@ -2337,6 +2407,7 @@ function manageEscapeAttr(str: string | undefined | null): string {
 window.setViewMode = setViewMode;
 window.selectFolder = selectFolder;
 window.toggleChart = toggleChart;
+window.toggleFolderEnabled = toggleFolderEnabled;
 window.deleteChart = deleteChart;
 window.triggerUpload = triggerUpload;
 window.triggerUploadEmpty = triggerUploadEmpty;

--- a/public/js/manage-charts-enhanced.ts
+++ b/public/js/manage-charts-enhanced.ts
@@ -416,7 +416,7 @@ function renderChartsUI(): void {
       const folderToggle =
         folder === '/'
           ? ''
-          : `<span class="folder-toggle ${state.enabled ? 'enabled' : 'disabled'}" role="button" tabindex="0" title="${state.enabled ? 'Disable' : 'Enable'} all charts in this folder" onclick="toggleFolderEnabled(event, '${manageEscapeAttr(folder)}')">
+          : `<span class="folder-toggle ${state.enabled ? 'enabled' : 'disabled'}" role="button" tabindex="0" title="${state.enabled ? 'Disable' : 'Enable'} all charts in this folder" onclick="toggleFolderEnabled(event, '${manageEscapeAttr(folder)}')" onkeydown="toggleFolderKeydown(event, '${manageEscapeAttr(folder)}')">
               ${state.enabled ? window.getIcon('checkmark') : window.getIcon('cross')}
             </span>`;
       html += `<button class="folder-btn ${isActive ? 'active' : ''} ${state.effectiveEnabled ? '' : 'folder-disabled'}" onclick="selectFolder('${manageEscapeAttr(folder)}')" ondragover="handleFolderDragOver(event)" ondrop="handleDropOnFolder(event, '${manageEscapeAttr(folder)}')" ondragleave="handleFolderDragLeave(event)">
@@ -662,6 +662,15 @@ async function toggleFolderEnabled(event: Event, folder: string): Promise<void> 
     console.error('Error toggling folder:', error);
     const message = error instanceof Error ? error.message : String(error);
     alert('Error toggling folder: ' + message);
+  }
+}
+
+// Keyboard support for the toggle (a span with role=button, so Enter/Space
+// don't come for free the way they would on a real <button>).
+function toggleFolderKeydown(event: KeyboardEvent, folder: string): void {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    void toggleFolderEnabled(event, folder);
   }
 }
 
@@ -2408,6 +2417,7 @@ window.setViewMode = setViewMode;
 window.selectFolder = selectFolder;
 window.toggleChart = toggleChart;
 window.toggleFolderEnabled = toggleFolderEnabled;
+window.toggleFolderKeydown = toggleFolderKeydown;
 window.deleteChart = deleteChart;
 window.triggerUpload = triggerUpload;
 window.triggerUploadEmpty = triggerUploadEmpty;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1385,6 +1385,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           return;
         }
 
+        if (!fs.statSync(fullPath).isDirectory()) {
+          res.status(400).send('Not a folder');
+          return;
+        }
+
         // Diff providers before/after the refresh: a folder toggle can affect
         // many charts (including nested folders), while charts that are
         // individually disabled stay absent on both sides and emit no delta.
@@ -1520,6 +1525,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         if (chartProviders[chartId]) {
           const chartData = sanitizeProvider(chartProviders[chartId], 2);
           emitChartDelta(chartId, chartData);
+        } else {
+          // The move can hide the chart from serving (target folder disabled)
+          // — retract it so v2 clients don't keep a stale entry whose tiles
+          // now 404.
+          emitChartDelta(chartId, null);
         }
 
         res.status(200).json({ success: true, message: 'Chart moved successfully' });

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,6 +260,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         clearInterval(catalogUpdateInterval);
         catalogUpdateInterval = null;
       }
+      // Release sqlite handles: on Windows an open handle keeps the
+      // .mbtiles file locked, and Signal K restarts the plugin on every
+      // config save, which would otherwise leak the whole map each time.
+      closeProviderHandles(Object.values(chartProviders));
+      chartProviders = {};
       app.setPluginStatus('stopped');
     },
     registerWithRouter: (router) => {
@@ -608,6 +613,39 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     return isChartEnabled(relativePath) && isFolderPathEnabled(path.dirname(relativePath));
   };
 
+  // findCharts opens a sqlite handle for every chart it finds; any provider
+  // that doesn't make it into (or drops out of) `chartProviders` must be
+  // closed explicitly or the handle leaks — and on Windows keeps the
+  // .mbtiles file locked. Safe to call on live objects being replaced:
+  // tile serving is synchronous from map lookup to handle use, so no
+  // in-flight request can hold a closed handle across an await.
+  const closeProviderHandles = (providers: Iterable<ChartProvider>): void => {
+    for (const provider of providers) {
+      try {
+        provider._mbtilesHandle?.close();
+      } catch {
+        // Already closed — nothing to release.
+      }
+    }
+  };
+
+  const partitionVisibleCharts = (
+    chartPath: string,
+    charts: Record<string, ChartProvider>
+  ): Record<string, ChartProvider> => {
+    const visible: Record<string, ChartProvider> = {};
+    const dropped: ChartProvider[] = [];
+    for (const [identifier, chart] of Object.entries(charts)) {
+      if (isChartVisible(chartPath, chart._filePath || '')) {
+        visible[identifier] = chart;
+      } else {
+        dropped.push(chart);
+      }
+    }
+    closeProviderHandles(dropped);
+    return visible;
+  };
+
   // Load enabled charts into `chartProviders` and prune stale install
   // records. Display-critical: must run (and resolve) before the resource
   // provider is registered so `listResources` has charts to return. Returns
@@ -615,11 +653,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
   const loadChartProviders = async (chartPath: string): Promise<boolean> => {
     try {
       const charts = await findCharts(chartPath);
-      const enabledCharts = Object.fromEntries(
-        Object.entries(charts).filter(([, chart]) =>
-          isChartVisible(chartPath, chart._filePath || '')
-        )
-      );
+      const enabledCharts = partitionVisibleCharts(chartPath, charts);
 
       app.debug(
         `Chart provider: Found ${Object.keys(charts).length} charts (${Object.keys(enabledCharts).length} enabled) from ${chartPath}.`
@@ -4170,11 +4204,11 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       const chartPath = props.chartPath || defaultChartsPath;
       const charts = await findCharts(chartPath);
 
-      chartProviders = Object.fromEntries(
-        Object.entries(charts).filter(([, chart]) =>
-          isChartVisible(chartPath, chart._filePath || '')
-        )
-      );
+      // Close the handles of the map being replaced — findCharts reopened
+      // every chart, so the old provider objects would otherwise leak.
+      const previous = chartProviders;
+      chartProviders = partitionVisibleCharts(chartPath, charts);
+      closeProviderHandles(Object.values(previous));
 
       app.debug(`Chart providers refreshed: ${Object.keys(chartProviders).length} enabled charts`);
     } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,13 @@ import {
 } from './utils/catalog-manager.js';
 import { cleanCatalogTitle } from './utils/catalog-title.js';
 import { initChartState, isChartEnabled, setChartEnabled } from './utils/chart-state.js';
+import {
+  initFolderState,
+  isFolderEnabled,
+  isFolderPathEnabled,
+  setFolderEnabled,
+  removeFolderState
+} from './utils/folder-state.js';
 import { getCpuBudget, setCpuBudget } from './utils/concurrency.js';
 import { PLUGIN_OWNER_ID } from './utils/container-jobs.js';
 import { getContainerManager, waitForContainerManager } from './utils/container-manager.js';
@@ -387,6 +394,7 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     }
 
     initChartState(pluginDataDir);
+    initFolderState(pluginDataDir);
 
     const dataDir = pluginDataDir;
     initCatalogManager(dataDir, app.debug.bind(app));
@@ -592,6 +600,14 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     void cleanupChartDirectory(chartPath);
   };
 
+  // A chart is served only when its own flag AND every ancestor folder's
+  // flag are enabled; folder state is a separate layer that never rewrites
+  // per-chart state.
+  const isChartVisible = (chartPath: string, filePath: string): boolean => {
+    const relativePath = path.relative(chartPath, filePath);
+    return isChartEnabled(relativePath) && isFolderPathEnabled(path.dirname(relativePath));
+  };
+
   // Load enabled charts into `chartProviders` and prune stale install
   // records. Display-critical: must run (and resolve) before the resource
   // provider is registered so `listResources` has charts to return. Returns
@@ -600,10 +616,9 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
     try {
       const charts = await findCharts(chartPath);
       const enabledCharts = Object.fromEntries(
-        Object.entries(charts).filter(([, chart]) => {
-          const relativePath = path.relative(chartPath, chart._filePath || '');
-          return isChartEnabled(relativePath);
-        })
+        Object.entries(charts).filter(([, chart]) =>
+          isChartVisible(chartPath, chart._filePath || '')
+        )
       );
 
       app.debug(
@@ -804,6 +819,13 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
   });
 
   const ChartToggleBody = Type.Object({
+    enabled: Type.Boolean()
+  });
+
+  // folderPath travels in the body (not a URL param): nested folders contain
+  // '/' and Express 5 rejects encoded %2F in path segments.
+  const FolderToggleBody = Type.Object({
+    folderPath: Type.String({ minLength: 1 }),
     enabled: Type.Boolean()
   });
 
@@ -1158,14 +1180,26 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
           return {
             ...chart,
             enabled: isChartEnabled(chart.relativePath),
+            folderEnabled: isFolderPathEnabled(chart.folder),
             downloading: downloadingFiles.has(chart.name),
             converting
           };
         });
 
+        const folderStates = Object.fromEntries(
+          folders.map((folder) => [
+            folder,
+            {
+              enabled: isFolderEnabled(folder),
+              effectiveEnabled: isFolderPathEnabled(folder)
+            }
+          ])
+        );
+
         res.json({
           charts: chartsWithState,
           folders: folders,
+          folderStates,
           basePath: chartPath
         });
       } catch (error) {
@@ -1317,10 +1351,75 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
         }
 
         await fs.promises.rmdir(fullPath);
+        removeFolderState(folderPathParam);
         res.status(200).json({ success: true, message: 'Folder deleted successfully' });
       } catch (error) {
         console.error('Error deleting folder:', error);
         res.status(500).send('Error deleting folder');
+      }
+    });
+
+    router.post('/folders/toggle', async (req: Request, res: Response) => {
+      const body = parseBody(FolderToggleBody, req, res);
+      if (!body) {
+        return;
+      }
+      const { folderPath, enabled } = body;
+
+      try {
+        const basePath = props.chartPath || defaultChartsPath;
+        const fullPath = path.join(basePath, folderPath);
+
+        if (!isWithinBase(fullPath, basePath)) {
+          res.status(403).send('Access denied: Invalid path');
+          return;
+        }
+
+        if (path.normalize(fullPath) === path.normalize(basePath)) {
+          res.status(400).send('Cannot toggle the root folder');
+          return;
+        }
+
+        if (!fs.existsSync(fullPath)) {
+          res.status(404).send('Folder not found');
+          return;
+        }
+
+        // Diff providers before/after the refresh: a folder toggle can affect
+        // many charts (including nested folders), while charts that are
+        // individually disabled stay absent on both sides and emit no delta.
+        const before = chartProviders;
+        setFolderEnabled(folderPath, enabled);
+        await refreshChartProviders();
+
+        let chartsAffected = 0;
+        for (const id of Object.keys(before)) {
+          if (!chartProviders[id]) {
+            emitChartDelta(id, null);
+            chartsAffected++;
+          }
+        }
+        for (const id of Object.keys(chartProviders)) {
+          if (!before[id]) {
+            emitChartDelta(id, sanitizeProvider(chartProviders[id], 2));
+            chartsAffected++;
+          }
+        }
+
+        app.debug(
+          `Folder ${folderPath} set to ${enabled ? 'enabled' : 'disabled'} (${chartsAffected} chart delta(s))`
+        );
+
+        res.status(200).json({
+          success: true,
+          message: `Folder ${enabled ? 'enabled' : 'disabled'}`,
+          folderPath,
+          enabled,
+          chartsAffected
+        });
+      } catch (error) {
+        console.error('Error toggling folder state:', error);
+        res.status(500).send('Error toggling folder state');
       }
     });
 
@@ -4062,10 +4161,9 @@ const pluginConstructor = (app: ExtendedServerAPI): Plugin => {
       const charts = await findCharts(chartPath);
 
       chartProviders = Object.fromEntries(
-        Object.entries(charts).filter(([, chart]) => {
-          const relativePath = path.relative(chartPath, chart._filePath || '');
-          return isChartEnabled(relativePath);
-        })
+        Object.entries(charts).filter(([, chart]) =>
+          isChartVisible(chartPath, chart._filePath || '')
+        )
       );
 
       app.debug(`Chart providers refreshed: ${Object.keys(chartProviders).length} enabled charts`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -358,6 +358,19 @@ export interface ChartStateEntry {
 
 export type ChartStateMap = Record<string, ChartStateEntry>;
 
+// ---- Folder State ----
+
+export interface FolderStateEntry {
+  enabled: boolean;
+}
+
+export type FolderStateMap = Record<string, FolderStateEntry>;
+
+export interface FolderStateInfo {
+  enabled: boolean;
+  effectiveEnabled: boolean;
+}
+
 // ---- Callbacks ----
 
 export type StatusCallback = (status: string, message: string) => void;

--- a/src/utils/folder-state.ts
+++ b/src/utils/folder-state.ts
@@ -1,0 +1,104 @@
+import fs from 'fs';
+import path from 'path';
+import type { FolderStateMap } from '../types.js';
+
+let folderState: FolderStateMap = {};
+let stateFilePath = '';
+
+// Keys are stored with forward slashes and no leading/trailing separators so
+// they are stable across platforms and match ScannedChart.folder semantics
+// ('.' and '' both mean the chart root, represented as '/').
+function normalizeFolder(folderPath: string): string {
+  const normalized = folderPath
+    .replace(/\\/g, '/')
+    .replace(/^\.\/+/, '')
+    .replace(/^\/+|\/+$/g, '');
+  return normalized === '' || normalized === '.' ? '/' : normalized;
+}
+
+function loadState(): void {
+  try {
+    if (fs.existsSync(stateFilePath)) {
+      const data = fs.readFileSync(stateFilePath, 'utf-8');
+      folderState = JSON.parse(data) as FolderStateMap;
+    }
+  } catch (error) {
+    console.error('Error loading folder state:', error);
+    folderState = {};
+  }
+}
+
+function saveState(): void {
+  try {
+    fs.writeFileSync(stateFilePath, JSON.stringify(folderState, null, 2), 'utf-8');
+  } catch (error) {
+    console.error('Error saving folder state:', error);
+  }
+}
+
+export function initFolderState(configPath: string): void {
+  stateFilePath = path.join(configPath, 'folder-state.json');
+  folderState = {};
+  loadState();
+}
+
+// Raw flag for this folder only; ancestors are not consulted.
+export function isFolderEnabled(folderPath: string): boolean {
+  const key = normalizeFolder(folderPath);
+  if (key === '/') {
+    return true;
+  }
+  if (folderState[key]) {
+    return folderState[key].enabled;
+  }
+  return true;
+}
+
+// Effective state: false if the folder or any ancestor folder is disabled.
+export function isFolderPathEnabled(folderPath: string): boolean {
+  const key = normalizeFolder(folderPath);
+  if (key === '/') {
+    return true;
+  }
+  const segments = key.split('/');
+  let prefix = '';
+  for (const segment of segments) {
+    prefix = prefix === '' ? segment : `${prefix}/${segment}`;
+    if (folderState[prefix] && !folderState[prefix].enabled) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function setFolderEnabled(folderPath: string, enabled: boolean): void {
+  const key = normalizeFolder(folderPath);
+  if (key === '/') {
+    return;
+  }
+  folderState[key] = { enabled };
+  saveState();
+}
+
+// Remove state for a folder and all of its descendants (used when a folder
+// is deleted, so recreating it later starts enabled again).
+export function removeFolderState(folderPath: string): void {
+  const key = normalizeFolder(folderPath);
+  if (key === '/') {
+    return;
+  }
+  let changed = false;
+  for (const stored of Object.keys(folderState)) {
+    if (stored === key || stored.startsWith(`${key}/`)) {
+      delete folderState[stored];
+      changed = true;
+    }
+  }
+  if (changed) {
+    saveState();
+  }
+}
+
+export function getAllFolderStates(): FolderStateMap {
+  return folderState;
+}

--- a/src/utils/folder-state.ts
+++ b/src/utils/folder-state.ts
@@ -9,10 +9,7 @@ let stateFilePath = '';
 // they are stable across platforms and match ScannedChart.folder semantics
 // ('.' and '' both mean the chart root, represented as '/').
 function normalizeFolder(folderPath: string): string {
-  const normalized = folderPath
-    .replace(/\\/g, '/')
-    .replace(/^\.\/+/, '')
-    .replace(/^\/+|\/+$/g, '');
+  const normalized = path.posix.normalize(folderPath.replace(/\\/g, '/')).replace(/^\/+|\/+$/g, '');
   return normalized === '' || normalized === '.' ? '/' : normalized;
 }
 

--- a/test/folder-state.test.ts
+++ b/test/folder-state.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the folder-state module: default-enabled semantics, persistence
+ * round-trips, ancestor-aware (descendant-disabling) matching, key
+ * normalization across platforms, and prefix-safe pruning.
+ */
+
+import { describe, it, beforeEach, after } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  getAllFolderStates,
+  initFolderState,
+  isFolderEnabled,
+  isFolderPathEnabled,
+  removeFolderState,
+  setFolderEnabled
+} from '../dist/utils/folder-state.js';
+
+const tempDirs: string[] = [];
+
+function freshDataDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'folder-state-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+beforeEach(() => {
+  initFolderState(freshDataDir());
+});
+
+after(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('defaults', () => {
+  it('treats unknown folders as enabled', () => {
+    assert.strictEqual(isFolderEnabled('Netherlands'), true);
+    assert.strictEqual(isFolderPathEnabled('Netherlands/Waddenzee'), true);
+  });
+
+  it('treats the root as always enabled', () => {
+    assert.strictEqual(isFolderEnabled('/'), true);
+    assert.strictEqual(isFolderPathEnabled('/'), true);
+    assert.strictEqual(isFolderPathEnabled('.'), true);
+    assert.strictEqual(isFolderPathEnabled(''), true);
+  });
+
+  it('ignores attempts to toggle the root', () => {
+    setFolderEnabled('/', false);
+    setFolderEnabled('.', false);
+    assert.strictEqual(isFolderPathEnabled('/'), true);
+    assert.deepStrictEqual(getAllFolderStates(), {});
+  });
+});
+
+describe('persistence', () => {
+  it('round-trips state through folder-state.json', () => {
+    const dir = freshDataDir();
+    initFolderState(dir);
+    setFolderEnabled('Netherlands', false);
+
+    const stateFile = path.join(dir, 'folder-state.json');
+    assert.ok(fs.existsSync(stateFile));
+
+    initFolderState(dir);
+    assert.strictEqual(isFolderEnabled('Netherlands'), false);
+    assert.strictEqual(isFolderEnabled('Germany'), true);
+  });
+
+  it('falls back to all-enabled on corrupt JSON', () => {
+    const dir = freshDataDir();
+    fs.writeFileSync(path.join(dir, 'folder-state.json'), 'not json{', 'utf-8');
+    initFolderState(dir);
+    assert.strictEqual(isFolderEnabled('Netherlands'), true);
+  });
+
+  it('does not leak state from a previously initialized directory', () => {
+    setFolderEnabled('Netherlands', false);
+    initFolderState(freshDataDir());
+    assert.strictEqual(isFolderEnabled('Netherlands'), true);
+  });
+});
+
+describe('descendant semantics', () => {
+  it('disabling a folder disables all descendants', () => {
+    setFolderEnabled('a', false);
+    assert.strictEqual(isFolderPathEnabled('a'), false);
+    assert.strictEqual(isFolderPathEnabled('a/b'), false);
+    assert.strictEqual(isFolderPathEnabled('a/b/c'), false);
+  });
+
+  it('leaves descendant raw flags and siblings untouched', () => {
+    setFolderEnabled('a', false);
+    assert.strictEqual(isFolderEnabled('a/b'), true);
+    assert.strictEqual(isFolderPathEnabled('b'), true);
+    assert.strictEqual(isFolderPathEnabled('ab'), true);
+  });
+
+  it('re-enabling a parent preserves a disabled child', () => {
+    setFolderEnabled('a', false);
+    setFolderEnabled('a/b', false);
+    setFolderEnabled('a', true);
+    assert.strictEqual(isFolderPathEnabled('a'), true);
+    assert.strictEqual(isFolderPathEnabled('a/b'), false);
+    assert.strictEqual(isFolderPathEnabled('a/b/c'), false);
+  });
+});
+
+describe('normalization', () => {
+  it('maps backslashes, ./ prefixes and stray slashes to one key', () => {
+    setFolderEnabled('a\\b', false);
+    assert.strictEqual(isFolderEnabled('a/b'), false);
+    assert.strictEqual(isFolderEnabled('./a/b'), false);
+    assert.strictEqual(isFolderEnabled('a/b/'), false);
+    assert.strictEqual(isFolderEnabled('/a/b'), false);
+    assert.strictEqual(Object.keys(getAllFolderStates()).length, 1);
+  });
+});
+
+describe('removeFolderState', () => {
+  it('removes the folder and its descendants but not lookalike siblings', () => {
+    setFolderEnabled('a', false);
+    setFolderEnabled('a/b', false);
+    setFolderEnabled('ab', false);
+    removeFolderState('a');
+    assert.strictEqual(isFolderEnabled('a'), true);
+    assert.strictEqual(isFolderEnabled('a/b'), true);
+    assert.strictEqual(isFolderEnabled('ab'), false);
+  });
+
+  it('persists the pruned state', () => {
+    const dir = freshDataDir();
+    initFolderState(dir);
+    setFolderEnabled('a', false);
+    removeFolderState('a');
+    initFolderState(dir);
+    assert.strictEqual(isFolderEnabled('a'), true);
+  });
+});

--- a/test/folder-state.test.ts
+++ b/test/folder-state.test.ts
@@ -118,6 +118,8 @@ describe('normalization', () => {
     assert.strictEqual(isFolderEnabled('./a/b'), false);
     assert.strictEqual(isFolderEnabled('a/b/'), false);
     assert.strictEqual(isFolderEnabled('/a/b'), false);
+    assert.strictEqual(isFolderEnabled('a/./b'), false);
+    assert.strictEqual(isFolderEnabled('a//b'), false);
     assert.strictEqual(Object.keys(getAllFolderStates()).length, 1);
   });
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -212,7 +212,9 @@ describe('Folder groups filtering', () => {
         void plugin.stop?.();
       },
       cleanup: () => {
-        fs.rmSync(tempDir, { recursive: true, force: true });
+        // Windows: retry to ride out transient locks from just-closed
+        // sqlite handles; an open handle would still fail all retries.
+        fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       }
     };
   }

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -160,6 +160,97 @@ describe('Charts Loader', () => {
   });
 });
 
+describe('Folder groups filtering', () => {
+  type ResourceProvider = Parameters<ExtendedServerAPI['registerResourceProvider']>[0];
+
+  // Drives plugin.start() against a temp chart tree containing
+  // groupA/test-chart.mbtiles. `start()` fires doStartup without awaiting
+  // it, so we poll until the resource provider has been registered.
+  async function startWithChart(
+    folderStateJson?: object,
+    chartFolder = 'groupA'
+  ): Promise<{
+    listed: Record<string, unknown>;
+    stop: () => void;
+    cleanup: () => void;
+  }> {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'folder-groups-'));
+    const chartPath = path.join(tempDir, 'charts');
+    fs.mkdirSync(path.join(chartPath, chartFolder), { recursive: true });
+    fs.copyFileSync(
+      path.join(FIXTURES, 'test-chart.mbtiles'),
+      path.join(chartPath, chartFolder, 'test-chart.mbtiles')
+    );
+
+    const app = createMockApp(tempDir);
+    if (folderStateJson) {
+      fs.writeFileSync(
+        path.join(app.getDataDirPath(), 'folder-state.json'),
+        JSON.stringify(folderStateJson),
+        'utf-8'
+      );
+    }
+
+    let provider: ResourceProvider | undefined;
+    app.registerResourceProvider = (p) => {
+      provider = p;
+    };
+
+    const plugin = pluginFactory(app);
+    plugin.start({ chartPath }, () => {});
+
+    const deadline = Date.now() + 5000;
+    while (!provider && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    assert.ok(provider, 'Resource provider should be registered within 5s');
+
+    const listed = await provider.methods.listResources({});
+    return {
+      listed,
+      stop: () => {
+        void plugin.stop?.();
+      },
+      cleanup: () => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    };
+  }
+
+  it('serves charts from enabled folders', async () => {
+    const { listed, stop, cleanup } = await startWithChart();
+    try {
+      assert.ok(listed['test-chart'], 'Chart in enabled folder should be listed');
+    } finally {
+      stop();
+      cleanup();
+    }
+  });
+
+  it('hides charts whose folder is disabled', async () => {
+    const { listed, stop, cleanup } = await startWithChart({ groupA: { enabled: false } });
+    try {
+      assert.deepStrictEqual(listed, {}, 'Chart in disabled folder should not be listed');
+    } finally {
+      stop();
+      cleanup();
+    }
+  });
+
+  it('hides charts whose ancestor folder is disabled', async () => {
+    const { listed, stop, cleanup } = await startWithChart(
+      { groupA: { enabled: false } },
+      path.join('groupA', 'inner')
+    );
+    try {
+      assert.deepStrictEqual(listed, {}, 'Chart under a disabled ancestor should not be listed');
+    } finally {
+      stop();
+      cleanup();
+    }
+  });
+});
+
 describe('Tile Serving', () => {
   let charts: Record<string, ChartProvider> | undefined;
   const chartsDir = FIXTURES;


### PR DESCRIPTION
Closes #172.

Folders now act as chart groups, OpenCPN-style. Each folder in the Manage Charts tab gets an enable/disable toggle; disabling a folder hides its charts and all nested folders' charts from tile serving and the v1/v2 chart lists. Per-chart flags are a separate layer and are never rewritten, so re-enabling a folder restores each chart's own state. State persists in `<dataDir>/folder-state.json`, mirroring the existing per-chart `chart-state.json`.

## API

`POST /plugins/signalk-charts-provider-simple/folders/toggle` with `{ "folderPath": "Netherlands", "enabled": false }` (admin auth, same as all management routes). The folder path travels in the body because nested folders contain `/` and Express 5 rejects encoded slashes in path params.

The route diffs the provider map before/after refresh and emits one `resources.charts` delta per affected chart — charts that are individually disabled produce no spurious delta. Clients like Freeboard-SK need no changes: toggled charts are retracted/re-added in `GET /signalk/v2/api/resources/charts` and announced via v2 deltas, so group switching is observable live.

`GET /local-charts` gains additive fields (`folderStates`, per-chart `folderEnabled`); the existing response shape is unchanged. Deleting a folder prunes its state including descendants. Charts ingested into a disabled folder stay hidden until the folder is re-enabled. The root `/` is not toggleable.

## Tested

- `npm run format && npm run build && npm test` — 467 unit tests pass, including new coverage for folder-state defaults, persistence round-trip, ancestor-aware descendant semantics, key normalization, and prefix-safe pruning, plus integration tests driving `plugin.start()` against a temp chart tree and asserting `listResources` filters disabled (and ancestor-disabled) folders
- `npm run test:e2e` — 18 Playwright specs pass, including two new ones for disabled-folder rendering and the toggle POST (with stopPropagation so the folder isn't selected)
- CodeRabbit CLI review vs main: 4 findings, 3 fixed (keyboard-operable toggle, mock ancestor cascade, path normalization), 1 doc-granularity nit skipped