### PR TITLE
chore(release): 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-charts-provider-simple",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Simple Signal K chart provider for local MBTiles with web and download management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump for the 2.6.0 minor release.

Highlights since 2.5.0:
- Folder groups (#172): enable/disable whole chart folders, OpenCPN-style, incl. nested folders; admin API `POST /folders/toggle`; clients observe switching live via `resources.charts` v2 deltas
- Fix: sqlite handles of dropped/replaced/stopped chart providers are now closed (fd leak on every config save and toggle; kept .mbtiles files locked on Windows)
- Fix: moving a chart into a disabled folder now retracts it from v2 clients